### PR TITLE
fix(devnet): supervise lumerad lifecycle in start.sh + add restart policy

### DIFF
--- a/devnet/generators/docker-compose.go
+++ b/devnet/generators/docker-compose.go
@@ -44,6 +44,7 @@ type DockerComposeService struct {
 	CapAdd        []string                               `yaml:"cap_add,omitempty"`
 	SecurityOpt   []string                               `yaml:"security_opt,omitempty"`
 	Logging       *DockerComposeLogging                  `yaml:"logging,omitempty"`
+	Restart       string                                 `yaml:"restart,omitempty"`
 }
 
 type DockerComposeNetwork struct {
@@ -226,6 +227,10 @@ func GenerateDockerCompose(config *confg.ChainConfig, validators []confg.Validat
 		service := DockerComposeService{
 			Build:         ".",
 			ContainerName: serviceName,
+			// Auto-restart on lumerad crashes / host pkill mishaps.
+			// start.sh wait_for_lumera() propagates lumerad exit code to PID 1,
+			// so a non-zero exit triggers docker restart and rejoins the chain.
+			Restart: "unless-stopped",
 			Ports: []string{
 				fmt.Sprintf("%d:%d", validator.Port, DefaultP2PPort),
 				fmt.Sprintf("%d:%d", validator.RPCPort, DefaultRPCPort),

--- a/devnet/generators/docker-compose.go
+++ b/devnet/generators/docker-compose.go
@@ -228,8 +228,8 @@ func GenerateDockerCompose(config *confg.ChainConfig, validators []confg.Validat
 			Build:         ".",
 			ContainerName: serviceName,
 			// Auto-restart on lumerad crashes / host pkill mishaps.
-			// start.sh wait_for_lumera() propagates lumerad exit code to PID 1,
-			// so a non-zero exit triggers docker restart and rejoins the chain.
+			// start.sh wait_for_lumera() makes PID 1 exit with lumerad's
+			// status for observability; this policy handles recovery.
 			Restart: "unless-stopped",
 			Ports: []string{
 				fmt.Sprintf("%d:%d", validator.Port, DefaultP2PPort),

--- a/devnet/scripts/start.sh
+++ b/devnet/scripts/start.sh
@@ -338,6 +338,8 @@ start_lumera() {
 	fi
 	# shellcheck disable=SC2086
 	run "${DAEMON}" start --home "${DAEMON_HOME}" ${EXTRA_START_FLAGS} >"${VALIDATOR_LOG}" 2>&1 &
+	LUMERAD_PID=$!
+	echo "[BOOT] ${MONIKER}: lumerad started, pid=${LUMERAD_PID}"
 
 	if [ "${MONIKER}" = "${PRIMARY_MONIKER}" ]; then
 		mkdir -p "$(dirname "${PRIMARY_STARTED_FLAG}")"
@@ -348,7 +350,39 @@ start_lumera() {
 
 tail_logs() {
 	touch "${VALIDATOR_LOG}" "${SUPERNODE_LOG}" "${SUPERNODE_SETUP_OUT}" "${VALIDATOR_SETUP_OUT}" "${UPLOADER_SETUP_OUT}" "${TEST_ACCOUNTS_SETUP_OUT}"
-	exec tail -F "${VALIDATOR_LOG}" "${SUPERNODE_LOG}" "${SUPERNODE_SETUP_OUT}" "${VALIDATOR_SETUP_OUT}" "${UPLOADER_SETUP_OUT}" "${TEST_ACCOUNTS_SETUP_OUT}"
+	tail -F "${VALIDATOR_LOG}" "${SUPERNODE_LOG}" "${SUPERNODE_SETUP_OUT}" "${VALIDATOR_SETUP_OUT}" "${UPLOADER_SETUP_OUT}" "${TEST_ACCOUNTS_SETUP_OUT}" &
+	TAIL_PID=$!
+}
+
+# Wait on the lumerad process and propagate its exit code as the container's
+# exit code. If lumerad dies (crash, SIGKILL on host that matches `pkill -f
+# 'lumerad start'`, OOM, etc.) the container exits non-zero. Combined with the
+# docker-compose `restart: unless-stopped` policy this auto-recovers from
+# silent zombification and surfaces real crashes to docker / observability.
+#
+# History: 2026-06-02 — a host `pkill -9 -f 'lumerad start'` matched lumerad
+# inside the 5 validator containers. PID 1 was bash + tail -F, so containers
+# stayed "Up" for 6 days while chain was dead. See PR description.
+wait_for_lumera() {
+	if [ -z "${LUMERAD_PID:-}" ]; then
+		echo "[BOOT] ${MONIKER}: lumerad pid not set; cannot supervise."
+		# Fall back to old tail-forever behaviour rather than exit 0 silently.
+		wait "${TAIL_PID:-}" 2>/dev/null || true
+		return 0
+	fi
+	# `wait <pid>` returns the exit status of that process. We deliberately do
+	# NOT use `set -e` here so we can capture the code.
+	set +e
+	wait "${LUMERAD_PID}"
+	local rc=$?
+	set -e
+	echo "[BOOT] ${MONIKER}: lumerad exited rc=${rc} — terminating container so docker restart policy can recover."
+	if [ -n "${TAIL_PID:-}" ]; then
+		kill "${TAIL_PID}" 2>/dev/null || true
+	fi
+	# Sleep briefly so the last log lines are flushed by tail -F before we exit.
+	sleep 1
+	exit "${rc}"
 }
 
 run_auto_flow() {
@@ -361,6 +395,7 @@ run_auto_flow() {
 	launch_test_accounts_setup
 	start_nm_ui_if_present
 	tail_logs
+	wait_for_lumera
 }
 
 case "${START_MODE}" in
@@ -388,6 +423,7 @@ run)
 	launch_test_accounts_setup
 	start_nm_ui_if_present
 	tail_logs
+	wait_for_lumera
 	;;
 
 wait)

--- a/devnet/scripts/start.sh
+++ b/devnet/scripts/start.sh
@@ -336,8 +336,9 @@ start_lumera() {
 		EXTRA_START_FLAGS="--skip-claims-check=false --claims-path=${CLAIMS_LOCAL}"
 		echo "[BOOT] ${MONIKER}: Claims CSV found, loading claim records at genesis"
 	fi
+	echo "+ ${DAEMON} start --home ${DAEMON_HOME} ${EXTRA_START_FLAGS}"
 	# shellcheck disable=SC2086
-	run "${DAEMON}" start --home "${DAEMON_HOME}" ${EXTRA_START_FLAGS} >"${VALIDATOR_LOG}" 2>&1 &
+	"${DAEMON}" start --home "${DAEMON_HOME}" ${EXTRA_START_FLAGS} >"${VALIDATOR_LOG}" 2>&1 &
 	LUMERAD_PID=$!
 	echo "[BOOT] ${MONIKER}: lumerad started, pid=${LUMERAD_PID}"
 
@@ -356,9 +357,9 @@ tail_logs() {
 
 # Wait on the lumerad process and propagate its exit code as the container's
 # exit code. If lumerad dies (crash, SIGKILL on host that matches `pkill -f
-# 'lumerad start'`, OOM, etc.) the container exits non-zero. Combined with the
-# docker-compose `restart: unless-stopped` policy this auto-recovers from
-# silent zombification and surfaces real crashes to docker / observability.
+# 'lumerad start'`, OOM, etc.) PID 1 exits too. The docker-compose
+# `restart: unless-stopped` policy handles recovery on any container exit while
+# the propagated code keeps crash/kill status visible to docker / observability.
 #
 # History: 2026-06-02 — a host `pkill -9 -f 'lumerad start'` matched lumerad
 # inside the 5 validator containers. PID 1 was bash + tail -F, so containers


### PR DESCRIPTION
## Summary

Make the devnet validator containers actually die — and auto-recover — when
`lumerad` dies. Today the container PID 1 outlives `lumerad`, so
`docker ps` happily reports "Up" while the chain process is a defunct
zombie. There is no `restart` policy either, so docker would not recover
the container even if PID 1 did exit.

## Incident that motivated this

**2026-06-02 13:05 UTC, lumera-devnet-1.** During a host cosmovisor
restart cycle, an operator ran:

```
sudo pkill -9 -f 'lumerad start'
```

on the host. The regex was intended to kill the host
`lumera-devnet-api.service` cosmovisor child, but Docker's PID namespace
is shared with the host, so the `pkill` also matched the `lumerad start`
processes inside the 5 validator containers. All 5 in-container
`lumerad`s got SIGKILLed.

Container PID 1 is `bash /root/scripts/start.sh`, which does:

```bash
"${DAEMON}" start --home "${DAEMON_HOME}" ... >"${VALIDATOR_LOG}" 2>&1 &
…
exec tail -F "${VALIDATOR_LOG}" "${SUPERNODE_LOG}" …
```

So PID 1 became `tail -F`. Tail doesn't care that lumerad died — it kept
following the log file forever. `docker ps` reported `Up 13 days` for
all 5 containers while the chain was actually dead at h=301810 for
**~6 days** before anyone noticed.

There was also no `restart:` policy on the validator service, so even
if PID 1 had exited correctly, docker would not have restarted the
container.

## Fix

### 1. `devnet/scripts/start.sh`

- Capture `LUMERAD_PID=$!` after launching lumerad.
- Demote `tail -F` from `exec` to a background `&`, capturing
  `TAIL_PID=$!`.
- Add `wait_for_lumera()`:
  - `wait "$LUMERAD_PID"`, capture rc.
  - `kill "$TAIL_PID"` to flush logs.
  - `exit "$rc"`.
- Call `wait_for_lumera` at the end of both `run_auto_flow` and the
  `run` mode.

PID 1 now dies with lumerad. Combined with the restart policy, docker
restarts the container automatically.

### 2. `devnet/generators/docker-compose.go`

- Add `Restart string` field (yaml `restart,omitempty`) to
  `DockerComposeService`.
- Set `Restart: "unless-stopped"` on the generated validator services.

Validator containers will now restart on lumerad death but NOT on a
deliberate `docker compose stop`.

## End-to-end validation

A standalone docker container reproducing the supervisor logic was
spawned with `--restart on-failure:3`:

```
[BOOT] iteration=1 pid1=1
[BOOT] fake lumerad pid=9
/sim_start.sh: line 27:     9 Killed                     sleep 100000
[BOOT] lumerad exited rc=137 — propagating to PID 1
[TEST] killed lumerad pid=9 at 17:40:13
[BOOT] iteration=2 pid1=1
[BOOT] fake lumerad pid=9
```

State across iterations (the `/state/iter` mount) was preserved across
the restart, which is exactly the behaviour the real validator
containers need so they rejoin the chain on the same data directory.

## Risks / non-goals

- **Devnet-only**. Touches `devnet/*` only — no chain state machine
  impact, no module impact, no protobuf changes, no consensus impact.
- `docker compose stop` continues to win over `unless-stopped`, so
  intentional shutdowns are unchanged.
- **Existing live devnet containers need to be recreated** for the new
  restart policy to apply. `docker compose restart` is NOT enough; ops
  needs `docker compose up -d --force-recreate` on next deploy.
  Existing containers also pick up the new `start.sh` only after a
  rebuild of the validator image (the script is baked into the image at
  build time). Both follow naturally from the next devnet rollout.

## Rollback

Revert the commit; existing containers do not depend on the new
behaviour for normal steady-state operation.

## Observability follow-ups (separate)

- lumera-devnet-1 is not currently shipping logs to Datadog (verified
  via Datadog API — only testnet supernode services are indexed). Once
  the next ops cycle wires devnet logs to DD, add a monitor for
  "lumera-devnet-1 height did not advance in 5 min". That's a separate
  ops task, not in scope here.
