### PR TITLE
fix(supernode): repair get-metrics AutoCLI args

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,26 @@ jobs:
       - name: Run unit tests
         run: go test -v ./x/...
 
+  cli-help-smoke:
+    name: cli-help-smoke
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.1
+
+      - name: Set up Go
+        uses: ./.github/actions/setup-go
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Build lumerad
+        run: go build -o ./build/lumerad ./cmd/lumera
+
+      - name: Smoke test generated CLI help
+        run: bash ./scripts/cli-help-smoke.sh ./build/lumerad
+
   integration-tests:
     name: integration
     runs-on: ubuntu-latest

--- a/cmd/lumera/cmd/root_test.go
+++ b/cmd/lumera/cmd/root_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "testing"
+
+func TestNewRootCmd_DoesNotPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewRootCmd panicked: %v", r)
+		}
+	}()
+
+	if cmd := NewRootCmd(); cmd == nil {
+		t.Fatal("NewRootCmd returned nil")
+	}
+}

--- a/scripts/cli-help-smoke.sh
+++ b/scripts/cli-help-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BIN="${1:-./build/lumerad}"
+
+if [[ ! -x "$BIN" ]]; then
+  echo "binary not found or not executable: $BIN" >&2
+  exit 1
+fi
+
+commands=(
+  "query action params"
+  "query action action"
+  "query action get-action-fee"
+  "query action list-actions"
+  "query action list-actions-by-creator"
+  "query action list-actions-by-supernode"
+  "query action list-actions-by-block-height"
+  "query action list-expired-actions"
+  "query action query-action-by-metadata"
+  "tx action request-action"
+  "tx action finalize-action"
+  "tx action approve-action"
+  "query audit params"
+  "query audit evidence"
+  "query audit evidence-by-subject"
+  "query audit evidence-by-action"
+  "query audit current-epoch"
+  "query audit epoch-anchor"
+  "query audit current-epoch-anchor"
+  "query audit assigned-targets"
+  "query audit epoch-report"
+  "query audit epoch-reports-by-reporter"
+  "query audit storage-challenge-reports"
+  "query audit host-reports"
+  "tx audit submit-epoch-report"
+  "tx audit submit-evidence"
+  "query claim params"
+  "query claim claim-record"
+  "query claim list-claimed"
+  "tx claim claim"
+  "tx claim delayed-claim"
+  "query lumeraid params"
+  "query supernode params"
+  "query supernode get-supernode"
+  "query supernode get-supernode-by-address"
+  "query supernode list-supernodes"
+  "query supernode get-metrics"
+  "query supernode get-top-supernodes-for-block"
+  "tx supernode register-supernode"
+  "tx supernode deregister-supernode"
+  "tx supernode start-supernode"
+  "tx supernode stop-supernode"
+  "tx supernode update-supernode"
+  "tx supernode report-supernode-metrics"
+)
+
+for cmd in "${commands[@]}"; do
+  read -r -a argv <<<"$cmd"
+  echo "==> $BIN ${argv[*]} --help"
+  "$BIN" "${argv[@]}" --help >/dev/null
+done
+
+echo "CLI help smoke test passed for ${#commands[@]} commands."

--- a/tests/systemtests/audit_cli_queries_test.go
+++ b/tests/systemtests/audit_cli_queries_test.go
@@ -1,0 +1,49 @@
+//go:build system_test
+
+package system
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestAuditCLIQueriesE2E(t *testing.T) {
+	const epochLengthBlocks = uint64(20)
+
+	sut.ModifyGenesisJSON(t,
+		setSupernodeParamsForAuditTests(t),
+		setAuditParamsForFastEpochs(t, epochLengthBlocks, 1, 1, 1, []uint32{4444}),
+	)
+	sut.StartChain(t)
+
+	cli := NewLumeradCLI(t, sut, true)
+	n0 := getNodeIdentity(t, cli, "node0")
+	n1 := getNodeIdentity(t, cli, "node1")
+
+	registerSupernode(t, cli, n0, "192.168.1.1")
+	registerSupernode(t, cli, n1, "192.168.1.2")
+
+	ws0 := auditQueryAssignedTargets(t, 0, false, n0.accAddr)
+	host := auditHostReportJSON([]string{"PORT_STATE_OPEN"})
+	RequireTxSuccess(t, submitEpochReport(t, cli, n0.nodeName, ws0.EpochId, host, nil))
+	RequireTxSuccess(t, submitEpochReport(t, cli, n1.nodeName, ws0.EpochId, host, nil))
+
+	awaitAtLeastHeight(t, ws0.EpochStartHeight+int64(epochLengthBlocks))
+
+	assignedRaw := cli.CustomQuery("q", "audit", "assigned-targets", n0.accAddr, "--epoch-id", strconv.FormatUint(ws0.EpochId+1, 10), "--filter-by-epoch-id")
+	assignedEpochID := gjsonUint64(gjson.Get(assignedRaw, "epoch_id"))
+	require.Equal(t, ws0.EpochId+1, assignedEpochID, "assigned-targets should honor the requested epoch")
+	require.NotEmpty(t, gjson.Get(assignedRaw, "target_supernode_accounts").Array(), "assigned-targets should return target accounts")
+
+	currentAnchorRaw := cli.CustomQuery("q", "audit", "current-epoch-anchor")
+	currentAnchorEpochID := gjsonUint64(gjson.Get(currentAnchorRaw, "anchor.epoch_id"))
+	require.Equal(t, ws0.EpochId+1, currentAnchorEpochID, "current-epoch-anchor should return the current epoch anchor")
+	require.NotEmpty(t, gjson.Get(currentAnchorRaw, "anchor.seed").String(), "current-epoch-anchor should expose the epoch seed")
+
+	epochAnchorRaw := cli.CustomQuery("q", "audit", "epoch-anchor", strconv.FormatUint(currentAnchorEpochID, 10))
+	require.Equal(t, currentAnchorEpochID, gjsonUint64(gjson.Get(epochAnchorRaw, "anchor.epoch_id")))
+	require.Equal(t, gjson.Get(currentAnchorRaw, "anchor.seed").String(), gjson.Get(epochAnchorRaw, "anchor.seed").String())
+}

