### PR TITLE
StateSync fix

### DIFF
--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -19,6 +19,14 @@ type UpgradeConfig struct {
 	Handler      upgradetypes.UpgradeHandler
 }
 
+var upgradeNames = []string{
+	upgrade_v1_6_1.UpgradeName,
+	upgrade_v1_7_0.UpgradeName,
+	upgrade_v1_7_2.UpgradeName,
+	upgrade_v1_8_0.UpgradeName,
+	upgrade_v1_8_4.UpgradeName,
+}
+
 var NoUpgradeConfig = UpgradeConfig{
 	StoreUpgrade: nil,
 	Handler:      nil,
@@ -62,4 +70,15 @@ func SetupUpgrades(upgradeName string, params appParams.AppUpgradeParams) (Upgra
 	default:
 		return UpgradeConfig{}, false
 	}
+}
+
+// AllUpgrades returns the upgrade configuration for every known upgrade name.
+func AllUpgrades(params appParams.AppUpgradeParams) map[string]UpgradeConfig {
+	configs := make(map[string]UpgradeConfig, len(upgradeNames))
+	for _, upgradeName := range upgradeNames {
+		if config, found := SetupUpgrades(upgradeName, params); found {
+			configs[upgradeName] = config
+		}
+	}
+	return configs
 }


### PR DESCRIPTION
Register all upgrade handlers at startup so state-sync nodes don’t fail downgrade verification (v1.8.4)

- Register every known upgrade handler during app startup (before Load) instead of only when an upgrade plan file exists.
- Centralize upgrade configs via AllUpgrades, reuse for store-loader setup; still only set store loader for the pending on-disk plan.
- Prevents x/upgrade downgrade check from panicking on state-synced nodes that already completed v1.8.4 but had no handler registered.