### PR TITLE
Add denom metdata

### DIFF
--- a/example_genesis.json
+++ b/example_genesis.json
@@ -83,7 +83,37 @@
           "amount": "25100001000000"
         }
       ],
-      "denom_metadata": [],
+      "denom_metadata": [
+        {
+          "name": "lume",
+          "description": "The native token of lumera",
+          "denom_units": [
+            {
+              "denom": "ulume",
+              "exponent": 0,
+              "aliases": [
+                "microlume"
+              ]
+            },
+            {
+              "denom": "mlume",
+              "exponent": 3,
+              "aliases": [
+                "millilume"
+              ]
+            },
+            {
+              "denom": "lume",
+              "exponent": 6
+            }
+          ],
+          "symbol": "LUME",
+          "base": "ulume",
+          "display": "lume",
+          "uri": "",
+          "uri_hash": ""
+        }
+      ],
       "send_enabled": []
     },
     "capability": {


### PR DESCRIPTION
This PR adds token denomination metadata to the genesis template, enabling flexible denomination usage across the chain (ulume, mlume, lume). Users can now specify token amounts using any defined denomination for transactions and queries.

Example:

```bash
lumerad tx bank send wallet1 wallet2 1000000ulume  # base units
lumerad tx bank send wallet1 wallet2 1000mlume     # milli units 
lumerad tx bank send wallet1 wallet2 1lume         # standard units
```