### PR TITLE
Add supernode metrics reporting handler

### DIFF
--- a/proto/lumera/supernode/v1/supernode_state.proto
+++ b/proto/lumera/supernode/v1/supernode_state.proto
@@ -14,6 +14,7 @@ enum SuperNodeState {
   SUPERNODE_STATE_DISABLED = 2 [(gogoproto.enumvalue_customname) = "SuperNodeStateDisabled"];
   SUPERNODE_STATE_STOPPED = 3 [(gogoproto.enumvalue_customname) = "SuperNodeStateStopped"];
   SUPERNODE_STATE_PENALIZED = 4 [(gogoproto.enumvalue_customname) = "SuperNodeStatePenalized"];
+  SUPERNODE_STATE_POSTPONED = 5 [(gogoproto.enumvalue_customname) = "SuperNodeStatePostponed"];
 }
 
 message SuperNodeStateRecord { 

--- a/proto/lumera/supernode/v1/tx.proto
+++ b/proto/lumera/supernode/v1/tx.proto
@@ -21,6 +21,7 @@ service Msg {
   rpc StartSupernode      (MsgStartSupernode     ) returns (MsgStartSupernodeResponse     );
   rpc StopSupernode       (MsgStopSupernode      ) returns (MsgStopSupernodeResponse      );
   rpc UpdateSupernode     (MsgUpdateSupernode    ) returns (MsgUpdateSupernodeResponse    );
+  rpc ReportSupernodeMetrics (MsgReportSupernodeMetrics) returns (MsgReportSupernodeMetricsResponse);
 }
 // MsgUpdateParams is the Msg/UpdateParams request type.
 message MsgUpdateParams {
@@ -87,4 +88,17 @@ message MsgUpdateSupernode {
 }
 
 message MsgUpdateSupernodeResponse {}
+
+message MsgReportSupernodeMetrics {
+  option (cosmos.msg.v1.signer) = "creator";
+  string creator = 1;
+  string validatorAddress = 2;
+  map<string, double> metrics = 3;
+  string version = 4;
+  int64 reported_height = 5;
+}
+
+message MsgReportSupernodeMetricsResponse {
+  repeated string issues = 1;
+}
 

--- a/x/supernode/v1/keeper/msg_server_report_metrics.go
+++ b/x/supernode/v1/keeper/msg_server_report_metrics.go
@@ -1,0 +1,221 @@
+package keeper
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+
+	"github.com/LumeraProtocol/lumera/x/supernode/v1/types"
+)
+
+var canonicalMetricRanges = map[string]struct {
+	min float64
+	max float64
+}{
+	types.MetricKeyCPUUsage:     {min: 0, max: 100},
+	types.MetricKeyMemoryUsage:  {min: 0, max: 100},
+	types.MetricKeyStorageUsage: {min: 0, max: 100},
+	types.MetricKeyP2PPortOpen:  {min: 0, max: 1},
+	types.MetricKeyRPCPortOpen:  {min: 0, max: 1},
+	// freshness is expressed in blocks; allow any non-negative number.
+	types.MetricKeyFreshness: {min: 0, max: 1_000_000_000},
+}
+
+func parseMetricsThresholds(thresholds string) map[string]float64 {
+	result := make(map[string]float64)
+	parts := strings.Split(thresholds, ",")
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+
+		kv := strings.SplitN(p, ":", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(kv[0])
+		val, err := strconv.ParseFloat(strings.TrimSpace(kv[1]), 64)
+		if err != nil {
+			continue
+		}
+		result[key] = val
+	}
+	return result
+}
+
+// ReportSupernodeMetrics ingests telemetry reports and updates compliance state.
+func (k msgServer) ReportSupernodeMetrics(goCtx context.Context, msg *types.MsgReportSupernodeMetrics) (*types.MsgReportSupernodeMetricsResponse, error) {
+	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
+	valOperAddr, err := sdk.ValAddressFromBech32(msg.ValidatorAddress)
+	if err != nil {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid validator address: %s", err)
+	}
+
+	supernode, found := k.QuerySuperNode(ctx, valOperAddr)
+	if !found {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrNotFound, "no supernode found for validator %s", msg.ValidatorAddress)
+	}
+
+	creatorAddr, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address: %s", err)
+	}
+
+	valAccAddr := sdk.AccAddress(valOperAddr)
+	supernodeAcc, err := sdk.AccAddressFromBech32(supernode.SupernodeAccount)
+	if err != nil {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid supernode account: %s", err)
+	}
+
+	if !(creatorAddr.Equals(valAccAddr) || creatorAddr.Equals(supernodeAcc)) {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "creator %s is not authorized for supernode", msg.Creator)
+	}
+
+	issues := make([]string, 0)
+	sanitized := make(map[string]float64)
+
+	for kKey, v := range msg.Metrics {
+		rangeSpec, ok := canonicalMetricRanges[kKey]
+		if !ok {
+			issues = append(issues, fmt.Sprintf("unknown metric key: %s", kKey))
+			continue
+		}
+
+		if v < rangeSpec.min || v > rangeSpec.max {
+			issues = append(issues, fmt.Sprintf("metric %s out of range", kKey))
+			continue
+		}
+
+		sanitized[kKey] = v
+	}
+
+	params := k.GetParams(ctx)
+	thresholds := parseMetricsThresholds(params.MetricsThresholds)
+
+	// Version compliance
+	if msg.Version == "" {
+		msg.Version = supernode.Note
+	}
+	if supernode.Note != "" && msg.Version != supernode.Note {
+		issues = append(issues, fmt.Sprintf("version mismatch: expected %s", supernode.Note))
+	}
+
+	// Usage thresholds
+	if threshold, ok := thresholds["cpu"]; ok {
+		if val, exists := sanitized[types.MetricKeyCPUUsage]; exists && val > threshold {
+			issues = append(issues, "cpu usage above threshold")
+		}
+	}
+	if threshold, ok := thresholds["memory"]; ok {
+		if val, exists := sanitized[types.MetricKeyMemoryUsage]; exists && val > threshold {
+			issues = append(issues, "memory usage above threshold")
+		}
+	}
+	if threshold, ok := thresholds["storage"]; ok {
+		if val, exists := sanitized[types.MetricKeyStorageUsage]; exists && val > threshold {
+			issues = append(issues, "storage usage above threshold")
+		}
+	}
+
+	// Port checks: expect value >=1 to indicate open
+	if val, ok := sanitized[types.MetricKeyP2PPortOpen]; ok && val < 1 {
+		issues = append(issues, "p2p port not reachable")
+	}
+	if val, ok := sanitized[types.MetricKeyRPCPortOpen]; ok && val < 1 {
+		issues = append(issues, "rpc port not reachable")
+	}
+
+	// Freshness based on reporting threshold parameter (in blocks)
+	reportedHeight := msg.ReportedHeight
+	if reportedHeight == 0 {
+		reportedHeight = ctx.BlockHeight()
+	}
+	if params.ReportingThreshold > 0 {
+		delta := ctx.BlockHeight() - reportedHeight
+		if delta < 0 {
+			delta = -delta
+		}
+		if uint64(delta) > params.ReportingThreshold {
+			issues = append(issues, "metrics report is stale")
+		}
+	}
+
+	metricsAgg := supernode.Metrics
+	if metricsAgg == nil {
+		metricsAgg = &types.MetricsAggregate{}
+	}
+	if metricsAgg.Metrics == nil {
+		metricsAgg.Metrics = make(map[string]float64)
+	}
+
+	for kKey, v := range sanitized {
+		metricsAgg.Metrics[kKey] = v
+	}
+	metricsAgg.ReportCount++
+	metricsAgg.Height = ctx.BlockHeight()
+	supernode.Metrics = metricsAgg
+
+	// Manage state transitions
+	var currentState types.SuperNodeState
+	if len(supernode.States) > 0 {
+		currentState = supernode.States[len(supernode.States)-1].State
+	}
+
+	previousEffective := currentState
+	for i := len(supernode.States) - 1; i >= 0; i-- {
+		if supernode.States[i].State != types.SuperNodeStatePostponed {
+			previousEffective = supernode.States[i].State
+			break
+		}
+	}
+
+	transition := ""
+	if len(issues) > 0 {
+		switch currentState {
+		case types.SuperNodeStateActive, types.SuperNodeStateDisabled:
+			supernode.States = append(supernode.States, &types.SuperNodeStateRecord{State: types.SuperNodeStatePostponed, Height: ctx.BlockHeight()})
+			transition = fmt.Sprintf("%s->%s", currentState.String(), types.SuperNodeStatePostponed.String())
+		}
+	} else {
+		if currentState == types.SuperNodeStatePostponed {
+			target := previousEffective
+			if target == types.SuperNodeStatePostponed || target == types.SuperNodeStateUnspecified {
+				target = types.SuperNodeStateActive
+			}
+			supernode.States = append(supernode.States, &types.SuperNodeStateRecord{State: target, Height: ctx.BlockHeight()})
+			transition = fmt.Sprintf("%s->%s", currentState.String(), target.String())
+		}
+	}
+
+	if err := k.SetSuperNode(ctx, supernode); err != nil {
+		return nil, err
+	}
+
+	attrs := []sdk.Attribute{
+		sdk.NewAttribute(types.AttributeKeyValidatorAddress, msg.ValidatorAddress),
+		sdk.NewAttribute(types.AttributeKeyIssuesCount, strconv.Itoa(len(issues))),
+		sdk.NewAttribute(types.AttributeKeyHeight, strconv.FormatInt(ctx.BlockHeight(), 10)),
+	}
+	if transition != "" {
+		attrs = append(attrs, sdk.NewAttribute(types.AttributeKeyStateTransition, transition))
+	}
+	ctx.EventManager().EmitEvent(
+		sdk.NewEvent(
+			types.EventTypeSupernodeMetrics,
+			attrs...,
+		),
+	)
+
+	return &types.MsgReportSupernodeMetricsResponse{Issues: issues}, nil
+}

