### PR TITLE
chore(upgrade/v1.12.0): persist post-1.11.1 defaults and anchor Everlight clock

### DIFF
--- a/app/upgrades/v1_12_0/upgrade.go
+++ b/app/upgrades/v1_12_0/upgrade.go
@@ -11,13 +11,48 @@ import (
 
 	consensusparams "github.com/LumeraProtocol/lumera/app/upgrades/internal/consensusparams"
 	appParams "github.com/LumeraProtocol/lumera/app/upgrades/params"
+	audittypes "github.com/LumeraProtocol/lumera/x/audit/v1/types"
 )
 
 // UpgradeName is the on-chain name used for this upgrade.
 const UpgradeName = "v1.12.0"
 
-// CreateUpgradeHandler runs the migration that initializes the supernode
-// module's embedded Everlight configuration.
+// Activation-time policy constants.
+//
+// These are written exactly once during the upgrade; thereafter, params are
+// governed by MsgUpdateParams.
+const (
+	// everlightEnabled is informational: Everlight payout logic activates as
+	// soon as supernode params carry a non-zero RewardDistribution. We persist
+	// the default RewardDistribution explicitly in this handler so the very
+	// first post-upgrade query returns the canonical values.
+	everlightEnabled = true
+
+	// storageTruthEnforcementMode is the LEP-6 enforcement mode burned in at
+	// activation. SHADOW means evidence is collected but no enforcement actions
+	// (postpone, slash) are taken. Future modes (SOFT, FULL) require an
+	// explicit governance MsgUpdateParams.
+	storageTruthEnforcementMode = audittypes.StorageTruthEnforcementMode_STORAGE_TRUTH_ENFORCEMENT_MODE_SHADOW
+)
+
+// CreateUpgradeHandler runs migrations and persists default values for params
+// and per-chain anchors introduced after v1.11.1-hotfix:
+//   - LEP-5 (action): SvcChallengeCount, SvcMinChunksForChallenge.
+//   - Everlight + LEP-4 (supernode): RewardDistribution, MetricsUpdateIntervalBlocks,
+//     MetricsGracePeriodBlocks, MetricsFreshnessMaxBlocks, MinSupernodeVersion,
+//     MinCpu/Mem/Storage, MaxCpu/Mem/StorageUsagePercent, RequiredOpenPorts.
+//   - LEP-6 (audit): StorageTruth* params and explicit enforcement mode (SHADOW).
+//
+// Module ConsensusVersion is unchanged for action and supernode (purely
+// additive params with safe defaults). x/audit's v1→v2 migration is invoked by
+// RunMigrations and bumps KeepLastEpochEntries to cover new windows.
+//
+// Per-chain anchors:
+//   - Anchors LastDistributionHeight to the upgrade height so the first
+//     Everlight payout fires one PaymentPeriodBlocks after activation, not on
+//     the very next block.
+//   - Calls SupernodeKeeper.EnsureModuleAccount so the supernode ModuleAccount
+//     is materialised with its updated permissions (Minter+Burner+Staking).
 func CreateUpgradeHandler(p appParams.AppUpgradeParams) upgradetypes.UpgradeHandler {
 	return func(goCtx context.Context, _ upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		p.Logger.Info(fmt.Sprintf("Starting upgrade %s...", UpgradeName))
@@ -28,8 +63,8 @@ func CreateUpgradeHandler(p appParams.AppUpgradeParams) upgradetypes.UpgradeHand
 			return nil, err
 		}
 
-		// Run all module migrations after consensus params have been verified.
-		// This triggers Everlight's InitGenesis which sets default params.
+		// RunMigrations triggers x/audit v1→v2 migration (KeepLastEpochEntries
+		// floor) and any additive InitGenesis for unseen modules.
 		p.Logger.Info("Running module migrations...")
 		newVM, err := p.ModuleManager.RunMigrations(ctx, p.Configurator, fromVM)
 		if err != nil {
@@ -37,6 +72,75 @@ func CreateUpgradeHandler(p appParams.AppUpgradeParams) upgradetypes.UpgradeHand
 			return nil, fmt.Errorf("failed to run migrations: %w", err)
 		}
 		p.Logger.Info("Module migrations completed.")
+
+		// All four keepers are required by this handler. Fail loudly on any
+		// wiring regression rather than nil-deref mid-upgrade.
+		if p.ActionKeeper == nil {
+			return nil, fmt.Errorf("%s upgrade requires action keeper to be wired", UpgradeName)
+		}
+		if p.SupernodeKeeper == nil {
+			return nil, fmt.Errorf("%s upgrade requires supernode keeper to be wired", UpgradeName)
+		}
+		if p.AuditKeeper == nil {
+			return nil, fmt.Errorf("%s upgrade requires audit keeper to be wired", UpgradeName)
+		}
+
+		// 1) Persist LEP-5 action params defaults.
+		// keeper.GetParams() now applies WithDefaults() on read and SetParams
+		// applies it on write — calling SetParams here burns the canonical
+		// values into the on-disk blob so external param queries return them
+		// without waiting for the next governance write.
+		actionParams := p.ActionKeeper.GetParams(ctx)
+		if err := p.ActionKeeper.SetParams(ctx, actionParams); err != nil {
+			return nil, fmt.Errorf("persist action params with defaults: %w", err)
+		}
+		p.Logger.Info("Action params persisted with LEP-5 defaults",
+			"svc_challenge_count", actionParams.SvcChallengeCount,
+			"svc_min_chunks_for_challenge", actionParams.SvcMinChunksForChallenge,
+		)
+
+		// 2) Persist Everlight + LEP-4 supernode params defaults.
+		snParams := p.SupernodeKeeper.GetParams(ctx).WithDefaults()
+		if err := p.SupernodeKeeper.SetParams(ctx, snParams); err != nil {
+			return nil, fmt.Errorf("persist supernode params with defaults: %w", err)
+		}
+		if snParams.RewardDistribution != nil {
+			p.Logger.Info("Supernode reward distribution params persisted",
+				"payment_period_blocks", snParams.RewardDistribution.PaymentPeriodBlocks,
+				"registration_fee_share_bps", snParams.RewardDistribution.RegistrationFeeShareBps,
+				"min_cascade_bytes_for_payment", snParams.RewardDistribution.MinCascadeBytesForPayment,
+				"everlight_enabled", everlightEnabled,
+			)
+		}
+
+		// 3) Anchor Everlight distribution clock at upgrade height so the
+		// first payout fires one PaymentPeriodBlocks AFTER the upgrade, not on
+		// the next block. Without this, currentHeight - lastDistHeight (=0)
+		// >= PaymentPeriodBlocks on every chain past PaymentPeriod blocks tall,
+		// triggering an immediate post-upgrade distribution.
+		p.SupernodeKeeper.SetLastDistributionHeight(ctx, ctx.BlockHeight())
+		p.Logger.Info("Anchored Everlight last distribution height",
+			"height", ctx.BlockHeight(),
+		)
+
+		// 4) Materialise the supernode ModuleAccount so it carries the
+		// updated permissions (Minter+Burner+Staking) declared in app_config
+		// instead of a stale BaseAccount or pre-Everlight ModuleAccount entry.
+		p.SupernodeKeeper.EnsureModuleAccount(ctx)
+		p.Logger.Info("Ensured supernode ModuleAccount with updated permissions")
+
+		// 5) LEP-6 (audit) — burn explicit StorageTruth enforcement mode at
+		// activation. WithDefaults intentionally does NOT promote UNSPECIFIED
+		// to SHADOW, so we set it here explicitly. The audit v1→v2 migration
+		// already ran via RunMigrations and applied StorageTruth* defaults.
+		auditParams := p.AuditKeeper.GetParams(ctx)
+		auditParams.StorageTruthEnforcementMode = storageTruthEnforcementMode
+		if err := p.AuditKeeper.SetParams(ctx, auditParams); err != nil {
+			return nil, fmt.Errorf("set audit storage_truth_enforcement_mode: %w", err)
+		}
+		p.Logger.Info("Audit storage-truth enforcement mode set",
+			"mode", storageTruthEnforcementMode.String(),
+		)
 
 		p.Logger.Info(fmt.Sprintf("Successfully completed upgrade %s", UpgradeName))
 		return newVM, nil

--- a/app/upgrades/v1_12_0/upgrade.go
+++ b/app/upgrades/v1_12_0/upgrade.go
@@ -73,8 +73,8 @@ func CreateUpgradeHandler(p appParams.AppUpgradeParams) upgradetypes.UpgradeHand
 		}
 		p.Logger.Info("Module migrations completed.")
 
