### PR TITLE
chore(devnet): add upgrade rehearsal targets v1.11.0/v1.11.1/v1.12.0 (cherry-pick of #133)

### DIFF
--- a/Makefile.devnet
+++ b/Makefile.devnet
@@ -300,7 +300,7 @@ devnet-update-scripts:
 		echo "No containers were updated. Ensure the devnet is running."; \
 	fi
 
-.PHONY: devnet-new-172 devnet-new-191 devnet-upgrade-180 devnet-upgrade-191 devnet-upgrade-1100 devnet-upgrade-1101
+.PHONY: devnet-new-172 devnet-new-191 devnet-upgrade-180 devnet-upgrade-191 devnet-upgrade-1100 devnet-upgrade-1101 devnet-upgrade-1110 devnet-upgrade-1111 devnet-upgrade-1120
 
 devnet-upgrade-180:
 	@cd devnet/scripts && ./upgrade.sh v1.8.0 auto-height ../bin-v1.8.0
@@ -312,7 +312,16 @@ devnet-upgrade-1100:
 	@cd devnet/scripts && ./upgrade.sh v1.10.0 auto-height ../bin-v1.10.0
 
 devnet-upgrade-1101:
-	@cd devnet/scripts && ./upgrade.sh v1.10.1 auto-height ../bin
+	@cd devnet/scripts && ./upgrade.sh v1.10.1 auto-height ../bin-v1.10.1
+
+devnet-upgrade-1110:
+	@cd devnet/scripts && ./upgrade.sh v1.11.0 auto-height ../bin-v1.11.0
+
+devnet-upgrade-1111:
+	@cd devnet/scripts && ./upgrade.sh v1.11.1 auto-height ../bin-v1.11.1
+
+devnet-upgrade-1120:
+	@cd devnet/scripts && ./upgrade.sh v1.12.0 auto-height ../bin-v1.12.0
 
 devnet-new-172:
 	$(MAKE) devnet-down


### PR DESCRIPTION
Cherry-pick of #133 (master commit `be1212c9` / squash `59eaf74e`) onto the `1.12.0` release branch.

## Behavior change

Adds three `Makefile.devnet` targets matching the existing per-version pattern (this branch still uses the pre-#108 explicit-target convention, so the original commit applies cleanly):

```
devnet-upgrade-1110  → ./upgrade.sh v1.11.0 auto-height ../bin-v1.11.0
devnet-upgrade-1111  → ./upgrade.sh v1.11.1 auto-height ../bin-v1.11.1
devnet-upgrade-1120  → ./upgrade.sh v1.12.0 auto-height ../bin-v1.12.0
```

Also normalizes `devnet-upgrade-1101` from `../bin` → `../bin-v1.10.1` to match the per-version convention used by every other target.

## Why backport

Every devnet rehearsal must have a local devnet target. Upgrade handlers `app/upgrades/v1_11_0`, `v1_11_1`, `v1_12_0` all exist on `1.12.0` — verified — but the corresponding rehearsal targets did not, which is the exact gap #133 closed on master.

## Cherry-pick mechanics

- Clean cherry-pick (`git cherry-pick be1212c9`), single Makefile.devnet auto-merge, no conflicts.
- Final diff vs `origin/1.12.0`: 1 file, +11/-2 — byte-identical to original #133 commit on master.
- Note: this is the **pre-rebase** form of #133, because `1.12.0` predates #108 (Cosmos EVM Integration) which refactored the rehearsal targets into a parameterized `devnet-upgrade-version VERSION=…` framework on master. The explicit-target shape here is correct for this branch.

## Local rehearsal evidence (from #133)

Original PR ran `devnet-upgrade-1120` end-to-end against `v1.11.1-hotfix` FROM_TAG: chain halted at upgrade height 116, swapped binaries, resumed block production on v1.12.0; `lumerad query upgrade applied v1.12.0` returned `height: "116"`. Call paths are identical on this branch.

## Risks

None. Pure additive Makefile change. The 1101 normalization fixes a pre-existing inconsistency and only affects which binary directory is required to exist when that target is invoked.

## Rollback

`git revert` — Makefile-only.

## Operator notes

`bin-v1.X.Y/` directories are operator-staged (not shipped in repo), matching existing convention.