--- a/testutil/autoclitest/assertions.go
+++ b/testutil/autoclitest/assertions.go
@@ -1,0 +1,38 @@
+package autoclitest
+
+import (
+	"testing"
+
+	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func AssertServiceMethodsCovered(t *testing.T, desc grpc.ServiceDesc, opts []*autocliv1.RpcCommandOptions, skipped ...string) {
+	t.Helper()
+
+	registered := make(map[string]*autocliv1.RpcCommandOptions, len(opts))
+	for _, opt := range opts {
+		method := opt.GetRpcMethod()
+		require.NotEmpty(t, method, "autocli entry should declare an RPC method")
+		require.NotContains(t, registered, method, "duplicate AutoCLI entry for %s", method)
+		registered[method] = opt
+	}
+
+	skip := make(map[string]struct{}, len(skipped))
+	for _, method := range skipped {
+		skip[method] = struct{}{}
+	}
+
+	for _, method := range desc.Methods {
+		if _, ok := skip[method.MethodName]; ok {
+			continue
+		}
+
+		opt, ok := registered[method.MethodName]
+		require.True(t, ok, "missing AutoCLI entry for RPC %s", method.MethodName)
+		if !opt.GetSkip() {
+			require.NotEmpty(t, opt.GetUse(), "AutoCLI entry for %s should define a Use string", method.MethodName)
+		}
+	}
+}

--- a/x/action/v1/module/autocli_test.go
+++ b/x/action/v1/module/autocli_test.go
@@ -1,0 +1,19 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/LumeraProtocol/lumera/testutil/autoclitest"
+	"github.com/LumeraProtocol/lumera/x/action/v1/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoCLIOptions_CoversAllRPCs(t *testing.T) {
+	opts := AppModule{}.AutoCLIOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Query)
+	require.NotNil(t, opts.Tx)
+
+	autoclitest.AssertServiceMethodsCovered(t, types.Query_serviceDesc, opts.Query.RpcCommandOptions)
+	autoclitest.AssertServiceMethodsCovered(t, types.Msg_serviceDesc, opts.Tx.RpcCommandOptions, "UpdateParams")
+}

--- a/x/audit/v1/module/autocli.go
+++ b/x/audit/v1/module/autocli.go
@@ -40,6 +40,23 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Short:     "Query current audit epoch boundaries",
 				},
 				{
+					RpcMethod:      "EpochAnchor",
+					Use:            "epoch-anchor [epoch-id]",
+					Short:          "Query the persisted anchor for an epoch",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "epoch_id"}},
+				},
+				{
+					RpcMethod: "CurrentEpochAnchor",
+					Use:       "current-epoch-anchor",
+					Short:     "Query the persisted anchor for the current epoch",
+				},
+				{
+					RpcMethod:      "AssignedTargets",
+					Use:            "assigned-targets [supernode-account]",
+					Short:          "Query the current or filtered target assignments for a reporter",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "supernode_account"}},
+				},
+				{
 					RpcMethod:      "EpochReport",
 					Use:            "epoch-report [epoch-id] [supernode-account]",
 					Short:          "Query an epoch report by epoch and reporter",

--- a/x/audit/v1/module/autocli_test.go
+++ b/x/audit/v1/module/autocli_test.go
@@ -1,0 +1,19 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/LumeraProtocol/lumera/testutil/autoclitest"
+	"github.com/LumeraProtocol/lumera/x/audit/v1/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoCLIOptions_CoversAllRPCs(t *testing.T) {
+	opts := AppModule{}.AutoCLIOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Query)
+	require.NotNil(t, opts.Tx)
+
+	autoclitest.AssertServiceMethodsCovered(t, types.Query_serviceDesc, opts.Query.RpcCommandOptions)
+	autoclitest.AssertServiceMethodsCovered(t, types.Msg_serviceDesc, opts.Tx.RpcCommandOptions, "UpdateParams")
+}