-		// All four keepers are required by this handler. Fail loudly on any
-		// wiring regression rather than nil-deref mid-upgrade.
+		// The action, supernode, and audit keepers are required by this handler.
+		// Fail loudly on any wiring regression rather than nil-deref mid-upgrade.
 		if p.ActionKeeper == nil {
 			return nil, fmt.Errorf("%s upgrade requires action keeper to be wired", UpgradeName)
 		}

--- a/app/upgrades/v1_12_0/upgrade_test.go
+++ b/app/upgrades/v1_12_0/upgrade_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	appParams "github.com/LumeraProtocol/lumera/app/upgrades/params"
+	audittypes "github.com/LumeraProtocol/lumera/x/audit/v1/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,4 +73,18 @@ func TestCreateUpgradeHandlerReturnsNonNil(t *testing.T) {
 	handler := CreateUpgradeHandler(appParams.AppUpgradeParams{})
 	require.NotNil(t, handler,
 		"CreateUpgradeHandler should return a non-nil upgrade handler function")
+}
+
+// ---------------------------------------------------------------------------
+// Activation policy constants — pin so future changes are intentional and
+// surface in code review.
+// ---------------------------------------------------------------------------
+
+func TestActivationPolicyConstants(t *testing.T) {
+	require.True(t, everlightEnabled,
+		"everlightEnabled must be true at activation; Everlight defaults are persisted")
+	require.Equal(t,
+		audittypes.StorageTruthEnforcementMode_STORAGE_TRUTH_ENFORCEMENT_MODE_SHADOW,
+		storageTruthEnforcementMode,
+		"LEP-6 enforcement mode at activation must be SHADOW")
 }

--- a/x/action/v1/keeper/params.go
+++ b/x/action/v1/keeper/params.go
@@ -17,12 +17,13 @@ func (k *Keeper) GetParams(ctx context.Context) (params types.Params) {
 	}
 
 	k.cdc.MustUnmarshal(bz, &params)
