### PR TITLE
Update readme.md - `ignite chain build`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ curl https://get.ignite.com/cli! | bash
 ### Build
 
 ```bash
-ignite build
+ignite chain build
 ```
 
 > **Note:** You can still build directly with go: `go build cmd`, but it won't build protobuf files.


### PR DESCRIPTION
> $ ignite build
> 
> Command "build" is deprecated, use `ignite chain build` instead.

```
$ ignite version  
Ignite CLI version:		v28.7.0
Ignite CLI build date:		2025-01-15T08:23:41Z
```