### PR TITLE
fix/action-distribute-fees-panic

### DIFF
--- a/x/action/v1/module/module.go
+++ b/x/action/v1/module/module.go
@@ -200,7 +200,7 @@ type ModuleInputs struct {
 	AccountKeeper      types2.AccountKeeper
 	BankKeeper         types2.BankKeeper
 	StakingKeeper      types2.StakingKeeper
-	distributionKeeper types2.DistributionKeeper
+	DistributionKeeper types2.DistributionKeeper
 	SupernodeKeeper    types2.SupernodeKeeper
 }
 
@@ -225,7 +225,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.BankKeeper,
 		in.AccountKeeper,
 		in.StakingKeeper,
-		in.distributionKeeper,
+		in.DistributionKeeper,
 		in.SupernodeKeeper,
 	)
 	m := NewAppModule(
@@ -234,7 +234,7 @@ func ProvideModule(in ModuleInputs) ModuleOutputs {
 		in.AccountKeeper,
 		in.BankKeeper,
 		in.StakingKeeper,
-		in.distributionKeeper,
+		in.DistributionKeeper,
 		in.SupernodeKeeper,
 	)
 


### PR DESCRIPTION
# Fix: Prevent panic in DistributeFees during Simulate (DI wiring)

## Summary

- Fix a nil-pointer panic in `x/action` simulation by correctly injecting `DistributionKeeper` (unexported DI field → nil at runtime).

## Root Cause

- `x/action/v1/module.ModuleInputs` used an unexported `distributionKeeper` field; depinject ignores unexported fields.
- With non-zero `Params.FoundationFeeShare`, `DistributeFees` called `FundCommunityPool` on a nil keeper and panicked.

## Why It Didn’t Reproduce Locally

- Local E2E sets `foundation_fee_share` to `"0.000000000000000000"` in genesis (`tests/system/e2e_cascade_test.go` → `SetActionParams`), so `DistributeFees` skips `FundCommunityPool` and never hits the nil path.

## Stack Trace (excerpt)

```
panic: invalid memory address or nil pointer dereference
... baseapp.(*BaseApp).runTx → x/auth/tx.Service.Simulate
... x/action/v1/keeper.(*Keeper).DistributeFees (action.go:597)
... x/action/v1/keeper.(*Keeper).FinalizeAction (action.go:246)
```

## Change

- `x/action/v1/module/module.go`:
  - Export DI field: `distributionKeeper` → `DistributionKeeper`.
  - Pass `in.DistributionKeeper` to `keeper.NewKeeper(...)` and `NewAppModule(...)`.

## Impact

- Simulation no longer panics when `FoundationFeeShare` > 0.
- No behavior change when the fee share is zero.

## Validation

- Configure non-zero `foundation_fee_share`; finalize CASCADE action:
  - Simulate: no panic; gas estimation returns or clean error.
  - DeliverTx: fees distribute to community pool and supernodes.

## Risk

- Low; wiring-only change. Optional hardening can add a `CheckTx/Simulate` guard in `DistributeFees` later.
