### PR TITLE
scripts(evmigration): make migrate-multisig.sh submit recoverable on broadcast RPC drop

### DIFF
--- a/scripts/migrate-multisig.sh
+++ b/scripts/migrate-multisig.sh
@@ -631,8 +631,38 @@ BANNER
   [[ -n "$home_dir"    ]] && args+=(--home "$home_dir")
   (( yes == 1 )) && args+=(-y)
 
-  local broadcast_json tx_hash
-  broadcast_json=$("$BIN" "${args[@]}")
+  # Capture stdout, stderr, and exit code separately so a partial RPC failure
+  # (e.g. lumerad prints `EOF` to stderr after the CometBFT RPC stream drops)
+  # doesn't kill the script under `set -e` with no diagnostic. The tx may or
+  # may not have entered the mempool; before erroring out, probe chain state
+  # for the migration record so the operator gets a definitive answer instead
+  # of a bare `EOF` line.
+  local broadcast_json broadcast_err broadcast_rc=0 tx_hash
+  local stderr_file
+  stderr_file=$(mktemp)
+  broadcast_json=$("$BIN" "${args[@]}" 2>"$stderr_file") || broadcast_rc=$?
+  broadcast_err=$(<"$stderr_file")
+  rm -f "$stderr_file"
+  if (( broadcast_rc != 0 )); then
+    log_error "broadcast command failed (rc=$broadcast_rc)"
+    [[ -n "$broadcast_err" ]] && log_error "lumerad stderr: $broadcast_err"
+    log_error "checking chain state — the tx may still have landed:"
+    log_error "  $BIN query evmigration migration-record $(legacy_value "$legacy") --node $node"
+    if lumerad_q evmigration migration-record "$legacy" >/dev/null 2>&1; then
+      local rec_new
+      rec_new=$(lumerad_q evmigration migration-record "$legacy" 2>/dev/null | jq -r '.record.new_address // empty')
+      if [[ "$rec_new" == "$new" ]]; then
+        log_info "on-chain migration record found for $(legacy_value "$legacy") -> $(new_value "$new")"
+        log_info "broadcast appears to have succeeded despite the RPC error above; running post-broadcast verification"
+        verify_migration "$legacy" "$new" "$snap"
+        show_migration_summary "$legacy" "$new"
+        log_info "migration complete"
+        return 0
+      fi
+    fi
+    log_error "no migration record found for $(legacy_value "$legacy") — tx did not land; safe to re-run submit"
+    exit 2
+  fi
   tx_hash=$(assert_broadcast_accepted "$broadcast_json")
 
   log_info "broadcast tx $tx_hash; waiting for inclusion..."

--- a/scripts/migrate-multisig.sh
+++ b/scripts/migrate-multisig.sh
@@ -644,24 +644,8 @@ BANNER
   broadcast_err=$(<"$stderr_file")
   rm -f "$stderr_file"
   if (( broadcast_rc != 0 )); then
-    log_error "broadcast command failed (rc=$broadcast_rc)"
-    [[ -n "$broadcast_err" ]] && log_error "lumerad stderr: $broadcast_err"
-    log_error "checking chain state — the tx may still have landed:"
-    log_error "  $BIN query evmigration migration-record $(legacy_value "$legacy") --node $node"
-    if lumerad_q evmigration migration-record "$legacy" >/dev/null 2>&1; then
-      local rec_new
-      rec_new=$(lumerad_q evmigration migration-record "$legacy" 2>/dev/null | jq -r '.record.new_address // empty')
-      if [[ "$rec_new" == "$new" ]]; then
-        log_info "on-chain migration record found for $(legacy_value "$legacy") -> $(new_value "$new")"
-        log_info "broadcast appears to have succeeded despite the RPC error above; running post-broadcast verification"
-        verify_migration "$legacy" "$new" "$snap"
-        show_migration_summary "$legacy" "$new"
-        log_info "migration complete"
-        return 0
-      fi
-    fi
-    log_error "no migration record found for $(legacy_value "$legacy") — tx did not land; safe to re-run submit"
-    exit 2
+    recover_submit_after_broadcast_error "$broadcast_rc" "$broadcast_err" "$legacy" "$new" "$snap"
+    return 0
   fi
   tx_hash=$(assert_broadcast_accepted "$broadcast_json")
 
