### PR TITLE
chore(lint): clear scoped golangci-lint + buf BRIDGE-surface findings

### DIFF
--- a/proto/lumera/action/v1/metadata.proto
+++ b/proto/lumera/action/v1/metadata.proto
@@ -8,8 +8,11 @@ import "gogoproto/gogo.proto";
 // HashAlgo enumerates the supported hash algorithms for availability
 // commitments.
 enum HashAlgo {
+  // HASH_ALGO_UNSPECIFIED is the zero value; rejected by validation.
   HASH_ALGO_UNSPECIFIED = 0;
+  // HASH_ALGO_BLAKE3 selects BLAKE3 as the chunk/leaf hash function.
   HASH_ALGO_BLAKE3      = 1;
+  // HASH_ALGO_SHA256 selects SHA-256 as the chunk/leaf hash function.
   HASH_ALGO_SHA256      = 2;
 }
 

--- a/proto/lumera/supernode/v1/params.proto
+++ b/proto/lumera/supernode/v1/params.proto
@@ -7,6 +7,9 @@ import "amino/amino.proto";
 import "gogoproto/gogo.proto";
 import "cosmos/base/v1beta1/coin.proto";
 
+// RewardDistribution governs the Everlight reward pool's payout cadence,
+// eligibility floor, ramp-up, smoothing window and growth cap. All fields
+// are governance-mutable via supernode MsgUpdateParams.
 message RewardDistribution {
   option (gogoproto.equal) = true;
 

--- a/proto/lumera/supernode/v1/supernode_state.proto
+++ b/proto/lumera/supernode/v1/supernode_state.proto
@@ -5,22 +5,36 @@ option go_package = "x/supernode/v1/types";
 
 import "gogoproto/gogo.proto";
 
+// SuperNodeState is the lifecycle state of a SuperNode. Transitions are
+// governed by the supernode and audit modules; see x/supernode/v1/keeper
+// and x/audit/v1/keeper for the authoritative state machine.
 enum SuperNodeState {
   option (gogoproto.goproto_enum_prefix) = false;
   option (gogoproto.goproto_enum_stringer) = true;
 
+  // SUPERNODE_STATE_UNSPECIFIED is the proto3 zero value; never persisted.
   SUPERNODE_STATE_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "SuperNodeStateUnspecified"];
+  // SUPERNODE_STATE_ACTIVE: SuperNode is healthy and eligible for all duties.
   SUPERNODE_STATE_ACTIVE = 1 [(gogoproto.enumvalue_customname) = "SuperNodeStateActive"];
+  // SUPERNODE_STATE_DISABLED: operator-disabled (deregistered) SuperNode.
   SUPERNODE_STATE_DISABLED = 2 [(gogoproto.enumvalue_customname) = "SuperNodeStateDisabled"];
+  // SUPERNODE_STATE_STOPPED: operator-stopped SuperNode (recoverable).
   SUPERNODE_STATE_STOPPED = 3 [(gogoproto.enumvalue_customname) = "SuperNodeStateStopped"];
+  // SUPERNODE_STATE_PENALIZED: penalized by chain enforcement (e.g. slashing).
   SUPERNODE_STATE_PENALIZED = 4 [(gogoproto.enumvalue_customname) = "SuperNodeStatePenalized"];
+  // SUPERNODE_STATE_POSTPONED: temporarily ineligible due to missing/overdue
+  // metrics or compliance violations; recovers on the next healthy report.
   SUPERNODE_STATE_POSTPONED = 5 [(gogoproto.enumvalue_customname) = "SuperNodeStatePostponed"];
+  // SUPERNODE_STATE_STORAGE_FULL: storage usage above max threshold;
+  // excluded from Cascade duties but still eligible for Sense/Agents.
   SUPERNODE_STATE_STORAGE_FULL = 6 [(gogoproto.enumvalue_customname) = "SuperNodeStateStorageFull"];
 }
 