--- a/x/supernode/v1/types/events.go
+++ b/x/supernode/v1/types/events.go
@@ -7,6 +7,7 @@ const (
 	EventTypeSupernodeStarted      = "supernode_started"
 	EventTypeSupernodeStopped      = "supernode_stopped"
 	EventTypeSupernodeUpdated      = "supernode_updated"
+	EventTypeSupernodeMetrics      = "supernode_metrics_reported"
 
 	AttributeKeyValidatorAddress = "validator_address"
 	AttributeKeyIPAddress        = "ip_address"
@@ -21,4 +22,6 @@ const (
 	AttributeKeyOldIPAddress     = "old_ip_address"
 	AttributeKeyHeight           = "height"
 	AttributeKeyFieldsUpdated    = "fields_updated"
+	AttributeKeyIssuesCount      = "issues_count"
+	AttributeKeyStateTransition  = "state_transition"
 )

--- a/x/supernode/v1/types/keys.go
+++ b/x/supernode/v1/types/keys.go
@@ -11,6 +11,9 @@ const (
 
 	// MemStoreKey defines the in-memory store key
 	MemStoreKey = "mem_supernode"
+
+	// RouterKey is the message route for supernode messages.
+	RouterKey = ModuleName
 )
 
 var (

--- a/x/supernode/v1/types/message_report_supernode_metrics.go
+++ b/x/supernode/v1/types/message_report_supernode_metrics.go
@@ -1,0 +1,67 @@
+package types
+
+import (
+	"fmt"
+
+	errorsmod "cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+var _ sdk.Msg = &MsgReportSupernodeMetrics{}
+
+// MsgReportSupernodeMetrics reports health metrics for a supernode.
+type MsgReportSupernodeMetrics struct {
+	Creator          string             `json:"creator"`
+	ValidatorAddress string             `json:"validatorAddress"`
+	Metrics          map[string]float64 `json:"metrics"`
+	Version          string             `json:"version"`
+	ReportedHeight   int64              `json:"reported_height"`
+}
+
+// MsgReportSupernodeMetricsResponse returns any compliance issues discovered.
+type MsgReportSupernodeMetricsResponse struct {
+	Issues []string `json:"issues"`
+}
+
+func NewMsgReportSupernodeMetrics(creator, validatorAddress, version string, metrics map[string]float64, reportedHeight int64) *MsgReportSupernodeMetrics {
+	return &MsgReportSupernodeMetrics{
+		Creator:          creator,
+		ValidatorAddress: validatorAddress,
+		Metrics:          metrics,
+		Version:          version,
+		ReportedHeight:   reportedHeight,
+	}
+}
+
+func (msg *MsgReportSupernodeMetrics) Route() string { return RouterKey }
+
+func (msg *MsgReportSupernodeMetrics) Type() string { return "report_supernode_metrics" }
+
+func (msg *MsgReportSupernodeMetrics) GetSigners() []sdk.AccAddress {
+	creator, err := sdk.AccAddressFromBech32(msg.Creator)
+	if err != nil {
+		panic(err)
+	}
+	return []sdk.AccAddress{creator}
+}
+
+func (msg *MsgReportSupernodeMetrics) ValidateBasic() error {
+	if msg == nil {
+		return fmt.Errorf("msg cannot be nil")
+	}
+
+	if _, err := sdk.AccAddressFromBech32(msg.Creator); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid creator address (%s)", err)
+	}
+
+	if _, err := sdk.ValAddressFromBech32(msg.ValidatorAddress); err != nil {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "invalid validator operator address (%s)", err)
+	}
+
+	if len(msg.Metrics) == 0 {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "metrics cannot be empty")
+	}
+
+	return nil
+}

