### PR TITLE
Update supernode protos for metrics reporting

### DIFF
--- a/proto/lumera/supernode/v1/params.proto
+++ b/proto/lumera/supernode/v1/params.proto
@@ -23,4 +23,10 @@ message Params {
   string evidence_retention_period = 5 [(gogoproto.moretags) = "yaml:\"evidence_retention_period\""];
   string slashing_fraction = 6 [(gogoproto.moretags) = "yaml:\"slashing_fraction\""];
   string inactivity_penalty_period = 7 [(gogoproto.moretags) = "yaml:\"inactivity_penalty_period\""];
+  string reporting_interval = 8 [(gogoproto.moretags) = "yaml:\"reporting_interval\""];
+  string reporting_grace_period = 9 [(gogoproto.moretags) = "yaml:\"reporting_grace_period\""];
+  string metrics_freshness = 10 [(gogoproto.moretags) = "yaml:\"metrics_freshness\""];
+  string minimum_supported_version = 11 [(gogoproto.moretags) = "yaml:\"minimum_supported_version\""];
+  string resource_thresholds = 12 [(gogoproto.moretags) = "yaml:\"resource_thresholds\""];
+  repeated string required_open_ports = 13 [(gogoproto.moretags) = "yaml:\"required_open_ports\""];
 }

--- a/proto/lumera/supernode/v1/supernode_state.proto
+++ b/proto/lumera/supernode/v1/supernode_state.proto
@@ -14,6 +14,7 @@ enum SuperNodeState {
   SUPERNODE_STATE_DISABLED = 2 [(gogoproto.enumvalue_customname) = "SuperNodeStateDisabled"];
   SUPERNODE_STATE_STOPPED = 3 [(gogoproto.enumvalue_customname) = "SuperNodeStateStopped"];
   SUPERNODE_STATE_PENALIZED = 4 [(gogoproto.enumvalue_customname) = "SuperNodeStatePenalized"];
+  SUPERNODE_STATE_POSTPONED = 5 [(gogoproto.enumvalue_customname) = "SuperNodeStatePostponed"];
 }
 
 message SuperNodeStateRecord { 

--- a/proto/lumera/supernode/v1/tx.proto
+++ b/proto/lumera/supernode/v1/tx.proto
@@ -7,6 +7,7 @@ import "amino/amino.proto";
 import "cosmos/msg/v1/msg.proto";
 import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
+import "lumera/supernode/v1/metrics_aggregate.proto";
 import "lumera/supernode/v1/params.proto";
 
 // Msg defines the Msg service.
@@ -21,6 +22,7 @@ service Msg {
   rpc StartSupernode      (MsgStartSupernode     ) returns (MsgStartSupernodeResponse     );
   rpc StopSupernode       (MsgStopSupernode      ) returns (MsgStopSupernodeResponse      );
   rpc UpdateSupernode     (MsgUpdateSupernode    ) returns (MsgUpdateSupernodeResponse    );
+  rpc ReportSupernodeMetrics(MsgReportSupernodeMetrics) returns (MsgReportSupernodeMetricsResponse);
 }
 // MsgUpdateParams is the Msg/UpdateParams request type.
 message MsgUpdateParams {
@@ -87,4 +89,15 @@ message MsgUpdateSupernode {
 }
 
 message MsgUpdateSupernodeResponse {}
+
+message MsgReportSupernodeMetrics {
+  option (cosmos.msg.v1.signer) = "validator_address";
+  option (cosmos.msg.v1.signer) = "supernode_account";
+
+  string validator_address = 1 [(cosmos_proto.scalar) = "cosmos.ValidatorAddressString"];
+  string supernode_account = 2 [(cosmos_proto.scalar) = "cosmos.AccAddressString"];
+  MetricsAggregate metrics = 3 [(gogoproto.nullable) = false];
+}
+
+message MsgReportSupernodeMetricsResponse {}
 


### PR DESCRIPTION
## Summary
- add a postponed supernode state with a custom gogo enum name
- extend supernode params with additional reporting, version, resource, and port settings
- introduce a metrics reporting message/response and RPC in the supernode Msg service

## Testing
- make build-proto *(fails: buf binary not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69276c3f347483289d8bb77e836cc8f9)