@@ -680,6 +664,59 @@ BANNER
   log_info "  legacy: $(legacy_value "$legacy")"
   log_info "  new:    $(new_value "$new")"
   log_info "  tx:     $tx_hash"
+}
+
+recover_submit_after_broadcast_error() {
+  local broadcast_rc="$1" broadcast_err="$2" legacy="$3" new="$4" snap="$5"
+  local timeout="${LUMERA_TX_WAIT_TIMEOUT:-90}"
+  local started=$SECONDS
+  local logged_wait=0
+
+  log_error "broadcast command failed (rc=$broadcast_rc)"
+  [[ -n "$broadcast_err" ]] && log_error "lumerad stderr: $broadcast_err"
+  log_error "checking chain state — the tx may still have landed:"
+  log_error "  $BIN query evmigration migration-record $(legacy_value "$legacy") --node $NODE"
+
+  while true; do
+    local rec_json rec_legacy rec_new rec_height
+    if ! rec_json=$(lumerad_q_capture evmigration migration-record "$legacy"); then
+      log_error "could not query migration-record for $(legacy_value "$legacy"); cannot determine whether the tx landed"
+      log_lumerad_err
+      log_error "do not re-run submit until the migration record is checked manually"
+      exit 7
+    fi
+
+    rec_legacy=$(jq -r '.record.legacy_address // empty' <<<"$rec_json")
+    if [[ -n "$rec_legacy" ]]; then
+      rec_new=$(jq -r '.record.new_address // "<missing>"' <<<"$rec_json")
+      rec_height=$(jq -r '.record.migration_height // "<unknown>"' <<<"$rec_json")
+      if [[ "$rec_new" == "$new" ]]; then
+        log_info "on-chain migration record found for $(legacy_value "$legacy") -> $(new_value "$new") at height $rec_height"
+        log_info "broadcast appears to have succeeded despite the RPC error above; running post-broadcast verification"
+        verify_migration "$legacy" "$new" "$snap"
+        show_migration_summary "$legacy" "$new"
+        log_info "migration complete"
+        return 0
+      fi
+      log_error "migration record found for $(legacy_value "$legacy"), but it points to a DIFFERENT destination:"
+      log_error "  on-chain destination:  $(new_value "$rec_new") (migrated at height $rec_height)"
+      log_error "  destination you asked: $(new_value "$new")"
+      log_error "do not re-run submit until the destination mismatch is resolved"
+      exit 7
+    fi
+
+    if (( SECONDS - started >= timeout )); then
+      break
+    fi
+    if (( logged_wait == 0 )); then
+      log_info "no migration record visible yet; polling for up to ${timeout}s before giving retry guidance"
+      logged_wait=1
+    fi
+    sleep 1
+  done
+
+  log_error "no migration record found for $(legacy_value "$legacy") after ${timeout}s — tx did not land within the wait window; safe to re-run submit"
+  exit 2
 }
 
 main() {

--- a/tests/scripts/fixtures/lumerad-shim.sh
+++ b/tests/scripts/fixtures/lumerad-shim.sh
@@ -26,6 +26,16 @@
 #   SHIM_SUBMIT_LANDED=1      — combined with SHIM_SUBMIT_EXIT, simulate the case
 #                                where the tx actually landed before the RPC dropped
 #                                (record/bank queries flip to their *_AFTER fixtures).
+#   SHIM_SUBMIT_PENDING=1     — combined with SHIM_SUBMIT_EXIT, mark the tx as
+#                                accepted but not visible in chain state yet.
+#   SHIM_PENDING_RECORD_AFTER_QUERIES=<n>
+#                              — when pending, flip to landed after n
+#                                migration-record queries.
+#   SHIM_RECORD_AFTER_SUBMIT_EXIT=<n>
+#                              — when pending, force migration-record to fail
+#                                with this exit code.
+#   SHIM_RECORD_AFTER_SUBMIT_STDERR=<msg>
+#                              — stderr for SHIM_RECORD_AFTER_SUBMIT_EXIT.
 
 set -u
 
@@ -34,6 +44,14 @@ if [[ -n "${SHIM_STDERR:-}" ]]; then
 fi
 
 fixtures_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pending_file() {
+  printf '%s.pending\n' "${SHIM_STATE_FILE:-}"
+}
+
+record_query_count_file() {
+  printf '%s.record_queries\n' "${SHIM_STATE_FILE:-}"
+}
 
 emit() {
   local name="$1"
@@ -77,6 +95,23 @@ fi
 case "$*" in
   "query evmigration migration-estimate "*)               emit "${SHIM_ESTIMATE_FIXTURE:-estimate-ok}" ;;
   "query evmigration migration-record "*)