--- a/x/supernode/v1/types/metrics.go
+++ b/x/supernode/v1/types/metrics.go
@@ -1,0 +1,12 @@
+package types
+
+// Canonical metric keys used when supernodes report telemetry.
+const (
+	MetricKeyCPUUsage     = "cpu_usage"
+	MetricKeyMemoryUsage  = "memory_usage"
+	MetricKeyStorageUsage = "storage_usage"
+	MetricKeyP2PPortOpen  = "p2p_port_open"
+	MetricKeyRPCPortOpen  = "rpc_port_open"
+	MetricKeyFreshness    = "freshness"
+	MetricKeyVersion      = "version"
+)

--- a/x/supernode/v1/types/supernode_state_postponed.go
+++ b/x/supernode/v1/types/supernode_state_postponed.go
@@ -1,0 +1,12 @@
+package types
+
+func init() {
+	// Extend generated enum maps with the Postponed state without regenerating protobufs.
+	SuperNodeState_name[int32(SuperNodeStatePostponed)] = "SuperNodeStatePostponed"
+	SuperNodeState_value["SuperNodeStatePostponed"] = int32(SuperNodeStatePostponed)
+}
+
+const (
+	// SuperNodeStatePostponed represents a temporary pause due to failed compliance checks.
+	SuperNodeStatePostponed SuperNodeState = 5
+)


### PR DESCRIPTION
## Summary
- add MsgReportSupernodeMetrics definitions and canonical metric keys to support telemetry reports
- implement metrics reporting handler that validates input, checks thresholds, updates aggregates, and manages state transitions including postponed state
- extend supernode state enum with a postponed status and emit metrics reporting events

## Testing
- go test ./... *(interrupted)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69276c4e1b148328ae9c08d74763c895)