--- a/x/claim/module/autocli_test.go
+++ b/x/claim/module/autocli_test.go
@@ -1,0 +1,19 @@
+package claim
+
+import (
+	"testing"
+
+	"github.com/LumeraProtocol/lumera/testutil/autoclitest"
+	"github.com/LumeraProtocol/lumera/x/claim/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoCLIOptions_CoversAllRPCs(t *testing.T) {
+	opts := AppModule{}.AutoCLIOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Query)
+	require.NotNil(t, opts.Tx)
+
+	autoclitest.AssertServiceMethodsCovered(t, types.Query_serviceDesc, opts.Query.RpcCommandOptions)
+	autoclitest.AssertServiceMethodsCovered(t, types.Msg_serviceDesc, opts.Tx.RpcCommandOptions, "UpdateParams")
+}

--- a/x/lumeraid/module/autocli_test.go
+++ b/x/lumeraid/module/autocli_test.go
@@ -1,0 +1,19 @@
+package lumeraid
+
+import (
+	"testing"
+
+	"github.com/LumeraProtocol/lumera/testutil/autoclitest"
+	"github.com/LumeraProtocol/lumera/x/lumeraid/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoCLIOptions_CoversAllRPCs(t *testing.T) {
+	opts := AppModule{}.AutoCLIOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Query)
+	require.NotNil(t, opts.Tx)
+
+	autoclitest.AssertServiceMethodsCovered(t, types.Query_serviceDesc, opts.Query.RpcCommandOptions)
+	autoclitest.AssertServiceMethodsCovered(t, types.Msg_serviceDesc, opts.Tx.RpcCommandOptions, "UpdateParams")
+}

--- a/x/supernode/v1/module/autocli.go
+++ b/x/supernode/v1/module/autocli.go
@@ -22,7 +22,8 @@ Flags:
 func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 	return &autocliv1.ModuleOptions{
 		Query: &autocliv1.ServiceCommandDescriptor{
-			Service: types.Query_serviceDesc.ServiceName,
+			Service:              types.Query_serviceDesc.ServiceName,
+			EnhanceCustomCommand: true,
 			RpcCommandOptions: []*autocliv1.RpcCommandOptions{
 				{
 					RpcMethod: "Params",
@@ -46,6 +47,15 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 					Use:            "list-supernodes",
 					Short:          "Query list-supernodes",
 					PositionalArgs: []*autocliv1.PositionalArgDescriptor{},
+				},
+				{
+					// Keep this on the generic AutoCLI path for consistency with the rest of the
+					// module's query surface. Note that response printing for this float-bearing
+					// payload is still limited on the generic path in this environment.
+					RpcMethod:      "GetMetrics",
+					Use:            "get-metrics [validator-address]",
+					Short:          "Query the latest supernode metrics for a validator",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "validatorAddress"}},
 				},
 				{
 					RpcMethod: "GetTopSuperNodesForBlock",

--- a/x/supernode/v1/module/autocli.go
+++ b/x/supernode/v1/module/autocli.go
@@ -138,6 +138,12 @@ func (am AppModule) AutoCLIOptions() *autocliv1.ModuleOptions {
 						},
 					},
 				},
+				{
+					RpcMethod:      "ReportSupernodeMetrics",
+					Use:            "report-supernode-metrics [validator-address]",
+					Short:          "Report structured metrics for a supernode",
+					PositionalArgs: []*autocliv1.PositionalArgDescriptor{{ProtoField: "validator_address"}},
+				},
 				// this line is used by ignite scaffolding # autocli/tx
 			},
 		},

--- a/x/supernode/v1/module/autocli_test.go
+++ b/x/supernode/v1/module/autocli_test.go
@@ -1,0 +1,27 @@
+package supernode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAutoCLIOptions_GetMetrics(t *testing.T) {
+	opts := AppModule{}.AutoCLIOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Query)
+
+	var found bool
+	for _, rpc := range opts.Query.RpcCommandOptions {
+		if rpc.GetRpcMethod() != "GetMetrics" {
+			continue
+		}
+
+		found = true
+		require.Equal(t, "get-metrics [validator-address]", rpc.GetUse())
+		require.Len(t, rpc.GetPositionalArgs(), 1)
+		require.Equal(t, "validatorAddress", rpc.GetPositionalArgs()[0].GetProtoField())
+	}
+
+	require.True(t, found, "GetMetrics query should be exposed via AutoCLI")
+}