+    if [[ -n "${SHIM_STATE_FILE:-}" && -f "$(pending_file)" ]]; then
+      if [[ -n "${SHIM_RECORD_AFTER_SUBMIT_EXIT:-}" ]]; then
+        [[ -n "${SHIM_RECORD_AFTER_SUBMIT_STDERR:-}" ]] && printf '%s\n' "$SHIM_RECORD_AFTER_SUBMIT_STDERR" >&2
+        exit "$SHIM_RECORD_AFTER_SUBMIT_EXIT"
+      fi
+      if [[ -n "${SHIM_PENDING_RECORD_AFTER_QUERIES:-}" ]]; then
+        count_file="$(record_query_count_file)"
+        count=0
+        [[ -f "$count_file" ]] && count=$(<"$count_file")
+        count=$((count + 1))
+        printf '%s\n' "$count" > "$count_file"
+        if (( count >= SHIM_PENDING_RECORD_AFTER_QUERIES )); then
+          touch "$SHIM_STATE_FILE"
+          rm -f "$(pending_file)"
+        fi
+      fi
+    fi
     if [[ -n "${SHIM_STATE_FILE:-}" && -f "${SHIM_STATE_FILE}" && -n "${SHIM_RECORD_AFTER_FIXTURE:-}" ]]; then
       emit "$SHIM_RECORD_AFTER_FIXTURE"
     else
@@ -208,6 +243,8 @@ ADDR
       # on-chain migration record on retry.
       if [[ -n "${SHIM_STATE_FILE:-}" && "${SHIM_SUBMIT_LANDED:-0}" == "1" ]]; then
         touch "$SHIM_STATE_FILE"
+      elif [[ -n "${SHIM_STATE_FILE:-}" && "${SHIM_SUBMIT_PENDING:-0}" == "1" ]]; then
+        touch "$(pending_file)"
       fi
       exit "$SHIM_SUBMIT_EXIT"
     fi

--- a/tests/scripts/fixtures/lumerad-shim.sh
+++ b/tests/scripts/fixtures/lumerad-shim.sh
@@ -19,6 +19,13 @@
 #   SHIM_BANK_AFTER_FIXTURE=<name>   — fixture for legacy bank balances AFTER broadcast.
 #   SHIM_BANK_NEW_FIXTURE=<name>     — fixture for bank balances of the new stub addr
 #                                      (always, regardless of phase).
+#
+# submit-proof failure simulation (for broadcast-RPC-EOF tests):
+#   SHIM_SUBMIT_EXIT=<n>      — force submit-proof to exit n (after emitting stderr)
+#   SHIM_SUBMIT_STDERR=<msg>  — emit this to stderr just for submit-proof
+#   SHIM_SUBMIT_LANDED=1      — combined with SHIM_SUBMIT_EXIT, simulate the case
+#                                where the tx actually landed before the RPC dropped
+#                                (record/bank queries flip to their *_AFTER fixtures).
 
 set -u
 
@@ -192,6 +199,18 @@ ADDR
     exit "${SHIM_COMBINE_EXIT:-${SHIM_EXIT:-0}}"
     ;;
   "tx evmigration submit-proof"*)
