### PR TITLE
Lep 6 postponed target assignment fix

### DIFF
--- a/x/audit/v1/keeper/audit_peer_assignment.go
+++ b/x/audit/v1/keeper/audit_peer_assignment.go
@@ -119,7 +119,11 @@ func computeStorageTruthTargetsForReporter(params paramsLike, activeSorted []str
 	}
 
 	active := sortedUniqueStrings(activeSorted)
-	targetCandidates := intersectionInOrder(sortedUniqueStrings(targetsSorted), active)
+	// Active supernodes are the only eligible challengers, but storage-truth targets
+	// must include the epoch target set captured by the anchor. That target set
+	// intentionally includes POSTPONED supernodes so active peers can continue
+	// submitting clean PASS proofs needed for storage-truth recovery.
+	targetCandidates := sortedUniqueStrings(targetsSorted)
 	if len(targetCandidates) == 0 {
 		targetCandidates = active
 	}

--- a/x/audit/v1/keeper/audit_peer_assignment_test.go
+++ b/x/audit/v1/keeper/audit_peer_assignment_test.go
@@ -34,6 +34,28 @@ func TestStorageTruthAssignmentUsesOneThirdCoverage(t *testing.T) {
 	require.Len(t, assignedTargets, 2)
 }
 
+func TestStorageTruthAssignmentIncludesPostponedTargets(t *testing.T) {
+	params := types.DefaultParams().WithDefaults()
+	params.StorageTruthEnforcementMode = types.StorageTruthEnforcementMode_STORAGE_TRUTH_ENFORCEMENT_MODE_FULL
+	params.StorageTruthChallengeTargetDivisor = 1
+
+	active := []string{"sn-a", "sn-b"}
+	targets := []string{"sn-postponed"}
+	seed := []byte("01234567890123456789012345678901")
+
+	assigned := false
+	for _, reporter := range active {
+		reporterTargets, isProber, err := computeAuditPeerTargetsForReporter(&params, active, targets, seed, reporter)
+		require.NoError(t, err)
+		require.True(t, isProber)
+		if containsString(reporterTargets, "sn-postponed") {
+			assigned = true
+		}
+	}
+
+	require.True(t, assigned, "active challengers must be able to target postponed supernodes for storage-truth recovery")
+}
+
 func TestStorageTruthAssignmentDisabledUsesLegacyCoverage(t *testing.T) {
 	params := types.DefaultParams().WithDefaults()
 	params.StorageTruthEnforcementMode = types.StorageTruthEnforcementMode_STORAGE_TRUTH_ENFORCEMENT_MODE_UNSPECIFIED


### PR DESCRIPTION
Summary

Fix LEP-6 storage-truth target assignment so POSTPONED supernodes remain challengeable by active challengers after they are postponed.

Before this change, storage-truth assignment computed targets by intersecting the epoch anchor’s target set with the active challenger set. That accidentally removed POSTPONED supernodes from future storage-truth assignments, even though the epoch anchor already records POSTPONED nodes in TargetSupernodeAccounts.

This made the LEP-6 recovery path unreachable in some cases:

text
storage failure → suspicion threshold crossed → POSTPONED
→ target no longer assigned
→ no clean PASS proofs can accrue
→ clean-pass recovery predicate cannot be satisfied




The fix keeps challenger eligibility active-only, but uses the anchored target set as the storage-truth target candidate set.

Why this is required

LEP-6 recovery requires both:

1. suspicion score decay below the recovery threshold, and
2. a configured number of clean PASS results after postponement.

The current chain implementation already separates:

- ActiveSupernodeAccounts: active/storage-full nodes eligible to challenge/report
- TargetSupernodeAccounts: active/storage-full/postponed nodes eligible to be challenged

CreateEpochAnchorIfNeeded already includes POSTPONED nodes in the target set. Existing test coverage also asserts this behavior. The assignment code was the inconsistent piece: it filtered the target set back down to active nodes, making POSTPONED targets unreachable.

Implementation

Updated computeStorageTruthTargetsForReporter so:

- reporters/challengers must still be active/eligible
- target candidates come from the epoch anchor’s TargetSupernodeAccounts
- POSTPONED targets remain challengeable by active peers
- fallback behavior for empty target sets is preserved
- legacy assignment behavior for UNSPECIFIED mode is unchanged

Added regression coverage to prove active challengers can be assigned POSTPONED storage-truth targets.

Spec / design alignment

This is aligned with LEP-6’s objective of storage-truth enforcement and recovery:

- does not allow POSTPONED nodes to act as challengers
- does not bypass recovery predicates
- does not weaken suspicion scoring or clean-pass requirements
- preserves bounded target count based on active challenger population
- enables the intended recovery loop:
  text
  failure → POSTPONED → clean PASS evidence → ACTIVE recovery
  



This also matches the implementation guide’s SOFT/FULL behavior: storage-truth enforcement can postpone nodes, and FULL mode requires complete proof coverage for assigned storage-truth targets.

Validation

Ran targeted keeper tests:

bash
go test ./x/audit/v1/keeper -run 'TestStorageTruthAssignment(UsesOneThirdCoverage|IncludesPostponedTargets|DisabledUsesLegacyCoverage)$' -count=1

Result:

text
ok  [github.com/LumeraProtocol/lumera/x/audit/v1/keeper](http://github.com/LumeraProtocol/lumera/x/audit/v1/keeper)  0.071s




Also ran full keeper package after review:

bash
go test ./x/audit/v1/keeper -count=1

Result:

text
ok  [github.com/LumeraProtocol/lumera/x/audit/v1/keeper](http://github.com/LumeraProtocol/lumera/x/audit/v1/keeper)  0.203s

Validated through the supernode LEP-6 local E2E flow consuming this chain fix:

Result: PASS

Key passing tests:

- TestLEP6StorageTruthEnforcementLifecycle
- TestLEP6RuntimeE2E_CascadeChallengeHealVerifyAndStore
- TestLEP6RealChainIntegration