### PR TITLE
Handle postponed supernodes in top supernode query

### DIFF
--- a/proto/lumera/supernode/v1/supernode_state.proto
+++ b/proto/lumera/supernode/v1/supernode_state.proto
@@ -14,6 +14,7 @@ enum SuperNodeState {
   SUPERNODE_STATE_DISABLED = 2 [(gogoproto.enumvalue_customname) = "SuperNodeStateDisabled"];
   SUPERNODE_STATE_STOPPED = 3 [(gogoproto.enumvalue_customname) = "SuperNodeStateStopped"];
   SUPERNODE_STATE_PENALIZED = 4 [(gogoproto.enumvalue_customname) = "SuperNodeStatePenalized"];
+  SUPERNODE_STATE_POSTPONED = 5 [(gogoproto.enumvalue_customname) = "SuperNodeStatePostponed"];
 }
 
 message SuperNodeStateRecord { 

--- a/x/supernode/v1/types/supernode_state.pb.go
+++ b/x/supernode/v1/types/supernode_state.pb.go
@@ -31,6 +31,7 @@ const (
 	SuperNodeStateDisabled    SuperNodeState = 2
 	SuperNodeStateStopped     SuperNodeState = 3
 	SuperNodeStatePenalized   SuperNodeState = 4
+	SuperNodeStatePostponed   SuperNodeState = 5
 )
 
 var SuperNodeState_name = map[int32]string{
@@ -39,6 +40,7 @@ var SuperNodeState_name = map[int32]string{
 	2: "SUPERNODE_STATE_DISABLED",
 	3: "SUPERNODE_STATE_STOPPED",
 	4: "SUPERNODE_STATE_PENALIZED",
+	5: "SUPERNODE_STATE_POSTPONED",
 }
 
 var SuperNodeState_value = map[string]int32{
@@ -47,6 +49,7 @@ var SuperNodeState_value = map[string]int32{
 	"SUPERNODE_STATE_DISABLED":    2,
 	"SUPERNODE_STATE_STOPPED":     3,
 	"SUPERNODE_STATE_PENALIZED":   4,
+	"SUPERNODE_STATE_POSTPONED":   5,
 }
 
 func (x SuperNodeState) String() string {


### PR DESCRIPTION
## Summary
- add the POSTPONED supernode state and exclude it from top-supernode rankings
- enforce compliance validation and freshness checks when returning disabled supernodes as candidates
- extend tests to cover postponed skipping and disabled filtering behaviors

## Testing
- go test ./x/supernode/v1/keeper -count=1 *(hangs in this environment; canceled after waiting)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69276c54bff883289148252b88b2eb0c)