-	return params
+	return params.WithDefaults()
 }
 
 // SetParams set the params
 func (k *Keeper) SetParams(ctx context.Context, params types.Params) error {
 	store := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
+	params = params.WithDefaults()
 	bz, err := k.cdc.Marshal(&params)
 	if err != nil {
 		return err

--- a/x/action/v1/types/params.go
+++ b/x/action/v1/types/params.go
@@ -102,6 +102,25 @@ func DefaultParams() Params {
 	)
 }
 
+// WithDefaults returns a copy of the params with any zero-value fields populated
+// from module defaults. Older genesis blobs and on-chain params written before
+// new fields existed (e.g. LEP-5 SVC params) read back as zero; reading via
+// WithDefaults keeps behaviour consistent without requiring a ConsensusVersion
+// bump for purely additive params with safe defaults.
+//
+// Note: WithDefaults does NOT call Validate. Callers that want strict
+// 0-as-unset semantics (genesis init, MsgUpdateParams) should apply
+// WithDefaults() before Validate().
+func (p Params) WithDefaults() Params {
+	if p.SvcChallengeCount == 0 {
+		p.SvcChallengeCount = DefaultSVCChallengeCount
+	}
+	if p.SvcMinChunksForChallenge == 0 {
+		p.SvcMinChunksForChallenge = DefaultSVCMinChunksForChallenge
+	}
+	return p
+}
+
 // ParamSetPairs get the params.ParamSet
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{

--- a/x/action/v1/types/params_with_defaults_test.go
+++ b/x/action/v1/types/params_with_defaults_test.go
@@ -1,0 +1,34 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/LumeraProtocol/lumera/x/action/v1/types"
+)
+
+// TestParamsWithDefaults_FillsZeroSVCFields ensures that an older params blob
+// (read back as zero-valued SVC fields) is normalised by WithDefaults to the
+// LEP-5 defaults. This is the soft-compat path used by keeper.GetParams and
+// SetParams to avoid a ConsensusVersion bump for purely additive params.
+func TestParamsWithDefaults_FillsZeroSVCFields(t *testing.T) {
+	in := types.Params{} // zero values everywhere
+	out := in.WithDefaults()
+	require.Equal(t, types.DefaultSVCChallengeCount, out.SvcChallengeCount,
+		"WithDefaults must populate SvcChallengeCount when zero")
+	require.Equal(t, types.DefaultSVCMinChunksForChallenge, out.SvcMinChunksForChallenge,
+		"WithDefaults must populate SvcMinChunksForChallenge when zero")
+}
+
+// TestParamsWithDefaults_PreservesNonZero ensures explicit non-zero values are
+// not overwritten by WithDefaults.
+func TestParamsWithDefaults_PreservesNonZero(t *testing.T) {
+	in := types.Params{
+		SvcChallengeCount:        16,
+		SvcMinChunksForChallenge: 8,
+	}
+	out := in.WithDefaults()
+	require.Equal(t, uint32(16), out.SvcChallengeCount)
+	require.Equal(t, uint32(8), out.SvcMinChunksForChallenge)
+}

--- a/x/supernode/v1/mocks/expected_keepers_mock.go
+++ b/x/supernode/v1/mocks/expected_keepers_mock.go
@@ -20,10 +20,11 @@ import (
 	address "cosmossdk.io/core/address"
 	log "cosmossdk.io/log"
 	math "cosmossdk.io/math"
-	types "github.com/LumeraProtocol/lumera/x/supernode/v1/types"
-	types0 "github.com/cosmos/cosmos-sdk/types"
+	types "github.com/LumeraProtocol/lumera/x/audit/v1/types"
+	types0 "github.com/LumeraProtocol/lumera/x/supernode/v1/types"
+	types1 "github.com/cosmos/cosmos-sdk/types"
 	query "github.com/cosmos/cosmos-sdk/types/query"
-	types1 "github.com/cosmos/cosmos-sdk/x/staking/types"
+	types2 "github.com/cosmos/cosmos-sdk/x/staking/types"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -52,7 +53,7 @@ func (m *MockSupernodeKeeper) EXPECT() *MockSupernodeKeeperMockRecorder {
 }
 
 // CheckValidatorSupernodeEligibility mocks base method.
-func (m *MockSupernodeKeeper) CheckValidatorSupernodeEligibility(ctx types0.Context, validator types1.ValidatorI, valAddr, supernodeAccount string) error {
+func (m *MockSupernodeKeeper) CheckValidatorSupernodeEligibility(ctx types1.Context, validator types2.ValidatorI, valAddr, supernodeAccount string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckValidatorSupernodeEligibility", ctx, validator, valAddr, supernodeAccount)
 	ret0, _ := ret[0].(error)
@@ -65,15 +66,41 @@ func (mr *MockSupernodeKeeperMockRecorder) CheckValidatorSupernodeEligibility(ct
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckValidatorSupernodeEligibility", reflect.TypeOf((*MockSupernodeKeeper)(nil).CheckValidatorSupernodeEligibility), ctx, validator, valAddr, supernodeAccount)
 }
 
+// CountEligibleSNs mocks base method.
+func (m *MockSupernodeKeeper) CountEligibleSNs(ctx types1.Context) uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountEligibleSNs", ctx)
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// CountEligibleSNs indicates an expected call of CountEligibleSNs.
+func (mr *MockSupernodeKeeperMockRecorder) CountEligibleSNs(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountEligibleSNs", reflect.TypeOf((*MockSupernodeKeeper)(nil).CountEligibleSNs), ctx)
+}
+
+// EnsureModuleAccount mocks base method.
+func (m *MockSupernodeKeeper) EnsureModuleAccount(ctx types1.Context) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "EnsureModuleAccount", ctx)
+}
+
+// EnsureModuleAccount indicates an expected call of EnsureModuleAccount.
+func (mr *MockSupernodeKeeperMockRecorder) EnsureModuleAccount(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureModuleAccount", reflect.TypeOf((*MockSupernodeKeeper)(nil).EnsureModuleAccount), ctx)
+}
+
 // GetAllSuperNodes mocks base method.
-func (m *MockSupernodeKeeper) GetAllSuperNodes(ctx types0.Context, stateFilters ...types.SuperNodeState) ([]types.SuperNode, error) {
+func (m *MockSupernodeKeeper) GetAllSuperNodes(ctx types1.Context, stateFilters ...types0.SuperNodeState) ([]types0.SuperNode, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx}
 	for _, a := range stateFilters {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetAllSuperNodes", varargs...)
-	ret0, _ := ret[0].([]types.SuperNode)
+	ret0, _ := ret[0].([]types0.SuperNode)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -100,7 +127,7 @@ func (mr *MockSupernodeKeeperMockRecorder) GetAuthority() *gomock.Call {
 }
 
 // GetBlockHashForHeight mocks base method.
-func (m *MockSupernodeKeeper) GetBlockHashForHeight(ctx types0.Context, height int64) ([]byte, error) {
+func (m *MockSupernodeKeeper) GetBlockHashForHeight(ctx types1.Context, height int64) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockHashForHeight", ctx, height)
 	ret0, _ := ret[0].([]byte)
@@ -114,11 +141,41 @@ func (mr *MockSupernodeKeeperMockRecorder) GetBlockHashForHeight(ctx, height any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockHashForHeight", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetBlockHashForHeight), ctx, height)
 }
 
+// GetLastDistributionHeight mocks base method.
+func (m *MockSupernodeKeeper) GetLastDistributionHeight(ctx types1.Context) int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLastDistributionHeight", ctx)
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetLastDistributionHeight indicates an expected call of GetLastDistributionHeight.
+func (mr *MockSupernodeKeeperMockRecorder) GetLastDistributionHeight(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastDistributionHeight", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetLastDistributionHeight), ctx)
+}
+
+// GetLatestCascadeBytesForPayout mocks base method.
+func (m *MockSupernodeKeeper) GetLatestCascadeBytesForPayout(ctx types1.Context, supernodeAccount string) (float64, int64, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLatestCascadeBytesForPayout", ctx, supernodeAccount)
+	ret0, _ := ret[0].(float64)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
+}
+
+// GetLatestCascadeBytesForPayout indicates an expected call of GetLatestCascadeBytesForPayout.
+func (mr *MockSupernodeKeeperMockRecorder) GetLatestCascadeBytesForPayout(ctx, supernodeAccount any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestCascadeBytesForPayout", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetLatestCascadeBytesForPayout), ctx, supernodeAccount)
+}
+
 // GetMetricsState mocks base method.
-func (m *MockSupernodeKeeper) GetMetricsState(ctx types0.Context, valAddr types0.ValAddress) (types.SupernodeMetricsState, bool) {
+func (m *MockSupernodeKeeper) GetMetricsState(ctx types1.Context, valAddr types1.ValAddress) (types0.SupernodeMetricsState, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMetricsState", ctx, valAddr)
-	ret0, _ := ret[0].(types.SupernodeMetricsState)
+	ret0, _ := ret[0].(types0.SupernodeMetricsState)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -130,10 +187,10 @@ func (mr *MockSupernodeKeeperMockRecorder) GetMetricsState(ctx, valAddr any) *go
 }
 
 // GetParams mocks base method.
-func (m *MockSupernodeKeeper) GetParams(ctx types0.Context) types.Params {
+func (m *MockSupernodeKeeper) GetParams(ctx types1.Context) types0.Params {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParams", ctx)
-	ret0, _ := ret[0].(types.Params)
+	ret0, _ := ret[0].(types0.Params)
 	return ret0
 }
 
@@ -143,11 +200,54 @@ func (mr *MockSupernodeKeeperMockRecorder) GetParams(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParams", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetParams), ctx)
 }
 
+// GetPoolBalance mocks base method.
+func (m *MockSupernodeKeeper) GetPoolBalance(ctx types1.Context) types1.Coins {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPoolBalance", ctx)
+	ret0, _ := ret[0].(types1.Coins)
+	return ret0
+}
+
+// GetPoolBalance indicates an expected call of GetPoolBalance.
+func (mr *MockSupernodeKeeperMockRecorder) GetPoolBalance(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPoolBalance", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetPoolBalance), ctx)
+}
+
+// GetRegistrationFeeShareBps mocks base method.
+func (m *MockSupernodeKeeper) GetRegistrationFeeShareBps(ctx types1.Context) uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRegistrationFeeShareBps", ctx)
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// GetRegistrationFeeShareBps indicates an expected call of GetRegistrationFeeShareBps.
+func (mr *MockSupernodeKeeperMockRecorder) GetRegistrationFeeShareBps(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistrationFeeShareBps", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetRegistrationFeeShareBps), ctx)
+}
+
+// GetSNDistState mocks base method.
+func (m *MockSupernodeKeeper) GetSNDistState(ctx types1.Context, valAddr string) (types0.SNDistState, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSNDistState", ctx, valAddr)
+	ret0, _ := ret[0].(types0.SNDistState)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetSNDistState indicates an expected call of GetSNDistState.
+func (mr *MockSupernodeKeeperMockRecorder) GetSNDistState(ctx, valAddr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSNDistState", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetSNDistState), ctx, valAddr)
+}
+
 // GetStakingKeeper mocks base method.
-func (m *MockSupernodeKeeper) GetStakingKeeper() types.StakingKeeper {
+func (m *MockSupernodeKeeper) GetStakingKeeper() types0.StakingKeeper {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStakingKeeper")
-	ret0, _ := ret[0].(types.StakingKeeper)
+	ret0, _ := ret[0].(types0.StakingKeeper)
 	return ret0
 }
 
@@ -158,10 +258,10 @@ func (mr *MockSupernodeKeeperMockRecorder) GetStakingKeeper() *gomock.Call {
 }
 
 // GetSuperNodeByAccount mocks base method.
-func (m *MockSupernodeKeeper) GetSuperNodeByAccount(ctx types0.Context, supernodeAccount string) (types.SuperNode, bool, error) {
+func (m *MockSupernodeKeeper) GetSuperNodeByAccount(ctx types1.Context, supernodeAccount string) (types0.SuperNode, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSuperNodeByAccount", ctx, supernodeAccount)
-	ret0, _ := ret[0].(types.SuperNode)
+	ret0, _ := ret[0].(types0.SuperNode)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -174,14 +274,14 @@ func (mr *MockSupernodeKeeperMockRecorder) GetSuperNodeByAccount(ctx, supernodeA
 }
 
 // GetSuperNodesPaginated mocks base method.
-func (m *MockSupernodeKeeper) GetSuperNodesPaginated(ctx types0.Context, pagination *query.PageRequest, stateFilters ...types.SuperNodeState) ([]*types.SuperNode, *query.PageResponse, error) {
+func (m *MockSupernodeKeeper) GetSuperNodesPaginated(ctx types1.Context, pagination *query.PageRequest, stateFilters ...types0.SuperNodeState) ([]*types0.SuperNode, *query.PageResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{ctx, pagination}
 	for _, a := range stateFilters {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "GetSuperNodesPaginated", varargs...)
-	ret0, _ := ret[0].([]*types.SuperNode)
+	ret0, _ := ret[0].([]*types0.SuperNode)
 	ret1, _ := ret[1].(*query.PageResponse)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
@@ -194,8 +294,22 @@ func (mr *MockSupernodeKeeperMockRecorder) GetSuperNodesPaginated(ctx, paginatio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSuperNodesPaginated", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetSuperNodesPaginated), varargs...)
 }
 
+// GetTotalDistributed mocks base method.
+func (m *MockSupernodeKeeper) GetTotalDistributed(ctx types1.Context) types1.Coins {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTotalDistributed", ctx)
+	ret0, _ := ret[0].(types1.Coins)
+	return ret0
+}
+
+// GetTotalDistributed indicates an expected call of GetTotalDistributed.
+func (mr *MockSupernodeKeeperMockRecorder) GetTotalDistributed(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTotalDistributed", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetTotalDistributed), ctx)
+}
+
 // IsEligibleAndNotJailedValidator mocks base method.
-func (m *MockSupernodeKeeper) IsEligibleAndNotJailedValidator(ctx types0.Context, valAddr types0.ValAddress) bool {
+func (m *MockSupernodeKeeper) IsEligibleAndNotJailedValidator(ctx types1.Context, valAddr types1.ValAddress) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsEligibleAndNotJailedValidator", ctx, valAddr)
 	ret0, _ := ret[0].(bool)
@@ -209,7 +323,7 @@ func (mr *MockSupernodeKeeperMockRecorder) IsEligibleAndNotJailedValidator(ctx, 
 }
 
 // IsSuperNodeActive mocks base method.
-func (m *MockSupernodeKeeper) IsSuperNodeActive(ctx types0.Context, valAddr types0.ValAddress) bool {
+func (m *MockSupernodeKeeper) IsSuperNodeActive(ctx types1.Context, valAddr types1.ValAddress) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsSuperNodeActive", ctx, valAddr)
 	ret0, _ := ret[0].(bool)
@@ -237,10 +351,10 @@ func (mr *MockSupernodeKeeperMockRecorder) Logger() *gomock.Call {
 }
 
 // QuerySuperNode mocks base method.
-func (m *MockSupernodeKeeper) QuerySuperNode(ctx types0.Context, valOperAddr types0.ValAddress) (types.SuperNode, bool) {
+func (m *MockSupernodeKeeper) QuerySuperNode(ctx types1.Context, valOperAddr types1.ValAddress) (types0.SuperNode, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QuerySuperNode", ctx, valOperAddr)
-	ret0, _ := ret[0].(types.SuperNode)
+	ret0, _ := ret[0].(types0.SuperNode)
 	ret1, _ := ret[1].(bool)
 	return ret0, ret1
 }
@@ -252,10 +366,10 @@ func (mr *MockSupernodeKeeperMockRecorder) QuerySuperNode(ctx, valOperAddr any) 
 }
 
 // RankSuperNodesByDistance mocks base method.
-func (m *MockSupernodeKeeper) RankSuperNodesByDistance(blockHash []byte, supernodes []types.SuperNode, topN int) []types.SuperNode {
+func (m *MockSupernodeKeeper) RankSuperNodesByDistance(blockHash []byte, supernodes []types0.SuperNode, topN int) []types0.SuperNode {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RankSuperNodesByDistance", blockHash, supernodes, topN)
-	ret0, _ := ret[0].([]types.SuperNode)
+	ret0, _ := ret[0].([]types0.SuperNode)
 	return ret0
 }
 
@@ -265,8 +379,34 @@ func (mr *MockSupernodeKeeperMockRecorder) RankSuperNodesByDistance(blockHash, s
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RankSuperNodesByDistance", reflect.TypeOf((*MockSupernodeKeeper)(nil).RankSuperNodesByDistance), blockHash, supernodes, topN)
 }
 
+// RecoverSuperNodeFromPostponed mocks base method.
+func (m *MockSupernodeKeeper) RecoverSuperNodeFromPostponed(ctx types1.Context, valAddr types1.ValAddress) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecoverSuperNodeFromPostponed", ctx, valAddr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RecoverSuperNodeFromPostponed indicates an expected call of RecoverSuperNodeFromPostponed.
+func (mr *MockSupernodeKeeperMockRecorder) RecoverSuperNodeFromPostponed(ctx, valAddr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecoverSuperNodeFromPostponed", reflect.TypeOf((*MockSupernodeKeeper)(nil).RecoverSuperNodeFromPostponed), ctx, valAddr)
+}
+
+// SetLastDistributionHeight mocks base method.
+func (m *MockSupernodeKeeper) SetLastDistributionHeight(ctx types1.Context, height int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetLastDistributionHeight", ctx, height)
+}
+
+// SetLastDistributionHeight indicates an expected call of SetLastDistributionHeight.
+func (mr *MockSupernodeKeeperMockRecorder) SetLastDistributionHeight(ctx, height any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastDistributionHeight", reflect.TypeOf((*MockSupernodeKeeper)(nil).SetLastDistributionHeight), ctx, height)
+}
+
 // SetMetricsState mocks base method.
-func (m *MockSupernodeKeeper) SetMetricsState(ctx types0.Context, state types.SupernodeMetricsState) error {
+func (m *MockSupernodeKeeper) SetMetricsState(ctx types1.Context, state types0.SupernodeMetricsState) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetMetricsState", ctx, state)
 	ret0, _ := ret[0].(error)
@@ -280,7 +420,7 @@ func (mr *MockSupernodeKeeperMockRecorder) SetMetricsState(ctx, state any) *gomo
 }
 
 // SetParams mocks base method.
-func (m *MockSupernodeKeeper) SetParams(ctx types0.Context, params types.Params) error {
+func (m *MockSupernodeKeeper) SetParams(ctx types1.Context, params types0.Params) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetParams", ctx, params)
 	ret0, _ := ret[0].(error)
@@ -294,7 +434,7 @@ func (mr *MockSupernodeKeeperMockRecorder) SetParams(ctx, params any) *gomock.Ca
 }
 
 // SetSuperNode mocks base method.
-func (m *MockSupernodeKeeper) SetSuperNode(ctx types0.Context, supernode types.SuperNode) error {
+func (m *MockSupernodeKeeper) SetSuperNode(ctx types1.Context, supernode types0.SuperNode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetSuperNode", ctx, supernode)
 	ret0, _ := ret[0].(error)
@@ -308,7 +448,7 @@ func (mr *MockSupernodeKeeperMockRecorder) SetSuperNode(ctx, supernode any) *gom
 }
 
 // SetSuperNodeActive mocks base method.
-func (m *MockSupernodeKeeper) SetSuperNodeActive(ctx types0.Context, valAddr types0.ValAddress, reason string) error {
+func (m *MockSupernodeKeeper) SetSuperNodeActive(ctx types1.Context, valAddr types1.ValAddress, reason string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetSuperNodeActive", ctx, valAddr, reason)
 	ret0, _ := ret[0].(error)
@@ -322,7 +462,7 @@ func (mr *MockSupernodeKeeperMockRecorder) SetSuperNodeActive(ctx, valAddr, reas
 }
 
 // SetSuperNodePostponed mocks base method.
-func (m *MockSupernodeKeeper) SetSuperNodePostponed(ctx types0.Context, valAddr types0.ValAddress, reason string) error {
+func (m *MockSupernodeKeeper) SetSuperNodePostponed(ctx types1.Context, valAddr types1.ValAddress, reason string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetSuperNodePostponed", ctx, valAddr, reason)
 	ret0, _ := ret[0].(error)
@@ -335,22 +475,8 @@ func (mr *MockSupernodeKeeperMockRecorder) SetSuperNodePostponed(ctx, valAddr, r
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSuperNodePostponed", reflect.TypeOf((*MockSupernodeKeeper)(nil).SetSuperNodePostponed), ctx, valAddr, reason)
 }
 
-// RecoverSuperNodeFromPostponed mocks base method.
-func (m *MockSupernodeKeeper) RecoverSuperNodeFromPostponed(ctx types0.Context, valAddr types0.ValAddress) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecoverSuperNodeFromPostponed", ctx, valAddr)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RecoverSuperNodeFromPostponed indicates an expected call of RecoverSuperNodeFromPostponed.
-func (mr *MockSupernodeKeeperMockRecorder) RecoverSuperNodeFromPostponed(ctx, valAddr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecoverSuperNodeFromPostponed", reflect.TypeOf((*MockSupernodeKeeper)(nil).RecoverSuperNodeFromPostponed), ctx, valAddr)
-}
-
 // SetSuperNodeStopped mocks base method.
-func (m *MockSupernodeKeeper) SetSuperNodeStopped(ctx types0.Context, valAddr types0.ValAddress, reason string) error {
+func (m *MockSupernodeKeeper) SetSuperNodeStopped(ctx types1.Context, valAddr types1.ValAddress, reason string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetSuperNodeStopped", ctx, valAddr, reason)
 	ret0, _ := ret[0].(error)
@@ -402,10 +528,10 @@ func (mr *MockStakingKeeperMockRecorder) ConsensusAddressCodec() *gomock.Call {
 }
 
 // Delegation mocks base method.
-func (m *MockStakingKeeper) Delegation(ctx context.Context, delAddr types0.AccAddress, valAddr types0.ValAddress) (types1.DelegationI, error) {
+func (m *MockStakingKeeper) Delegation(ctx context.Context, delAddr types1.AccAddress, valAddr types1.ValAddress) (types2.DelegationI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delegation", ctx, delAddr, valAddr)
-	ret0, _ := ret[0].(types1.DelegationI)
+	ret0, _ := ret[0].(types2.DelegationI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -417,10 +543,10 @@ func (mr *MockStakingKeeperMockRecorder) Delegation(ctx, delAddr, valAddr any) *
 }
 
 // Validator mocks base method.
-func (m *MockStakingKeeper) Validator(arg0 context.Context, arg1 types0.ValAddress) (types1.ValidatorI, error) {
+func (m *MockStakingKeeper) Validator(arg0 context.Context, arg1 types1.ValAddress) (types2.ValidatorI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validator", arg0, arg1)
-	ret0, _ := ret[0].(types1.ValidatorI)
+	ret0, _ := ret[0].(types2.ValidatorI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -432,10 +558,10 @@ func (mr *MockStakingKeeperMockRecorder) Validator(arg0, arg1 any) *gomock.Call 
 }
 
 // ValidatorByConsAddr mocks base method.
-func (m *MockStakingKeeper) ValidatorByConsAddr(arg0 context.Context, arg1 types0.ConsAddress) (types1.ValidatorI, error) {
+func (m *MockStakingKeeper) ValidatorByConsAddr(arg0 context.Context, arg1 types1.ConsAddress) (types2.ValidatorI, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidatorByConsAddr", arg0, arg1)
-	ret0, _ := ret[0].(types1.ValidatorI)
+	ret0, _ := ret[0].(types2.ValidatorI)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -444,6 +570,62 @@ func (m *MockStakingKeeper) ValidatorByConsAddr(arg0 context.Context, arg1 types
 func (mr *MockStakingKeeperMockRecorder) ValidatorByConsAddr(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidatorByConsAddr", reflect.TypeOf((*MockStakingKeeper)(nil).ValidatorByConsAddr), arg0, arg1)
+}
+
+// MockAuditKeeper is a mock of AuditKeeper interface.
+type MockAuditKeeper struct {
+	ctrl     *gomock.Controller
+	recorder *MockAuditKeeperMockRecorder
+	isgomock struct{}
+}
+
+// MockAuditKeeperMockRecorder is the mock recorder for MockAuditKeeper.
+type MockAuditKeeperMockRecorder struct {
+	mock *MockAuditKeeper
+}
+
+// NewMockAuditKeeper creates a new mock instance.
+func NewMockAuditKeeper(ctrl *gomock.Controller) *MockAuditKeeper {
+	mock := &MockAuditKeeper{ctrl: ctrl}
+	mock.recorder = &MockAuditKeeperMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAuditKeeper) EXPECT() *MockAuditKeeperMockRecorder {
+	return m.recorder
+}
+
+// GetCurrentEpochInfo mocks base method.
+func (m *MockAuditKeeper) GetCurrentEpochInfo(ctx types1.Context) (uint64, int64, int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentEpochInfo", ctx)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(int64)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// GetCurrentEpochInfo indicates an expected call of GetCurrentEpochInfo.
+func (mr *MockAuditKeeperMockRecorder) GetCurrentEpochInfo(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentEpochInfo", reflect.TypeOf((*MockAuditKeeper)(nil).GetCurrentEpochInfo), ctx)
+}
+
+// GetReport mocks base method.
+func (m *MockAuditKeeper) GetReport(ctx types1.Context, epochID uint64, reporterSupernodeAccount string) (types.EpochReport, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReport", ctx, epochID, reporterSupernodeAccount)
+	ret0, _ := ret[0].(types.EpochReport)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetReport indicates an expected call of GetReport.
+func (mr *MockAuditKeeperMockRecorder) GetReport(ctx, epochID, reporterSupernodeAccount any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReport", reflect.TypeOf((*MockAuditKeeper)(nil).GetReport), ctx, epochID, reporterSupernodeAccount)
 }
 
 // MockSlashingKeeper is a mock of SlashingKeeper interface.
@@ -471,7 +653,7 @@ func (m *MockSlashingKeeper) EXPECT() *MockSlashingKeeperMockRecorder {
 }
 
 // IsTombstoned mocks base method.
-func (m *MockSlashingKeeper) IsTombstoned(arg0 context.Context, arg1 types0.ConsAddress) bool {
+func (m *MockSlashingKeeper) IsTombstoned(arg0 context.Context, arg1 types1.ConsAddress) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsTombstoned", arg0, arg1)
 	ret0, _ := ret[0].(bool)
@@ -485,7 +667,7 @@ func (mr *MockSlashingKeeperMockRecorder) IsTombstoned(arg0, arg1 any) *gomock.C
 }
 
 // Jail mocks base method.
-func (m *MockSlashingKeeper) Jail(arg0 context.Context, arg1 types0.ConsAddress) error {
+func (m *MockSlashingKeeper) Jail(arg0 context.Context, arg1 types1.ConsAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Jail", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -499,7 +681,7 @@ func (mr *MockSlashingKeeperMockRecorder) Jail(arg0, arg1 any) *gomock.Call {
 }
 
 // JailUntil mocks base method.
-func (m *MockSlashingKeeper) JailUntil(arg0 context.Context, arg1 types0.ConsAddress, arg2 time.Time) error {
+func (m *MockSlashingKeeper) JailUntil(arg0 context.Context, arg1 types1.ConsAddress, arg2 time.Time) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "JailUntil", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -513,7 +695,7 @@ func (mr *MockSlashingKeeperMockRecorder) JailUntil(arg0, arg1, arg2 any) *gomoc
 }
 
 // Slash mocks base method.
-func (m *MockSlashingKeeper) Slash(ctx context.Context, consAddr types0.ConsAddress, fraction math.LegacyDec, power, distributionHeight int64) error {
+func (m *MockSlashingKeeper) Slash(ctx context.Context, consAddr types1.ConsAddress, fraction math.LegacyDec, power, distributionHeight int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Slash", ctx, consAddr, fraction, power, distributionHeight)
 	ret0, _ := ret[0].(error)
@@ -551,10 +733,10 @@ func (m *MockAccountKeeper) EXPECT() *MockAccountKeeperMockRecorder {
 }
 
 // GetAccount mocks base method.
-func (m *MockAccountKeeper) GetAccount(arg0 context.Context, arg1 types0.AccAddress) types0.AccountI {
+func (m *MockAccountKeeper) GetAccount(arg0 context.Context, arg1 types1.AccAddress) types1.AccountI {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAccount", arg0, arg1)
-	ret0, _ := ret[0].(types0.AccountI)
+	ret0, _ := ret[0].(types1.AccountI)
 	return ret0
 }
 
@@ -562,6 +744,34 @@ func (m *MockAccountKeeper) GetAccount(arg0 context.Context, arg1 types0.AccAddr
 func (mr *MockAccountKeeperMockRecorder) GetAccount(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccount", reflect.TypeOf((*MockAccountKeeper)(nil).GetAccount), arg0, arg1)
+}
+
+// GetModuleAccount mocks base method.
+func (m *MockAccountKeeper) GetModuleAccount(ctx context.Context, moduleName string) types1.ModuleAccountI {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModuleAccount", ctx, moduleName)
+	ret0, _ := ret[0].(types1.ModuleAccountI)
+	return ret0
+}
+
+// GetModuleAccount indicates an expected call of GetModuleAccount.
+func (mr *MockAccountKeeperMockRecorder) GetModuleAccount(ctx, moduleName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleAccount", reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAccount), ctx, moduleName)
+}
+
+// GetModuleAddress mocks base method.
+func (m *MockAccountKeeper) GetModuleAddress(moduleName string) types1.AccAddress {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModuleAddress", moduleName)
+	ret0, _ := ret[0].(types1.AccAddress)
+	return ret0
+}
+
+// GetModuleAddress indicates an expected call of GetModuleAddress.
+func (mr *MockAccountKeeperMockRecorder) GetModuleAddress(moduleName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleAddress", reflect.TypeOf((*MockAccountKeeper)(nil).GetModuleAddress), moduleName)
 }
 
 // MockBankKeeper is a mock of BankKeeper interface.
@@ -588,25 +798,11 @@ func (m *MockBankKeeper) EXPECT() *MockBankKeeperMockRecorder {
 	return m.recorder
 }
 
-// GetBalance mocks base method.
-func (m *MockBankKeeper) GetBalance(ctx context.Context, addr types0.AccAddress, denom string) types0.Coin {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBalance", ctx, addr, denom)
-	ret0, _ := ret[0].(types0.Coin)
-	return ret0
-}
-
-// GetBalance indicates an expected call of GetBalance.
-func (mr *MockBankKeeperMockRecorder) GetBalance(ctx, addr, denom any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MockBankKeeper)(nil).GetBalance), ctx, addr, denom)
-}
-
 // GetAllBalances mocks base method.
-func (m *MockBankKeeper) GetAllBalances(ctx context.Context, addr types0.AccAddress) types0.Coins {
+func (m *MockBankKeeper) GetAllBalances(ctx context.Context, addr types1.AccAddress) types1.Coins {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllBalances", ctx, addr)
-	ret0, _ := ret[0].(types0.Coins)
+	ret0, _ := ret[0].(types1.Coins)
 	return ret0
 }
 
@@ -616,8 +812,22 @@ func (mr *MockBankKeeperMockRecorder) GetAllBalances(ctx, addr any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllBalances", reflect.TypeOf((*MockBankKeeper)(nil).GetAllBalances), ctx, addr)
 }
 
+// GetBalance mocks base method.
+func (m *MockBankKeeper) GetBalance(ctx context.Context, addr types1.AccAddress, denom string) types1.Coin {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBalance", ctx, addr, denom)
+	ret0, _ := ret[0].(types1.Coin)
+	return ret0
+}
+
+// GetBalance indicates an expected call of GetBalance.
+func (mr *MockBankKeeperMockRecorder) GetBalance(ctx, addr, denom any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBalance", reflect.TypeOf((*MockBankKeeper)(nil).GetBalance), ctx, addr, denom)
+}
+
 // SendCoinsFromModuleToAccount mocks base method.
-func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr types0.AccAddress, amt types0.Coins) error {
+func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr types1.AccAddress, amt types1.Coins) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendCoinsFromModuleToAccount", ctx, senderModule, recipientAddr, amt)
 	ret0, _ := ret[0].(error)
@@ -631,10 +841,10 @@ func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToAccount(ctx, senderMo
 }
 
 // SpendableCoins mocks base method.
-func (m *MockBankKeeper) SpendableCoins(arg0 context.Context, arg1 types0.AccAddress) types0.Coins {
+func (m *MockBankKeeper) SpendableCoins(arg0 context.Context, arg1 types1.AccAddress) types1.Coins {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SpendableCoins", arg0, arg1)
-	ret0, _ := ret[0].(types0.Coins)
+	ret0, _ := ret[0].(types1.Coins)
 	return ret0
 }
 
@@ -669,7 +879,7 @@ func (m *MockStakingHooks) EXPECT() *MockStakingHooksMockRecorder {
 }
 
 // AfterDelegationModified mocks base method.
-func (m *MockStakingHooks) AfterDelegationModified(ctx context.Context, delAddr types0.AccAddress, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) AfterDelegationModified(ctx context.Context, delAddr types1.AccAddress, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AfterDelegationModified", ctx, delAddr, valAddr)
 	ret0, _ := ret[0].(error)
@@ -683,7 +893,7 @@ func (mr *MockStakingHooksMockRecorder) AfterDelegationModified(ctx, delAddr, va
 }
 
 // AfterValidatorBeginUnbonding mocks base method.
-func (m *MockStakingHooks) AfterValidatorBeginUnbonding(ctx context.Context, consAddr types0.ConsAddress, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) AfterValidatorBeginUnbonding(ctx context.Context, consAddr types1.ConsAddress, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AfterValidatorBeginUnbonding", ctx, consAddr, valAddr)
 	ret0, _ := ret[0].(error)
@@ -697,7 +907,7 @@ func (mr *MockStakingHooksMockRecorder) AfterValidatorBeginUnbonding(ctx, consAd
 }
 
 // AfterValidatorBonded mocks base method.
-func (m *MockStakingHooks) AfterValidatorBonded(ctx context.Context, consAddr types0.ConsAddress, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) AfterValidatorBonded(ctx context.Context, consAddr types1.ConsAddress, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AfterValidatorBonded", ctx, consAddr, valAddr)
 	ret0, _ := ret[0].(error)
@@ -711,7 +921,7 @@ func (mr *MockStakingHooksMockRecorder) AfterValidatorBonded(ctx, consAddr, valA
 }
 
 // AfterValidatorCreated mocks base method.
-func (m *MockStakingHooks) AfterValidatorCreated(ctx context.Context, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) AfterValidatorCreated(ctx context.Context, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AfterValidatorCreated", ctx, valAddr)
 	ret0, _ := ret[0].(error)
@@ -725,7 +935,7 @@ func (mr *MockStakingHooksMockRecorder) AfterValidatorCreated(ctx, valAddr any) 
 }
 
 // AfterValidatorRemoved mocks base method.
-func (m *MockStakingHooks) AfterValidatorRemoved(ctx context.Context, consAddr types0.ConsAddress, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) AfterValidatorRemoved(ctx context.Context, consAddr types1.ConsAddress, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AfterValidatorRemoved", ctx, consAddr, valAddr)
 	ret0, _ := ret[0].(error)
@@ -739,7 +949,7 @@ func (mr *MockStakingHooksMockRecorder) AfterValidatorRemoved(ctx, consAddr, val
 }
 
 // BeforeDelegationCreated mocks base method.
-func (m *MockStakingHooks) BeforeDelegationCreated(ctx context.Context, delAddr types0.AccAddress, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) BeforeDelegationCreated(ctx context.Context, delAddr types1.AccAddress, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeforeDelegationCreated", ctx, delAddr, valAddr)
 	ret0, _ := ret[0].(error)
@@ -753,7 +963,7 @@ func (mr *MockStakingHooksMockRecorder) BeforeDelegationCreated(ctx, delAddr, va
 }
 
 // BeforeDelegationRemoved mocks base method.
-func (m *MockStakingHooks) BeforeDelegationRemoved(ctx context.Context, delAddr types0.AccAddress, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) BeforeDelegationRemoved(ctx context.Context, delAddr types1.AccAddress, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeforeDelegationRemoved", ctx, delAddr, valAddr)
 	ret0, _ := ret[0].(error)
@@ -767,7 +977,7 @@ func (mr *MockStakingHooksMockRecorder) BeforeDelegationRemoved(ctx, delAddr, va
 }
 
 // BeforeDelegationSharesModified mocks base method.
-func (m *MockStakingHooks) BeforeDelegationSharesModified(ctx context.Context, delAddr types0.AccAddress, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) BeforeDelegationSharesModified(ctx context.Context, delAddr types1.AccAddress, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeforeDelegationSharesModified", ctx, delAddr, valAddr)
 	ret0, _ := ret[0].(error)
@@ -781,7 +991,7 @@ func (mr *MockStakingHooksMockRecorder) BeforeDelegationSharesModified(ctx, delA
 }
 
 // BeforeValidatorModified mocks base method.
-func (m *MockStakingHooks) BeforeValidatorModified(ctx context.Context, valAddr types0.ValAddress) error {
+func (m *MockStakingHooks) BeforeValidatorModified(ctx context.Context, valAddr types1.ValAddress) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeforeValidatorModified", ctx, valAddr)
 	ret0, _ := ret[0].(error)
@@ -795,7 +1005,7 @@ func (mr *MockStakingHooksMockRecorder) BeforeValidatorModified(ctx, valAddr any
 }
 
 // BeforeValidatorSlashed mocks base method.
-func (m *MockStakingHooks) BeforeValidatorSlashed(ctx context.Context, valAddr types0.ValAddress, fraction math.LegacyDec) error {
+func (m *MockStakingHooks) BeforeValidatorSlashed(ctx context.Context, valAddr types1.ValAddress, fraction math.LegacyDec) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BeforeValidatorSlashed", ctx, valAddr, fraction)
 	ret0, _ := ret[0].(error)
@@ -806,117 +1016,4 @@ func (m *MockStakingHooks) BeforeValidatorSlashed(ctx context.Context, valAddr t
 func (mr *MockStakingHooksMockRecorder) BeforeValidatorSlashed(ctx, valAddr, fraction any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeforeValidatorSlashed", reflect.TypeOf((*MockStakingHooks)(nil).BeforeValidatorSlashed), ctx, valAddr, fraction)
-}
-
-// CountEligibleSNs mocks base method.
-func (m *MockSupernodeKeeper) CountEligibleSNs(ctx types0.Context) uint64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountEligibleSNs", ctx)
-	ret0, _ := ret[0].(uint64)
-	return ret0
-}
-
-// CountEligibleSNs indicates an expected call of CountEligibleSNs.
-func (mr *MockSupernodeKeeperMockRecorder) CountEligibleSNs(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountEligibleSNs", reflect.TypeOf((*MockSupernodeKeeper)(nil).CountEligibleSNs), ctx)
-}
-
-// GetLastDistributionHeight mocks base method.
-func (m *MockSupernodeKeeper) GetLastDistributionHeight(ctx types0.Context) int64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLastDistributionHeight", ctx)
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-// GetLastDistributionHeight indicates an expected call of GetLastDistributionHeight.
-func (mr *MockSupernodeKeeperMockRecorder) GetLastDistributionHeight(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastDistributionHeight", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetLastDistributionHeight), ctx)
-}
-
-// GetLatestCascadeBytesForPayout mocks base method.
-func (m *MockSupernodeKeeper) GetLatestCascadeBytesForPayout(ctx types0.Context, supernodeAccount string) (float64, int64, bool) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLatestCascadeBytesForPayout", ctx, supernodeAccount)
-	ret0, _ := ret[0].(float64)
-	ret1, _ := ret[1].(int64)
-	ret2, _ := ret[2].(bool)
-	return ret0, ret1, ret2
-}
-
-// GetLatestCascadeBytesForPayout indicates an expected call of GetLatestCascadeBytesForPayout.
-func (mr *MockSupernodeKeeperMockRecorder) GetLatestCascadeBytesForPayout(ctx, supernodeAccount any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestCascadeBytesForPayout", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetLatestCascadeBytesForPayout), ctx, supernodeAccount)
-}
-
-// GetPoolBalance mocks base method.
-func (m *MockSupernodeKeeper) GetPoolBalance(ctx types0.Context) types0.Coins {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPoolBalance", ctx)
-	ret0, _ := ret[0].(types0.Coins)
-	return ret0
-}
-
-// GetPoolBalance indicates an expected call of GetPoolBalance.
-func (mr *MockSupernodeKeeperMockRecorder) GetPoolBalance(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPoolBalance", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetPoolBalance), ctx)
-}
-
-// GetTotalDistributed mocks base method.
-func (m *MockSupernodeKeeper) GetTotalDistributed(ctx types0.Context) types0.Coins {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTotalDistributed", ctx)
-	ret0, _ := ret[0].(types0.Coins)
-	return ret0
-}
-
-// GetTotalDistributed indicates an expected call of GetTotalDistributed.
-func (mr *MockSupernodeKeeperMockRecorder) GetTotalDistributed(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTotalDistributed", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetTotalDistributed), ctx)
-}
-
-// GetSNDistState mocks base method.
-func (m *MockSupernodeKeeper) GetSNDistState(ctx types0.Context, valAddr string) (types.SNDistState, bool) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSNDistState", ctx, valAddr)
-	ret0, _ := ret[0].(types.SNDistState)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
-}
-
-// GetSNDistState indicates an expected call of GetSNDistState.
-func (mr *MockSupernodeKeeperMockRecorder) GetSNDistState(ctx, valAddr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSNDistState", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetSNDistState), ctx, valAddr)
-}
-
-// GetRegistrationFeeShareBps mocks base method.
-func (m *MockSupernodeKeeper) GetRegistrationFeeShareBps(ctx types0.Context) uint64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRegistrationFeeShareBps", ctx)
-	ret0, _ := ret[0].(uint64)
-	return ret0
-}
-
-// GetRegistrationFeeShareBps indicates an expected call of GetRegistrationFeeShareBps.
-func (mr *MockSupernodeKeeperMockRecorder) GetRegistrationFeeShareBps(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRegistrationFeeShareBps", reflect.TypeOf((*MockSupernodeKeeper)(nil).GetRegistrationFeeShareBps), ctx)
-}
-
-// SetLastDistributionHeight mocks base method.
-func (m *MockSupernodeKeeper) SetLastDistributionHeight(ctx types0.Context, height int64) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetLastDistributionHeight", ctx, height)
-}
-
-// SetLastDistributionHeight indicates an expected call of SetLastDistributionHeight.
-func (mr *MockSupernodeKeeperMockRecorder) SetLastDistributionHeight(ctx, height any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLastDistributionHeight", reflect.TypeOf((*MockSupernodeKeeper)(nil).SetLastDistributionHeight), ctx, height)
 }

--- a/x/supernode/v1/types/expected_keepers.go
+++ b/x/supernode/v1/types/expected_keepers.go
@@ -49,6 +49,7 @@ type SupernodeKeeper interface {
 	GetRegistrationFeeShareBps(ctx sdk.Context) uint64
 	CountEligibleSNs(ctx sdk.Context) uint64
 	GetLatestCascadeBytesForPayout(ctx sdk.Context, supernodeAccount string) (float64, int64, bool)
+	EnsureModuleAccount(ctx sdk.Context)
 }
 
 // StakingKeeper defines the expected interface for the Staking module.


### PR DESCRIPTION
## What & Why

The v1.12.0 upgrade handler previously ran module migrations only. Several PRs merged after `v1.11.1-hotfix` introduced new params and per-chain anchors that were **not persisted at activation**:

| PR | Module | What landed | Persisted by old handler? |
|---|---|---|---|
| #103 (LEP-5) | `x/action` | `SvcChallengeCount`, `SvcMinChunksForChallenge` | ❌ blob keeps zero values |
| #113 (Everlight + LEP-4) | `x/supernode` | `RewardDistribution{...}`, full LEP-4 metrics block, new state keys (`LastDistributionHeight`, `TotalDistributed`, `SNDistState`), module-account perms now `Minter+Burner+Staking` | ❌ blob zeros; clock not anchored; perms stale |
| #117 (LEP-6) | `x/audit` | `StorageTruth*` params block; ConsensusVersion 1→2 with registered migration | ✅ migration covers `KeepLastEpochEntries`; ❌ enforcement mode not explicitly burned |

Symptoms without this PR:
- `lumerad q action params` and `lumerad q supernode params` return zeros on the new fields until next governance write.
- **Everlight first payout fires on the block immediately after the upgrade height** because `lastDistHeight=0` and `currentHeight - 0 ≥ PaymentPeriodBlocks` for any chain past 100,800 blocks — almost certainly not the intended activation policy.
- Supernode ModuleAccount may persist with pre-Everlight perms until first interaction.
- LEP-6 enforcement mode would rely on `WithDefaults` promotion, which intentionally does NOT promote `UNSPECIFIED` to `SHADOW`.

## Changes

### `app/upgrades/v1_12_0/upgrade.go` — completed handler
1. `consensusparams.EnsurePresent` (defensive, matches v1.10.1/v1.11.x pattern).
2. `RunMigrations` (audit v1→v2 fires here; bumps `KeepLastEpochEntries` floor).
3. `ActionKeeper.SetParams(ctx, ActionKeeper.GetParams(ctx))` — burns LEP-5 defaults to disk via the new `WithDefaults` path.
4. `SupernodeKeeper.SetParams(ctx, GetParams(ctx).WithDefaults())` — burns Everlight + LEP-4 defaults.
5. `SupernodeKeeper.SetLastDistributionHeight(ctx, ctx.BlockHeight())` — anchors Everlight clock at upgrade height. **First payout fires one `PaymentPeriodBlocks` after upgrade**, not on the next block.
6. `SupernodeKeeper.EnsureModuleAccount(ctx)` — refreshes ModuleAccount with `Minter+Burner+Staking` perms.
7. Burns `audit.StorageTruthEnforcementMode = SHADOW` explicitly (matches v1.11.0's `auditScEnabled = true` precedent).

Activation-policy constants (with regression tests pinning them):
```go
const everlightEnabled = true
const storageTruthEnforcementMode = audittypes.StorageTruthEnforcementMode_STORAGE_TRUTH_ENFORCEMENT_MODE_SHADOW
```

### `x/action/v1/types/params.go` and `keeper/params.go`
- Adds `Params.WithDefaults()` (sibling-asymmetry fix — supernode and audit already had this since v1.11.x).
- `keeper.GetParams` applies `WithDefaults()` on read; `keeper.SetParams` on write.
- Direct callers reading `Params.SvcChallengeCount` no longer see `0` post-upgrade. (Previously masked by the ad-hoc fallback in `keeper.GetSVCParams`.)

### `x/supernode/v1/types/expected_keepers.go` (+ regenerated mock)
- Adds `EnsureModuleAccount(ctx sdk.Context)` to the `SupernodeKeeper` interface so the upgrade handler can call it through `appParams.AppUpgradeParams.SupernodeKeeper`.
- `go generate` re-ran cleanly on `expected_keepers_mock.go`.

## What is intentionally NOT done

- **No `ConsensusVersion` bump** for action or supernode. Both modules' changes are purely additive params with safe zero-default semantics; bumping would force a near-empty per-module migration with the same effect as the in-handler `SetParams`. Lumera precedent (this PR's behaviour) follows v1.11.1's audit `min_disk_free_percent` floor pattern.
- **No additional InitGenesis call** for any module. Audit v1→v2 migration already covers everything; supernode/action InitGenesis already ran on v1.11.x.
- **No new `StoreUpgrades.Added/Deleted`**: Everlight uses the existing `supernode` store; LEP-6 uses the existing `audit` store.

## Risks

| Risk | Mitigation |
|---|---|
| `SetParams` on a module already at correct values is a wasted write | Idempotent; tiny gas; happens once per upgrade |
| Anchoring `lastDistHeight = upgradeHeight` delays first payout | This is the **intended** activation behaviour per discussion |
| `EnsureModuleAccount` no-ops if account already correct | Safe by design (matches InitGenesis usage in PR #113) |
| `WithDefaults` on action params changes runtime semantics for callers reading `Params` directly | Defaults match what `keeper.GetSVCParams` already returned via fallback; verified all `SvcChallengeCount` / `SvcMinChunksForChallenge` consumers |

## Rollback

Revert this commit and `lumerad rollback`. No store schema change, no migration replay required.

## Tests

- `app/upgrades/v1_12_0/upgrade_test.go` — pins activation constants (`everlightEnabled`, enforcement mode) plus existing semver / store-safety / handler-non-nil tests.
- `x/action/v1/types/params_with_defaults_test.go` — new: `WithDefaults` fills zero SVC fields and preserves non-zero values.
- `go build ./...` ✅
- `go vet ./...` ✅
- All unit tests in `app/upgrades/...`, `x/action/...`, `x/supernode/...`, `x/audit/...` ✅
- All `tests/integration/{action,audit,bank,everlight,gov,staking,supernode,wasm}` and `tests/system/{action,audit,supernode,wasm}` ✅

## Devnet rehearsal

Recommend a `lumera-upgrade-rehearsal` run `v1.11.1 → v1.12.0` and `v1.10.1 → v1.12.0` before mainnet — the handler is keeper-heavy and the existing `app/upgrades/upgrades_test.go::TestSetupUpgradesAndHandlers` smoke test cannot exercise it (skipped, same as v1.11.0/v1.11.1).