+    if [[ -n "${SHIM_SUBMIT_STDERR:-}" ]]; then
+      printf '%s\n' "$SHIM_SUBMIT_STDERR" >&2
+    fi
+    if [[ -n "${SHIM_SUBMIT_EXIT:-}" ]]; then
+      # SHIM_SUBMIT_LANDED=1 simulates "the tx actually entered a block before
+      # the RPC dropped"; the wrapper's recovery path can then observe an
+      # on-chain migration record on retry.
+      if [[ -n "${SHIM_STATE_FILE:-}" && "${SHIM_SUBMIT_LANDED:-0}" == "1" ]]; then
+        touch "$SHIM_STATE_FILE"
+      fi
+      exit "$SHIM_SUBMIT_EXIT"
+    fi
     if [[ -n "${SHIM_STATE_FILE:-}" ]]; then
       touch "$SHIM_STATE_FILE"
     fi

--- a/tests/scripts/migrate-multisig.bats
+++ b/tests/scripts/migrate-multisig.bats
@@ -110,6 +110,7 @@ setup() {
   local state_dir; state_dir=$(mktemp -d)
   local state_file="$state_dir/state"
   run env \
+    LUMERA_TX_WAIT_TIMEOUT=1 \
     SHIM_STATE_FILE="$state_file" \
     SHIM_ESTIMATE_FIXTURE=estimate-multisig \
     SHIM_SUBMIT_EXIT=1 \
@@ -124,6 +125,77 @@ setup() {
   [[ "$output" == *"lumerad stderr: EOF"* ]]
   [[ "$output" == *"tx did not land"* ]]
   [[ "$output" == *"safe to re-run submit"* ]]
+  rm -rf "$state_dir"
+}
+
+@test "submit polls after broadcast EOF until a pending tx creates the migration record" {
+  local state_dir; state_dir=$(mktemp -d)
+  local state_file="$state_dir/state"
+  run env \
+    LUMERA_TX_WAIT_TIMEOUT=3 \
+    SHIM_STATE_FILE="$state_file" \
+    SHIM_ESTIMATE_FIXTURE=estimate-multisig \
+    SHIM_RECORD_AFTER_FIXTURE=record-post-migration \
+    SHIM_BANK_AFTER_FIXTURE=bank-balances-empty \
+    SHIM_SUBMIT_EXIT=1 \
+    SHIM_SUBMIT_STDERR="EOF" \
+    SHIM_SUBMIT_PENDING=1 \
+    SHIM_PENDING_RECORD_AFTER_QUERIES=2 \
+    "$SCRIPTS_DIR/migrate-multisig.sh" submit "$FIX_DIR/combined-tx.json" \
+      --binary "$SHIM" \
+      --chain-id shim-test \
+      --node tcp://local:1 \
+      --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no migration record visible yet; polling"* ]]
+  [[ "$output" == *"on-chain migration record found"* ]]
+  [[ "$output" == *"migration complete"* ]]
+  rm -rf "$state_dir"
+}
+
+@test "submit exits 7 when recovery query fails after broadcast EOF" {
+  local state_dir; state_dir=$(mktemp -d)
+  local state_file="$state_dir/state"
+  run env \
+    SHIM_STATE_FILE="$state_file" \
+    SHIM_ESTIMATE_FIXTURE=estimate-multisig \
+    SHIM_SUBMIT_EXIT=1 \
+    SHIM_SUBMIT_STDERR="EOF" \
+    SHIM_SUBMIT_PENDING=1 \
+    SHIM_RECORD_AFTER_SUBMIT_EXIT=1 \
+    SHIM_RECORD_AFTER_SUBMIT_STDERR="rpc unavailable" \
+    "$SCRIPTS_DIR/migrate-multisig.sh" submit "$FIX_DIR/combined-tx.json" \
+      --binary "$SHIM" \
+      --chain-id shim-test \
+      --node tcp://local:1 \
+      --yes
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"could not query migration-record"* ]]
+  [[ "$output" == *"rpc unavailable"* ]]
+  [[ "$output" == *"do not re-run submit"* ]]
+  [[ "$output" != *"safe to re-run submit"* ]]
+  rm -rf "$state_dir"
+}
+
+@test "submit exits 7 when recovery finds a different destination record" {
+  local state_dir; state_dir=$(mktemp -d)
+  local state_file="$state_dir/state"
+  run env \
+    SHIM_STATE_FILE="$state_file" \
+    SHIM_ESTIMATE_FIXTURE=estimate-multisig \
+    SHIM_RECORD_AFTER_FIXTURE=record-found \
+    SHIM_SUBMIT_EXIT=1 \
+    SHIM_SUBMIT_STDERR="EOF" \
+    SHIM_SUBMIT_LANDED=1 \
+    "$SCRIPTS_DIR/migrate-multisig.sh" submit "$FIX_DIR/combined-tx.json" \
+      --binary "$SHIM" \
+      --chain-id shim-test \
+      --node tcp://local:1 \
+      --yes
+  [ "$status" -eq 7 ]
+  [[ "$output" == *"DIFFERENT destination"* ]]
+  [[ "$output" == *"destination you asked"* ]]
+  [[ "$output" != *"safe to re-run submit"* ]]
   rm -rf "$state_dir"
 }
 