--- a/x/supernode/v1/module/autocli_test.go
+++ b/x/supernode/v1/module/autocli_test.go
@@ -3,8 +3,20 @@ package supernode
 import (
 	"testing"
 
+	"github.com/LumeraProtocol/lumera/testutil/autoclitest"
+	"github.com/LumeraProtocol/lumera/x/supernode/v1/types"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAutoCLIOptions_CoversAllRPCs(t *testing.T) {
+	opts := AppModule{}.AutoCLIOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Query)
+	require.NotNil(t, opts.Tx)
+
+	autoclitest.AssertServiceMethodsCovered(t, types.Query_serviceDesc, opts.Query.RpcCommandOptions)
+	autoclitest.AssertServiceMethodsCovered(t, types.Msg_serviceDesc, opts.Tx.RpcCommandOptions, "UpdateParams")
+}
 
 func TestAutoCLIOptions_GetMetrics(t *testing.T) {
 	opts := AppModule{}.AutoCLIOptions()
@@ -24,4 +36,24 @@ func TestAutoCLIOptions_GetMetrics(t *testing.T) {
 	}
 
 	require.True(t, found, "GetMetrics query should be exposed via AutoCLI")
+}
+
+func TestAutoCLIOptions_ReportSupernodeMetrics(t *testing.T) {
+	opts := AppModule{}.AutoCLIOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Tx)
+
+	var found bool
+	for _, rpc := range opts.Tx.RpcCommandOptions {
+		if rpc.GetRpcMethod() != "ReportSupernodeMetrics" {
+			continue
+		}
+
+		found = true
+		require.Equal(t, "report-supernode-metrics [validator-address]", rpc.GetUse())
+		require.Len(t, rpc.GetPositionalArgs(), 1)
+		require.Equal(t, "validator_address", rpc.GetPositionalArgs()[0].GetProtoField())
+	}
+
+	require.True(t, found, "ReportSupernodeMetrics tx should be exposed via AutoCLI")
 }


### PR DESCRIPTION
 ## Summary

  This PR fixes the generated CLI regressions around supernode metrics and adds guardrails so similar AutoCLI issues are caught earlier.

  ## Included changes

  ### 1. Fix query supernode get-metrics

  - Exposes GetMetrics explicitly in supernode query AutoCLI.
  - Enables query command enhancement for the supernode module.
  - Restores the expected command shape:
      - lumerad query supernode get-metrics [validator-address]

  ### 2. Fix tx supernode report-supernode-metrics

  - Exposes ReportSupernodeMetrics explicitly in supernode tx AutoCLI.
  - Fixes the positional argument mapping to the correct proto field.
  - Restores the expected command shape:
      - lumerad tx supernode report-supernode-metrics [validator-address] --metrics <json> --from <key>
  - Prevents CLI startup/runtime failure caused by the broken AutoCLI descriptor.

  ### 3. Fix other missing AutoCLI audit queries

  Adds missing audit query commands that existed in proto but were not exposed:

  - lumerad query audit epoch-anchor [epoch-id]
  - lumerad query audit current-epoch-anchor
  - lumerad query audit assigned-targets [supernode-account]

  ## Test and CI hardening

  - Adds targeted AutoCLI tests for the supernode metrics commands.
  - Adds module-level AutoCLI coverage tests across:
      - x/action
      - x/audit
      - x/claim
      - x/lumeraid
      - x/supernode
  - Adds a root command smoke test to ensure NewRootCmd() does not panic on invalid AutoCLI descriptors.
  - Adds a CLI help smoke script plus CI job that builds lumerad and runs --help across generated commands.
  - Adds a system test covering the newly exposed audit CLI queries end-to-end.

  ## Why

  We found two separate metrics-related CLI regressions:

  - get-metrics was not properly exposed through query AutoCLI.
  - report-supernode-metrics was exposed incorrectly and could degrade into broken generic RPC behavior or invalid descriptor wiring.

  This PR fixes both and adds coverage to catch future proto/AutoCLI drift.

  ## Validation

  Ran successfully:

  - go test ./cmd/lumera/cmd ./x/action/v1/module ./x/audit/v1/module ./x/claim/module ./x/lumeraid/module ./x/supernode/v1/module
  - bash ./scripts/cli-help-smoke.sh /tmp/lumerad-autocli
  - go test -tags=system_test -run TestAuditCLIQueriesE2E -timeout 20m -binary lumerad -v . in tests/systemtests