### PR TITLE
Split devnet init and start phase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ repomix-*
 .repomixignore
 
 tests/systemtests/testnet
+devnet/docker-compose.start.yml
+devnet/start.sh

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,12 @@ devnet-build:
 		CONFIG_JSON="$${CONFIG_JSON:-$(DEFAULT_CONFIG_JSON)}" \
 		VALIDATORS_JSON="$${VALIDATORS_JSON:-$(DEFAULT_VALIDATORS_JSON)}" \
 		go run . && \
-		docker compose build; \
+		docker compose build && \
+		docker compose up -d && \
+		echo "Waiting for initialization to complete..." && \
+		while [ ! -f "$(SHARED_DIR)/setup_complete" ]; do sleep 1; done && \
+		docker compose down && \
+		echo "Initialization complete. Ready to start nodes."; \
 	else \
 		echo "No external claims file provided or file not found."; \
 		exit 1; \
@@ -81,7 +86,7 @@ devnet-rebuild:
 
 devnet-up:
 	cd devnet && \
-	docker compose up
+	docker compose -f docker-compose.start.yml up
 
 devnet-up-detach:
 	cd devnet && \

--- a/devnet/dockerfile
+++ b/devnet/dockerfile
@@ -19,9 +19,11 @@ RUN mkdir -p /root/scripts
 # Copy scripts with correct paths
 COPY primary-validator.sh /root/scripts/primary-validator.sh
 COPY secondary-validator.sh /root/scripts/secondary-validator.sh
+COPY start.sh /root/scripts/start.sh
 
 RUN chmod +x /root/scripts/primary-validator.sh && \
-    chmod +x /root/scripts/secondary-validator.sh
+    chmod +x /root/scripts/secondary-validator.sh && \
+    chmod +x /root/scripts/start.sh
 
 # Expose necessary ports
 EXPOSE 26656 26657 1317 9090

--- a/devnet/generators/primary-validator.go
+++ b/devnet/generators/primary-validator.go
@@ -228,8 +228,19 @@ func GeneratePrimaryValidatorScript(config *confg.ChainConfig, validators []conf
 	sb.shareAndCreateGentx()
 	sb.waitAndCollectGentx()
 	sb.setupPeers()
-	sb.addStartCommand()
+	// sb.addStartCommand()
 
 	script := strings.Join(sb.lines, "\n")
 	return os.WriteFile("primary-validator.sh", []byte(script), 0755)
+}
+
+func GenerateStartScript(config *confg.ChainConfig) error {
+	script := fmt.Sprintf(`#!/bin/bash
+set -e
+
+echo "Starting validator %s..."
+%s start --minimum-gas-prices %s
+`, config.Daemon.Binary, config.Daemon.Binary, config.Chain.Denom.MinimumGasPrice)
+
+	return os.WriteFile("start.sh", []byte(script), 0755)
 }

--- a/devnet/generators/secondary-validator.go
+++ b/devnet/generators/secondary-validator.go
@@ -171,10 +171,10 @@ func (sb *SecondaryScriptBuilder) addStartCommand() {
 		"    sleep 1",
 		"done",
 		"",
-		fmt.Sprintf(`echo "Starting secondary validator %s..."`, sb.config.Daemon.Binary),
-		fmt.Sprintf("%s start --minimum-gas-prices %s",
-			sb.config.Daemon.Binary,
-			sb.config.Chain.Denom.MinimumGasPrice),
+		// fmt.Sprintf(`echo "Starting secondary validator %s..."`, sb.config.Daemon.Binary),
+		// fmt.Sprintf("%s start --minimum-gas-prices %s",
+		// 	sb.config.Daemon.Binary,
+		// 	sb.config.Chain.Denom.MinimumGasPrice),
 	}...)
 }
 

--- a/devnet/main.go
+++ b/devnet/main.go
@@ -43,6 +43,7 @@ func main() {
 		}
 	}
 
+	// Generate init docker-compose
 	compose, err := generators.GenerateDockerCompose(cfg, validators, useExistingGenesis)
 	if err != nil {
 		log.Fatalf("Failed to generate docker-compose configuration: %v", err)
@@ -53,6 +54,18 @@ func main() {
 		log.Fatalf("Failed to write docker-compose.yml: %v", err)
 	}
 
+	// Generate start docker-compose
+	startCompose, err := generators.GenerateStartDockerCompose(cfg, validators)
+	if err != nil {
+		log.Fatalf("Failed to generate start docker-compose configuration: %v", err)
+	}
+
+	err = generators.WriteDockerCompose(startCompose, "docker-compose.start.yml")
+	if err != nil {
+		log.Fatalf("Failed to write docker-compose.start.yml: %v", err)
+	}
+
+	// Generate validator scripts
 	err = generators.GeneratePrimaryValidatorScript(cfg, validators, useExistingGenesis)
 	if err != nil {
 		log.Fatalf("Failed to generate primary validator script: %v", err)
@@ -63,5 +76,16 @@ func main() {
 		log.Fatalf("Failed to generate secondary validator script: %v", err)
 	}
 
-	fmt.Println("Successfully generated docker-compose.yml")
+	// Generate start script
+	err = generators.GenerateStartScript(cfg)
+	if err != nil {
+		log.Fatalf("Failed to generate start script: %v", err)
+	}
+
+	fmt.Println("Successfully generated all configuration files:")
+	fmt.Println("- docker-compose.yml (for initialization)")
+	fmt.Println("- docker-compose.start.yml (for starting nodes)")
+	fmt.Println("- primary-validator.sh")
+	fmt.Println("- secondary-validator.sh")
+	fmt.Println("- start.sh")
 }


### PR DESCRIPTION
# Split Node Initialization and Start Phases

## Problem
Currently unable to modify node configurations in devnet (app.toml, config.toml) as initialization and startup are combined.

## Solution
Split into initialization and start phases with separate docker compose files, allowing configuration changes between phases.

## Usage
```bash
make devnet-build  # Initialize
# Modify configs if needed
make devnet-up     # Start nodes