--- a/tests/scripts/migrate-multisig.bats
+++ b/tests/scripts/migrate-multisig.bats
@@ -71,6 +71,62 @@ setup() {
   rm -rf "$state_dir"
 }
 
+@test "submit recovers when broadcast prints EOF but tx actually landed" {
+  # Simulate the RPC dropping the connection mid-broadcast (lumerad prints
+  # 'EOF' to stderr and exits non-zero) AFTER the tx has been accepted into
+  # the mempool and committed. The wrapper should query the migration record,
+  # see that the migration actually completed, log a recovery message, run
+  # post-broadcast verification, and exit 0.
+  local state_dir; state_dir=$(mktemp -d)
+  local state_file="$state_dir/state"
+  # SHIM_SUBMIT_LANDED=1 makes the shim flip the state file to "after"
+  # right before exiting non-zero with EOF on stderr — i.e. the tx landed,
+  # but the operator only sees the RPC error.
+  run env \
+    SHIM_STATE_FILE="$state_file" \
+    SHIM_ESTIMATE_FIXTURE=estimate-multisig \
+    SHIM_RECORD_AFTER_FIXTURE=record-post-migration \
+    SHIM_BANK_AFTER_FIXTURE=bank-balances-empty \
+    SHIM_SUBMIT_EXIT=1 \
+    SHIM_SUBMIT_STDERR="EOF" \
+    SHIM_SUBMIT_LANDED=1 \
+    "$SCRIPTS_DIR/migrate-multisig.sh" submit "$FIX_DIR/combined-tx.json" \
+      --binary "$SHIM" \
+      --chain-id shim-test \
+      --node tcp://local:1 \
+      --yes
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"broadcast command failed"* ]]
+  [[ "$output" == *"lumerad stderr: EOF"* ]]
+  [[ "$output" == *"on-chain migration record found"* ]]
+  [[ "$output" == *"migration complete"* ]]
+  rm -rf "$state_dir"
+}
+
+@test "submit exits 2 with clear retry guidance when broadcast fails and tx did not land" {
+  # Same RPC-EOF scenario, but the tx never made it into the mempool. The
+  # wrapper should query for a migration record, find none, tell the operator
+  # the tx did not land, and exit 2 (broadcast-rejected sentinel).
+  local state_dir; state_dir=$(mktemp -d)
+  local state_file="$state_dir/state"
+  run env \
+    SHIM_STATE_FILE="$state_file" \
+    SHIM_ESTIMATE_FIXTURE=estimate-multisig \
+    SHIM_SUBMIT_EXIT=1 \
+    SHIM_SUBMIT_STDERR="EOF" \
+    "$SCRIPTS_DIR/migrate-multisig.sh" submit "$FIX_DIR/combined-tx.json" \
+      --binary "$SHIM" \
+      --chain-id shim-test \
+      --node tcp://local:1 \
+      --yes
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"broadcast command failed"* ]]
+  [[ "$output" == *"lumerad stderr: EOF"* ]]
+  [[ "$output" == *"tx did not land"* ]]
+  [[ "$output" == *"safe to re-run submit"* ]]
+  rm -rf "$state_dir"
+}
+
 @test "submit rejects non-multisig tx JSON (exit 3)" {
   run "$SCRIPTS_DIR/migrate-multisig.sh" submit "$FIX_DIR/combined-tx-single.json" \
       --binary "$SHIM" \


### PR DESCRIPTION
## Summary

Make `scripts/migrate-multisig.sh submit` recoverable when the CometBFT RPC stream drops mid-broadcast (lumerad exits non-zero after printing `EOF` to stderr). Today the wrapper dies under `set -e` with no diagnostic and a bare `EOF` line — the operator has no way to know whether the tx actually made it into the mempool.

## Why

Observed in the wild on `lumera-devnet-1` during the `val2` multisig validator migration ceremony. The `migrate-multisig.sh submit` wrapper printed:

```
gas estimate: 6871045
EOF
```

…and exited. But the tx had in fact landed cleanly at the next block (`migrate_validator` event, `code: 0`, h=51008). The operator's only recourse without this change is to manually query the migration record themselves and figure out whether the tx landed. If they guess wrong:

- Tx **did** land + operator re-submits → second attempt fails with `migration record already exists` (confusing but harmless).
- Tx **did not** land + operator re-submits → exactly the right move, but only if you're sure.

There's no way for the operator to be sure from the wrapper's output alone.

## What this PR changes

`scripts/migrate-multisig.sh` — `_mms_submit`:

- Capture `lumerad tx evmigration submit-proof` stdout/stderr/exit code separately instead of letting `set -e` kill the script.
- On non-zero exit:
  - Log the lumerad stderr (so the operator sees `EOF` or whatever the real error was, not just a silent bash exit).
  - Query the on-chain migration record for the legacy address.
  - If the record exists and `new_address` matches the destination from `tx.json`, log a recovery message, run the standard `verify_migration` + `show_migration_summary` path, and exit 0.
  - If no record exists, log `tx did not land; safe to re-run submit` and exit 2 (existing broadcast-rejected sentinel).

`tests/scripts/fixtures/lumerad-shim.sh`:

- New env vars `SHIM_SUBMIT_EXIT`, `SHIM_SUBMIT_STDERR`, `SHIM_SUBMIT_LANDED` so tests can simulate "broadcast bombs with EOF but tx landed" and "broadcast bombs and tx didn't land".

`tests/scripts/migrate-multisig.bats`:

- `submit recovers when broadcast prints EOF but tx actually landed` — asserts exit 0 + recovery log + verification ran.
- `submit exits 2 with clear retry guidance when broadcast fails and tx did not land` — asserts exit 2 + retry guidance in the output.

## Scope

- Only `migrate-multisig.sh submit`. `migrate-account.sh` and `migrate-validator.sh` are single-signer and don't expose the same operator-confusion failure mode (a single-key broadcast that returns EOF is just a retry — there's no offline ceremony in front of it to worry about discarding).
- No protocol or chain-state changes.
- No new dependencies (uses `mktemp`, `lumerad_q`, `jq` — already required by the script).

## Test plan

```
$ bats tests/scripts/migrate-multisig.bats
ok 1..43

$ bats tests/scripts/
1..121
… all 121 tests pass
```

Locally rehearsed by hand: pointed the script at a node whose RPC was getting killed mid-flight and confirmed both branches (recovery / retry-guidance) trigger as expected.

## Risks

Low. The change is fenced inside the `(( broadcast_rc != 0 ))` branch — happy-path behavior is unchanged (existing `submit happy path (broadcast + verify) exits 0` test still passes).

## Rollback strategy

Revert this PR. No state-machine changes, no migration record on-chain, no schema changes.