-message SuperNodeStateRecord { 
+// SuperNodeStateRecord is one entry in the append-only state history of a
+// SuperNode. The latest entry is the current state.
+message SuperNodeStateRecord {
   SuperNodeState state = 1 [(gogoproto.moretags) = "yaml:\"state\""];
-  int64 height = 2; 
+  int64 height = 2;
   // reason is an optional string describing why the state transition occurred.
   // It is currently set only for transitions into POSTPONED.
   string reason = 3 [(gogoproto.moretags) = "yaml:\"reason\""];

--- a/x/action/v1/keeper/crypto_test.go
+++ b/x/action/v1/keeper/crypto_test.go
@@ -267,8 +267,8 @@ func TestGenerateSupernodeRQIDs(t *testing.T) {
 		rqMax     uint32
 	}
 
-	rand.Seed(time.Now().UnixNano())
-	ic := uint32(rand.Intn(100000))
+	rng := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // test-only randomness
+	ic := uint32(rng.Intn(100000))
 
 	tests := []testCase{
 		{

--- a/x/action/v1/keeper/query_action_by_metadata_test.go
+++ b/x/action/v1/keeper/query_action_by_metadata_test.go
@@ -132,10 +132,10 @@ func TestQueryActionByMetadata(t *testing.T) {
 				MetadataQuery: "collection_id=collection1",
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
-				k.SetAction(ctx, &action4)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
+				require.NoError(t, k.SetAction(ctx, &action4))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryActionByMetadataResponse) {
@@ -152,9 +152,9 @@ func TestQueryActionByMetadata(t *testing.T) {
 				MetadataQuery: "collection_id=collection3",
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryActionByMetadataResponse) {
@@ -173,10 +173,10 @@ func TestQueryActionByMetadata(t *testing.T) {
 				},
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
-				k.SetAction(ctx, &action4)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
+				require.NoError(t, k.SetAction(ctx, &action4))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryActionByMetadataResponse) {

--- a/x/action/v1/keeper/query_get_action_fee_test.go
+++ b/x/action/v1/keeper/query_get_action_fee_test.go
@@ -40,7 +40,7 @@ func TestKeeper_GetActionFee(t *testing.T) {
 				params := types.DefaultParams()
 				params.BaseActionFee = sdk.NewCoin("ulume", math.NewInt(10000))
 				params.FeePerKbyte = sdk.NewCoin("ulume", math.NewInt(100))
-				k.SetParams(ctx, params)
+				require.NoError(t, k.SetParams(ctx, params))
 			},
 			expectedFee: "10000",
 		},
@@ -51,7 +51,7 @@ func TestKeeper_GetActionFee(t *testing.T) {
 				params := types.DefaultParams()
 				params.BaseActionFee = sdk.NewCoin("ulume", math.NewInt(10000))
 				params.FeePerKbyte = sdk.NewCoin("ulume", math.NewInt(100))
-				k.SetParams(ctx, params)
+				require.NoError(t, k.SetParams(ctx, params))
 			},
 			expectedFee: "30000", // 100 * 200 + 10000
 		},

--- a/x/action/v1/keeper/query_get_action_test.go
+++ b/x/action/v1/keeper/query_get_action_test.go
@@ -60,7 +60,7 @@ func TestKeeper_GetAction(t *testing.T) {
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
 				action.Price = price.String()
-				k.SetAction(ctx, &action)
+				require.NoError(t, k.SetAction(ctx, &action))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryGetActionResponse) {

--- a/x/action/v1/keeper/query_list_actions_by_block_height_test.go
+++ b/x/action/v1/keeper/query_list_actions_by_block_height_test.go
@@ -93,8 +93,8 @@ func TestKeeper_ListActionsByBlockHeight(t *testing.T) {
 				BlockHeight: blockHeight,
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsByBlockHeightResponse) {
@@ -110,9 +110,9 @@ func TestKeeper_ListActionsByBlockHeight(t *testing.T) {
 				BlockHeight: blockHeight,
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsByBlockHeightResponse) {

--- a/x/action/v1/keeper/query_list_actions_by_sn_test.go
+++ b/x/action/v1/keeper/query_list_actions_by_sn_test.go
@@ -91,8 +91,8 @@ func TestKeeper_ListActionsBySuperNode(t *testing.T) {
 				SuperNodeAddress: superNodeAddr,
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsBySuperNodeResponse) {
@@ -108,9 +108,9 @@ func TestKeeper_ListActionsBySuperNode(t *testing.T) {
 				SuperNodeAddress: superNodeAddr,
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsBySuperNodeResponse) {
@@ -129,8 +129,8 @@ func TestKeeper_ListActionsBySuperNode(t *testing.T) {
 				},
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsBySuperNodeResponse) {

--- a/x/action/v1/keeper/query_list_actions_test.go
+++ b/x/action/v1/keeper/query_list_actions_test.go
@@ -74,9 +74,9 @@ func TestKeeper_ListActions(t *testing.T) {
 				ActionState: types.ActionStateProcessing,
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsResponse) {
@@ -91,9 +91,9 @@ func TestKeeper_ListActions(t *testing.T) {
 				ActionType: types.ActionTypeCascade,
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsResponse) {
@@ -111,9 +111,9 @@ func TestKeeper_ListActions(t *testing.T) {
 				},
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsResponse) {
@@ -131,9 +131,9 @@ func TestKeeper_ListActions(t *testing.T) {
 				},
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListActionsResponse) {

--- a/x/action/v1/keeper/query_list_expired_actions_test.go
+++ b/x/action/v1/keeper/query_list_expired_actions_test.go
@@ -71,9 +71,9 @@ func TestKeeper_ListExpiredActions(t *testing.T) {
 			name: "actions found with EXPIRED state",
 			req:  &types.QueryListExpiredActionsRequest{},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListExpiredActionsResponse) {
@@ -87,7 +87,7 @@ func TestKeeper_ListExpiredActions(t *testing.T) {
 			name: "no expired actions",
 			req:  &types.QueryListExpiredActionsRequest{},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action2)
+				require.NoError(t, k.SetAction(ctx, &action2))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListExpiredActionsResponse) {
@@ -104,9 +104,9 @@ func TestKeeper_ListExpiredActions(t *testing.T) {
 				},
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListExpiredActionsResponse) {
@@ -124,9 +124,9 @@ func TestKeeper_ListExpiredActions(t *testing.T) {
 				},
 			},
 			setupState: func(k keeper.Keeper, ctx sdk.Context) {
-				k.SetAction(ctx, &action1)
-				k.SetAction(ctx, &action2)
-				k.SetAction(ctx, &action3)
+				require.NoError(t, k.SetAction(ctx, &action1))
+				require.NoError(t, k.SetAction(ctx, &action2))
+				require.NoError(t, k.SetAction(ctx, &action3))
 			},
 			expectedErr: nil,
 			checkResult: func(t *testing.T, resp *types.QueryListExpiredActionsResponse) {

--- a/x/action/v1/module/module.go
+++ b/x/action/v1/module/module.go
@@ -25,7 +25,7 @@ var (
 	_ module.AppModuleBasic      = (*AppModule)(nil)
 	_ module.AppModuleSimulation = (*AppModule)(nil)
 	_ module.HasGenesis          = (*AppModule)(nil)
-	_ module.HasInvariants       = (*AppModule)(nil)
+	_ module.HasInvariants       = (*AppModule)(nil) //nolint:staticcheck // SDK v0.50 still requires HasInvariants; removed only when x/crisis is dropped.
 	_ module.HasConsensusVersion = (*AppModule)(nil)
 
 	_ appmodule.AppModule       = (*AppModule)(nil)
@@ -129,7 +129,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 }
 
 // RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted)
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {} //nolint:staticcheck // see HasInvariants note above
 
 // InitGenesis performs the module's genesis initialization. It returns no validator updates.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {

--- a/x/action/v1/module/simulation.go
+++ b/x/action/v1/module/simulation.go
@@ -23,19 +23,8 @@ var (
 )
 
 const (
-	opWeightMsgRequestAction = "op_weight_msg_request_action"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgRequestAction int = 100
-
-	opWeightMsgFinalizeAction = "op_weight_msg_finalize_action"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgFinalizeAction int = 100
-
-	opWeightMsgApproveAction = "op_weight_msg_approve_action"
-	// TODO: Determine the simulation weight value
-	defaultWeightMsgApproveAction int = 100
-
 	// this line is used by starport scaffolding # simapp/module/const
+	_ = "" // placeholder to keep starport scaffolding line stable
 )
 
 // GenerateGenesisState creates a randomized GenState of the module.

--- a/x/action/v1/simulation/helpers.go
+++ b/x/action/v1/simulation/helpers.go
@@ -385,11 +385,6 @@ func selectRandomActionType(r *rand.Rand) string {
 	return actionTypes[r.Intn(len(actionTypes))]
 }
 
-// generateRandomOtiValues generates n random bytes as OTI value for CASCADE metadata
-func generateRandomOtiValues(n int) []byte {
-	return make([]byte, n)
-}
-
 // getRandomActiveSupernodes simulates getting a list of active supernodes from the system
 func getRandomActiveSupernodes(r *rand.Rand, ctx sdk.Context, numSupernodes int, ak types.AuthKeeper, k keeper.Keeper, accs []simtypes.Account) ([]simtypes.Account, error) {
 	top10 := getTop10Supernodes(ctx, k)

--- a/x/supernode/v1/keeper/metrics_state.go
+++ b/x/supernode/v1/keeper/metrics_state.go
@@ -53,48 +53,6 @@ func recoverFromPostponed(ctx sdk.Context, keeper types.SupernodeKeeper, sn *typ
 	return nil
 }
 
-func markStorageFull(ctx sdk.Context, keeper types.SupernodeKeeper, sn *types.SuperNode) error {
-	if len(sn.States) == 0 {
-		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "supernode state missing")
-	}
-	last := sn.States[len(sn.States)-1]
-	if last.State == types.SuperNodeStateStorageFull {
-		return nil
-	}
-	sn.States = append(sn.States, &types.SuperNodeStateRecord{State: types.SuperNodeStateStorageFull, Height: ctx.BlockHeight()})
-	if err := keeper.SetSuperNode(ctx, *sn); err != nil {
-		return err
-	}
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			types.EventTypeSupernodeStorageFull,
-			sdk.NewAttribute(types.AttributeKeyValidatorAddress, sn.ValidatorAddress),
-			sdk.NewAttribute(types.AttributeKeyOldState, last.State.String()),
-			sdk.NewAttribute(types.AttributeKeyHeight, stringHeight(ctx.BlockHeight())),
-		),
-	)
-	return nil
-}
-
-func recoverFromStorageFull(ctx sdk.Context, keeper types.SupernodeKeeper, sn *types.SuperNode, target types.SuperNodeState) error {
-	if target == types.SuperNodeStateUnspecified {
-		target = types.SuperNodeStateActive
-	}
-	sn.States = append(sn.States, &types.SuperNodeStateRecord{State: target, Height: ctx.BlockHeight()})
-	if err := keeper.SetSuperNode(ctx, *sn); err != nil {
-		return err
-	}
-	ctx.EventManager().EmitEvent(
-		sdk.NewEvent(
-			types.EventTypeSupernodeStorageRecovered,
-			sdk.NewAttribute(types.AttributeKeyValidatorAddress, sn.ValidatorAddress),
-			sdk.NewAttribute(types.AttributeKeyOldState, types.SuperNodeStateStorageFull.String()),
-			sdk.NewAttribute(types.AttributeKeyHeight, stringHeight(ctx.BlockHeight())),
-		),
-	)
-	return nil
-}
-
 func stringHeight(height int64) string {
 	return strconv.FormatInt(height, 10)
 }

--- a/x/supernode/v1/keeper/metrics_validation.go
+++ b/x/supernode/v1/keeper/metrics_validation.go
@@ -205,17 +205,3 @@ func evaluateCompliance(ctx sdk.Context, params types.Params, m types.SupernodeM
 	return ComplianceResult{Issues: issues, StorageFull: storageFull}
 }
 
-// lastNonDegradedState returns the most recent state that is not POSTPONED
-// or STORAGE_FULL, for use when recovering from a degraded state.
-func lastNonDegradedState(states []*types.SuperNodeStateRecord) types.SuperNodeState {
-	for i := len(states) - 1; i >= 0; i-- {
-		if states[i] == nil {
-			continue
-		}
-		s := states[i].State
-		if s != types.SuperNodeStatePostponed && s != types.SuperNodeStateStorageFull {
-			return s
-		}
-	}
-	return types.SuperNodeStateUnspecified
-}

--- a/x/supernode/v1/keeper/msg_server_deregister_supernode_test.go
+++ b/x/supernode/v1/keeper/msg_server_deregister_supernode_test.go
@@ -89,7 +89,7 @@ func TestMsgServer_DeRegisterSupernode(t *testing.T) {
 			k, ctx := setupKeeperForTest(t, stakingKeeper, slashingKeeper, bankKeeper)
 			if tc.expectedError != sdkerrors.ErrNotFound {
 
-				k.SetSuperNode(ctx, types.SuperNode{
+				require.NoError(t, k.SetSuperNode(ctx, types.SuperNode{
 					SupernodeAccount: creatorAddr.String(),
 					ValidatorAddress: valAddr.String(),
 					Note:             "1.0.0",
@@ -111,7 +111,7 @@ func TestMsgServer_DeRegisterSupernode(t *testing.T) {
 						},
 					},
 					P2PPort: "26657",
-				})
+				}))
 			}
 
 			msgServer := keeper.NewMsgServerImpl(k)

--- a/x/supernode/v1/keeper/msg_server_report_supernode_metrics_test.go
+++ b/x/supernode/v1/keeper/msg_server_report_supernode_metrics_test.go
@@ -98,7 +98,7 @@ func TestReportSupernodeMetrics_SingleReportRecoversPostponed(t *testing.T) {
 	ctx = ctx.WithBlockHeader(header)
 
 	resp, err := ms.ReportSupernodeMetrics(
-		sdk.WrapSDKContext(ctx),
+		ctx,
 		&types.MsgReportSupernodeMetrics{
 			ValidatorAddress: supernode.ValidatorAddress,
 			SupernodeAccount: supernode.SupernodeAccount,
@@ -174,7 +174,7 @@ func TestReportSupernodeMetrics_ClosedRequiredPortDoesNotPostpone(t *testing.T) 
 	ctx = ctx.WithBlockHeader(header)
 
 	resp, err := ms.ReportSupernodeMetrics(
-		sdk.WrapSDKContext(ctx),
+		ctx,
 		&types.MsgReportSupernodeMetrics{
 			ValidatorAddress: supernode.ValidatorAddress,
 			SupernodeAccount: supernode.SupernodeAccount,
@@ -236,7 +236,7 @@ func TestReportSupernodeMetrics_EmptyPortsStillPersistsAndDoesNotRecover(t *test
 	ctx = ctx.WithBlockHeader(header)
 
 	resp, err := ms.ReportSupernodeMetrics(
-		sdk.WrapSDKContext(ctx),
+		ctx,
 		&types.MsgReportSupernodeMetrics{
 			ValidatorAddress: supernode.ValidatorAddress,
 			SupernodeAccount: supernode.SupernodeAccount,
@@ -305,7 +305,7 @@ func TestReportSupernodeMetrics_StorageFullSignalDoesNotTransitionState(t *testi
 	ctx = ctx.WithBlockHeader(tmproto.Header{Height: ctx.BlockHeight()})
 
 	resp, err := ms.ReportSupernodeMetrics(
-		sdk.WrapSDKContext(ctx),
+		ctx,
 		&types.MsgReportSupernodeMetrics{
 			ValidatorAddress: supernode.ValidatorAddress,
 			SupernodeAccount: supernode.SupernodeAccount,
@@ -376,7 +376,7 @@ func TestReportSupernodeMetrics_DoesNotRecoverFromStorageFull(t *testing.T) {
 	ctx = ctx.WithBlockHeader(tmproto.Header{Height: ctx.BlockHeight()})
 
 	resp, err := ms.ReportSupernodeMetrics(
-		sdk.WrapSDKContext(ctx),
+		ctx,
 		&types.MsgReportSupernodeMetrics{
 			ValidatorAddress: supernode.ValidatorAddress,
 			SupernodeAccount: supernode.SupernodeAccount,

--- a/x/supernode/v1/module/module.go
+++ b/x/supernode/v1/module/module.go
@@ -26,7 +26,7 @@ var (
 	_ module.AppModuleBasic      = (*AppModule)(nil)
 	_ module.AppModuleSimulation = (*AppModule)(nil)
 	_ module.HasGenesis          = (*AppModule)(nil)
-	_ module.HasInvariants       = (*AppModule)(nil)
+	_ module.HasInvariants       = (*AppModule)(nil) //nolint:staticcheck // SDK v0.50 still requires HasInvariants; removed only when x/crisis is dropped.
 	_ module.HasConsensusVersion = (*AppModule)(nil)
 
 	_ appmodule.AppModule       = (*AppModule)(nil)
@@ -132,7 +132,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 }
 
 // RegisterInvariants registers the invariants of the module. If an invariant deviates from its predicted value, the InvariantRegistry triggers appropriate logic (most often the chain will be halted)
-func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
+func (am AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {} //nolint:staticcheck // see HasInvariants note above
 
 // InitGenesis performs the module's genesis initialization. It returns no validator updates.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, gs json.RawMessage) {

--- a/x/supernode/v1/simulation/update_supernode.go
+++ b/x/supernode/v1/simulation/update_supernode.go
@@ -81,10 +81,7 @@ func SimulateMsgUpdateSupernode(
 					break
 				}
 			}
-			// If no free account found, skip updating the supernode account.
-			if supernodeAccount == "" {
-				updateAccount = false
-			}
+			// If no free account found, supernodeAccount stays empty and is skipped.
 		}
 
 		if updateVersion {


### PR DESCRIPTION
## Summary

Drops the scoped `golangci-lint` count from **25 → 0** and clears the BRIDGE-surface `buf lint` findings the Everlight gate report flagged. No state-machine, schema, or on-chain behavior changes.

Triggered by the post-Everlight gate report (2026-04-28): functional Everlight evidence was already green (`PASS: 35  FAIL: 0  SKIP: 5` on devnet, two clean iterations) but `OVERALL: FAIL` on code-quality.

## Scoped lint: 25 → 0

| Class | Action |
|---|---|
| Unused state-machine helpers in `x/supernode/v1/keeper/metrics_state.go` and `metrics_validation.go` | **Deleted** `markStorageFull`, `recoverFromStorageFull`, `lastNonDegradedState`. The audit module already performs STORAGE_FULL/POSTPONED transitions inline in `x/audit/v1/keeper/state.go` and `enforcement.go`. |
| Unused simulation scaffolding in `x/action/v1/simulation/helpers.go` and `module/simulation.go` | **Deleted** `generateRandomOtiValues` and 6 `opWeightMsg*`/`defaultWeightMsg*` consts. |
| ineffassign in `x/supernode/v1/simulation/update_supernode.go` | Removed dead `updateAccount = false` branch. |
| errcheck across 8 scoped action `*_test.go` and 1 supernode test | Wrap `k.SetAction` / `k.SetParams` / `k.SetSuperNode` in `require.NoError(t, ...)`. Tests now fail on store errors instead of silently swallowing them. |
| SA1019 `sdk.WrapSDKContext` | Removed (5 sites). |
| SA1019 `rand.Seed` | Replaced with `rand.New(rand.NewSource(...))`. |
| SA1019 `module.HasInvariants` / `sdk.InvariantRegistry` | `//nolint:staticcheck` with rationale: SDK v0.50 still requires `HasInvariants`; deprecation only resolves when `x/crisis` is dropped. |

## buf lint: BRIDGE surfaces commented

Added doc comments to `HashAlgo`, `RewardDistribution`, `SuperNodeState`, `SuperNodeStateRecord`.

**Out of scope:** `SUPER_NODE_STATE_*` prefix and `field_lower_snake_case` (`actionID → action_id`) findings — those are wire-incompatible renames touching every existing client.

## Verification

```
golangci-lint run ./x/action/v1/... ./x/supernode/v1/...    # 0 issues, exit 0
go test ./x/action/v1/... ./x/supernode/v1/... -count=1     # PASS
go test ./tests/integration/everlight ./tests/e2e/everlight \
        ./app/upgrades/v1_12_0 ./tests/integration/action/...  # PASS
go build -tags netgo,ledger -o /tmp/lumerad ./cmd/lumera    # OK
```

Devnet (`make -f Makefile.devnet devnet-tests-everlight`) was green on master before this PR (2 consecutive iterations, FAIL=0) and these are scoped lint changes only — no devnet behavioral impact expected.

## Risks

Minimal. All deletions are dead code (verified via repo-wide grep for call sites). errcheck/SA1019 changes are mechanical and behavior-preserving. The only behavioral change is *positive*: tests will fail on swallowed store errors instead of continuing.

## Rollback

Single revert. No migration, no upgrade handler, no on-chain effect.

## Note on the deleted helpers

`metrics_state.go` previously shipped `markStorageFull`/`recoverFromStorageFull` while `x/audit/v1/keeper/state.go:57`+`enforcement.go:464` performed the same transitions inline. That was a duplicated, drift-prone state-machine surface. Deleting the unused helpers removes the ambiguity. Routing both modules through a single set of helpers (restoring SSoT for SuperNode state transitions) is a worthwhile follow-up but is a larger refactor not in scope here.
