### PR TITLE
feat(devnet): remote devnet deployment + gen-activity config/wizard/multisig/vesting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,28 @@ make devnet-reset             # Reset chain state, keep config
 make devnet-evm-upgrade       # Run EVM upgrade on devnet
 ```
 
+### Current shared devnet host notes
+
+For the shared EVM migration/devnet environment, SSH via:
+
+```bash
+ssh lumera-devnet
+```
+
+Important paths and containers:
+
+- Host devnet root: `/tmp/lumera-devnet-1`
+- Shared host path: `/tmp/lumera-devnet-1/shared`
+- Shared container path: `/shared`
+- Accounts file: `/tmp/lumera-devnet-1/shared/release/accounts-devnet.json` on the host, `/shared/release/accounts-devnet.json` in containers
+- Validator containers: `lumera-supernova_validator_1` through `lumera-supernova_validator_5`
+- Hermes container: `lumera-hermes`
+- Container shell: `docker exec -it lumera-supernova_validator_1 bash`
+- Validator data bind mounts: `/tmp/lumera-devnet-1/supernova_validator_N-data` on the host maps to `/root/.lumera` in `lumera-supernova_validator_N`
+- Migration scripts in validator containers: `/root/scripts/migration/migrate-account.sh`, `/root/scripts/migration/migrate-validator.sh`, `/root/scripts/migration/migrate-multisig.sh`
+
+For manual multisig migration work, run from inside a validator container that has the relevant keyring entries. The generated devnet multisig records in `accounts-devnet.json` list the composite and member key names, while the actual keyring entries live under the validator container's `/root/.lumera`. Save full transcripts and proof artifacts under `/shared/release/migration-transcripts/<account>-<timestamp>/` so they appear on the host under `/tmp/lumera-devnet-1/shared/release/migration-transcripts/`.
+
 **Note**: `claims.csv` is only needed if genesis `TotalClaimableAmount > 0` (claiming period ended 2025-01-01; default is now 0).
 
 **Rule**: After completing any multi-file code change, run `make lint` and fix any issues before considering the task done. Lint must pass cleanly (0 issues).

--- a/Makefile.devnet
+++ b/Makefile.devnet
@@ -1,7 +1,7 @@
 .PHONY: devnet-build devnet-tests-build _devnet-stage-migration-scripts devnet-up devnet-reset devnet-up-detach devnet-down devnet-stop devnet-clean devnet-deploy-tar devnet-upgrade devnet-new devnet-start devnet-evm-upgrade
 .PHONY: devnet-build-default _devnet-select-default-genesis devnet-refresh-bin devnet-update-binaries devnet-update-binaries-default devnet-update-scripts
-.PHONY: devnet-build-version devnet-new-version devnet-upgrade-version
-.PHONY: _check-devnet-version-bin _check-devnet-build-version-cfg
+.PHONY: devnet-build-version devnet-new-version devnet-upgrade-version devnet-stage-external-version devnet-new-remote-version
+.PHONY: _check-devnet-version-bin _check-devnet-build-version-cfg _check-devnet-external-version-cfg
 .PHONY: devnet-download-binaries
 .PHONY: devnet-evmigration-sync-bin devnet-evmigration-prepare devnet-evmigration-estimate devnet-evmigration-migrate devnet-evmigration-migrate-validator devnet-evmigration-verify devnet-evmigration-cleanup
 .PHONY: devnet-evmigrationp-prepare devnet-evmigrationp-estimate devnet-evmigrationp-migrate devnet-evmigrationp-migrate-validator devnet-evmigrationp-migrate-all devnet-evmigrationp-verify devnet-evmigrationp-cleanup
@@ -23,6 +23,10 @@
 #   make devnet-new-version       VERSION=v1.12.0   # clean + build-version + up
 #   make devnet-upgrade-version   VERSION=v1.12.0   # update running devnet to those binaries
 #
+# -- Remote execution from downloaded binaries -----------------
+#   make devnet-stage-external-version VERSION=v1.12.0   # local staging only, no Docker build, Hermes disabled
+#   make devnet-new-remote-version VERSION=v1.12.0       # stage locally, run on REMOTE_DEVNET_HOST
+#
 # -- Lifecycle (on an already-built devnet) --------------------
 #   make devnet-up                                  # start containers (foreground)
 #   make devnet-up-detach                           # start containers (background)
@@ -42,8 +46,8 @@
 #
 # -- External genesis / claims (override inputs to devnet-build) --
 #   make devnet-build \
-#       EXTERNAL_CLAIMS_FILE=~/claims.csv \
 #       EXTERNAL_GENESIS_FILE=~/genesis.json
+#   # Optional: EXTERNAL_CLAIMS_FILE=~/claims.csv
 #   # Optional: CONFIG_JSON=path/to/config.json VALIDATORS_JSON=path/to/validators.json
 #
 # -- Container maintenance -------------------------------------
@@ -76,6 +80,8 @@ CLAIMS_FILE := $(SHARED_CONFIG_DIR)/claims.csv
 COMPOSE_FILE := devnet/docker-compose.yml
 
 DEVNET_BUILD_LUMERA ?= 1      # 1 = build lumerad for devnet setup, 0 = skip
+DEVNET_BUILD_TESTS ?= 1       # 1 = build devnet test helper binaries, 0 = use existing/skip
+DEVNET_DOCKER_BUILD ?= 1      # 1 = build Docker images after staging, 0 = only stage runtime files
 # directory to take lumerad/supernode/lumera-uploader/sncli binaries from
 DEVNET_BIN_DIR ?= devnet/bin
 DEVNET_BIN_DIR_ABS := $(abspath $(DEVNET_BIN_DIR))
@@ -91,6 +97,14 @@ DEFAULT_CLAIMS_FILE := devnet/default-config/claims.csv
 ORIG_GENESIS_FILE := devnet/default-config/devnet-genesis-orig.json
 EVM_CUTOVER_VERSION ?= v1.20.0
 DEVNET_UPGRADE_RELEASE ?= auto
+REMOTE_DEVNET_HOST ?= lumera-devnet
+REMOTE_DEVNET_DIR ?= lumera-devnet
+REMOTE_DEVNET_SSH ?= ssh
+REMOTE_DEVNET_RSYNC ?= rsync -az
+REMOTE_EXTERNAL_GENESIS_FILE ?= $(HOME)/external-genesis/lumera-devnet-1/genesis.json
+REMOTE_DEVNET_STAGE_DIR ?= $(abspath build/devnet-remote-stage/lumera-devnet-1)
+REMOTE_CONFIG_JSON ?= $(REMOTE_DEVNET_STAGE_DIR)/config-no-hermes.json
+DEVNET_EXTERNAL_GENESIS_FILE = $(or $(EXTERNAL_GENESIS_FILE),$(REMOTE_EXTERNAL_GENESIS_FILE))
 
 devnet-tests-build:
 	@mkdir -p "${DEVNET_BIN_DIR_ABS}"
@@ -139,46 +153,68 @@ devnet-build:
 	if [ -n "$(EXTERNAL_CLAIMS_FILE)" ] && [ -f "$(EXTERNAL_CLAIMS_FILE)" ]; then \
 		cp -f "$(EXTERNAL_CLAIMS_FILE)" "$(CLAIMS_FILE)"; \
 		echo "Using claims file $(EXTERNAL_CLAIMS_FILE)"; \
-		EXTERNAL_GENESIS_FILE=$${EXTERNAL_GENESIS_FILE}; \
-		mkdir -p "${DEVNET_BIN_DIR}"; \
-		if [ "$(DEVNET_BUILD_LUMERA)" -eq "1" ]; then \
-			$(MAKE) build; \
-			if [ ! -f "${BUILD_DIR}/lumerad" ]; then \
-				echo "Cannot find lumerad binary [${BUILD_DIR}/lumerad]"; \
-				exit 1; \
-			fi; \
-			echo "Copying [${BUILD_DIR}/lumerad] to [${DEVNET_BIN_DIR}] directory..."; \
-			cp -f ${BUILD_DIR}/lumerad "${DEVNET_BIN_DIR}"; \
-			go get github.com/CosmWasm/wasmvm/$(WASMVM_VERSION); \
-			find $$(go env GOPATH)/pkg/mod/github.com/!cosm!wasm/wasmvm/$(WASMVM_VERSION) -name "libwasmvm.x86_64.so" -exec cp -f {} ${DEVNET_BIN_DIR}/libwasmvm.x86_64.so \; ; \
-		else \
-			echo "Using existing lumera binaries from ${DEVNET_BIN_DIR}..."; \
-		fi; \
-		if [ ! -f "${DEVNET_BIN_DIR}/lumerad" ]; then \
-			echo "${DEVNET_BIN_DIR}/lumerad binary not found..."; \
-			exit 1; \
-		fi; \
-		if [ ! -f "${DEVNET_BIN_DIR}/libwasmvm.x86_64.so" ]; then \
-			echo "${DEVNET_BIN_DIR}/libwasmvm.x86_64.so library not found..."; \
-			exit 1; \
-		fi; \
-		$(MAKE) devnet-tests-build DEVNET_BIN_DIR="${DEVNET_BIN_DIR}"; \
-        cp -f "${DEVNET_BIN_DIR}/lumerad" "${SHARED_RELEASE_DIR}/"; \
-        cp -f "${DEVNET_BIN_DIR}/libwasmvm.x86_64.so" "${SHARED_RELEASE_DIR}/"; \
-		$(MAKE) _devnet-stage-migration-scripts; \
-		cd devnet && \
-		${GO} mod tidy && \
-		CONFIG_JSON="$${CONFIG_JSON:-$(DEFAULT_CONFIG_JSON)}" \
-		VALIDATORS_JSON="$${VALIDATORS_JSON:-$(DEFAULT_VALIDATORS_JSON)}" \
-		./scripts/configure.sh --bin-dir "${DEVNET_BIN_DIR}" &&\
-		DEVNET_BIN_DIR="${DEVNET_BIN_DIR_ABS}" \
-		${GO} run . && \
-		START_MODE=bootstrap docker compose build && \
-		echo "Initialization complete. Ready to start nodes."; \
 	else \
-		echo "No external claims file provided or file not found."; \
+		if [ -n "$(EXTERNAL_CLAIMS_FILE)" ]; then \
+			echo "External claims file not found: $(EXTERNAL_CLAIMS_FILE)"; \
+			exit 1; \
+		fi; \
+		rm -f "$(CLAIMS_FILE)"; \
+		echo "No external claims file provided; claims.csv will not be staged."; \
+	fi; \
+	EXTERNAL_GENESIS_FILE=$${EXTERNAL_GENESIS_FILE}; \
+	mkdir -p "${DEVNET_BIN_DIR}"; \
+	if [ "$(DEVNET_BUILD_LUMERA)" -eq "1" ]; then \
+		$(MAKE) build; \
+		if [ ! -f "${BUILD_DIR}/lumerad" ]; then \
+			echo "Cannot find lumerad binary [${BUILD_DIR}/lumerad]"; \
+			exit 1; \
+		fi; \
+		echo "Copying [${BUILD_DIR}/lumerad] to [${DEVNET_BIN_DIR}] directory..."; \
+		cp -f ${BUILD_DIR}/lumerad "${DEVNET_BIN_DIR}"; \
+		go get github.com/CosmWasm/wasmvm/$(WASMVM_VERSION); \
+		find $$(go env GOPATH)/pkg/mod/github.com/!cosm!wasm/wasmvm/$(WASMVM_VERSION) -name "libwasmvm.x86_64.so" -exec cp -f {} ${DEVNET_BIN_DIR}/libwasmvm.x86_64.so \; ; \
+	else \
+		echo "Using existing lumera binaries from ${DEVNET_BIN_DIR}..."; \
+	fi; \
+	if [ ! -f "${DEVNET_BIN_DIR}/lumerad" ]; then \
+		echo "${DEVNET_BIN_DIR}/lumerad binary not found..."; \
 		exit 1; \
-	fi
+	fi; \
+	if [ ! -f "${DEVNET_BIN_DIR}/libwasmvm.x86_64.so" ]; then \
+		echo "${DEVNET_BIN_DIR}/libwasmvm.x86_64.so library not found..."; \
+		exit 1; \
+	fi; \
+	if [ "$${EXTERNAL_GENESIS_FILE}" = "1" ] && [ ! -f "$(CLAIMS_FILE)" ]; then \
+		CLAIM_TOTAL="$$(jq -r 'try (.app_state.claim.total_claimable_amount // "0") catch "0"' "$(EXTERNAL_GENESIS)")"; \
+		if [ "$${CLAIM_TOTAL}" != "0" ] && [ "$${CLAIM_TOTAL}" != "null" ] && ! "${DEVNET_BIN_DIR}/lumerad" start --help 2>&1 | grep -q -- '--skip-claims-check'; then \
+			echo "External genesis has claim.total_claimable_amount=$${CLAIM_TOTAL}, but no claims CSV was provided and ${DEVNET_BIN_DIR}/lumerad cannot skip claims loading."; \
+			echo "Set app_state.claim.total_claimable_amount to 0 for a no-claims devnet or provide EXTERNAL_CLAIMS_FILE."; \
+			exit 1; \
+		fi; \
+	fi; \
+	if [ "$(DEVNET_BUILD_TESTS)" = "1" ]; then \
+		$(MAKE) devnet-tests-build DEVNET_BIN_DIR="${DEVNET_BIN_DIR}"; \
+	else \
+		echo "Skipping devnet test binary build (DEVNET_BUILD_TESTS=0)."; \
+	fi; \
+	cp -f "${DEVNET_BIN_DIR}/lumerad" "${SHARED_RELEASE_DIR}/"; \
+	cp -f "${DEVNET_BIN_DIR}/libwasmvm.x86_64.so" "${SHARED_RELEASE_DIR}/"; \
+	$(MAKE) _devnet-stage-migration-scripts; \
+	cd devnet && \
+	${GO} mod tidy && \
+	CONFIG_JSON="$${CONFIG_JSON:-$(DEFAULT_CONFIG_JSON)}" \
+	VALIDATORS_JSON="$${VALIDATORS_JSON:-$(DEFAULT_VALIDATORS_JSON)}" \
+	DEVNET_SHARED_DIR="$(SHARED_DIR)" \
+	./scripts/configure.sh --bin-dir "${DEVNET_BIN_DIR}" &&\
+	DEVNET_SHARED_DIR="$(SHARED_DIR)" \
+	DEVNET_BIN_DIR="${DEVNET_BIN_DIR_ABS}" \
+	${GO} run . && \
+	if [ "$(DEVNET_DOCKER_BUILD)" = "1" ]; then \
+		START_MODE=bootstrap docker compose build; \
+	else \
+		echo "Skipping local docker compose build (DEVNET_DOCKER_BUILD=0)."; \
+	fi && \
+	echo "Initialization complete. Ready to start nodes."
 
 devnet-build-default:
 	@GENESIS_FILE="$$( $(MAKE) --no-print-directory _devnet-select-default-genesis )"; \
@@ -202,6 +238,64 @@ devnet-build-version: _check-devnet-build-version-cfg
 		EXTERNAL_GENESIS_FILE="$$(realpath "$$GENESIS_FILE")" \
 		EXTERNAL_CLAIMS_FILE="$$(realpath $(DEFAULT_CLAIMS_FILE))"
 
+# Stage a devnet runtime from an external genesis and pre-downloaded versioned
+# binaries. This is intended for remote execution workflows: it generates the
+# compose file and /tmp/<chain-id>/shared locally without building Docker images.
+# Usage: make devnet-stage-external-version VERSION=v1.12.0
+# Optional: EXTERNAL_GENESIS_FILE=/path/to/genesis.json EXTERNAL_CLAIMS_FILE=/path/to/claims.csv
+devnet-stage-external-version: _check-devnet-external-version-cfg
+	@rm -rf "$(REMOTE_DEVNET_STAGE_DIR)"
+	@mkdir -p "$(REMOTE_DEVNET_STAGE_DIR)"
+	@jq '.hermes.enabled = false' devnet/config/config.json > "$(REMOTE_CONFIG_JSON)"
+	@$(MAKE) devnet-build \
+		DEVNET_DIR="$(REMOTE_DEVNET_STAGE_DIR)" \
+		DEVNET_BUILD_LUMERA=0 \
+		DEVNET_BUILD_TESTS=0 \
+		DEVNET_DOCKER_BUILD=0 \
+		DEVNET_BIN_DIR=devnet/bin-$(VERSION) \
+		CONFIG_JSON="$(REMOTE_CONFIG_JSON)" \
+		EXTERNAL_GENESIS_FILE="$$(realpath "$(DEVNET_EXTERNAL_GENESIS_FILE)")" \
+		$(if $(EXTERNAL_CLAIMS_FILE),EXTERNAL_CLAIMS_FILE="$$(realpath "$(EXTERNAL_CLAIMS_FILE)")",)
+
+# Build/stage locally from downloaded binaries, then run the Dockerized devnet
+# on a remote host. The remote host only needs ssh access plus Docker Compose.
+# Usage: make devnet-new-remote-version VERSION=v1.12.0
+devnet-new-remote-version: devnet-stage-external-version
+	@$(REMOTE_DEVNET_SSH) $(REMOTE_DEVNET_HOST) 'set -e; \
+		command -v docker >/dev/null; \
+		docker compose version >/dev/null; \
+		mkdir -p $(REMOTE_DEVNET_DIR)/devnet; \
+		if [ -f $(REMOTE_DEVNET_DIR)/devnet/docker-compose.yml ]; then \
+			cd $(REMOTE_DEVNET_DIR)/devnet && docker compose down --remove-orphans || true; \
+		fi; \
+		if command -v sudo >/dev/null 2>&1 && sudo -n true >/dev/null 2>&1; then \
+			sudo rm -rf $(DEVNET_DIR); \
+		elif rm -rf $(DEVNET_DIR) 2>/tmp/lumera-devnet-rm.err; then \
+			:; \
+		elif command -v docker >/dev/null 2>&1; then \
+			docker run --rm -v /tmp:/host-tmp busybox:1.36 sh -c "rm -rf /host-tmp/$$(basename $(DEVNET_DIR))" || { cat /tmp/lumera-devnet-rm.err >&2; rm -f /tmp/lumera-devnet-rm.err; exit 1; }; \
+		else \
+			cat /tmp/lumera-devnet-rm.err >&2; \
+			rm -f /tmp/lumera-devnet-rm.err; \
+			exit 1; \
+		fi; \
+		rm -f /tmp/lumera-devnet-rm.err; \
+		mkdir -p $(REMOTE_DEVNET_DIR)/devnet $(SHARED_DIR)'
+	@$(REMOTE_DEVNET_RSYNC) --delete \
+		devnet/docker-compose.yml \
+		devnet/dockerfile \
+		devnet/scripts \
+		devnet/hermes \
+		$(REMOTE_DEVNET_HOST):$(REMOTE_DEVNET_DIR)/devnet/
+	@$(REMOTE_DEVNET_RSYNC) --delete \
+		$(REMOTE_DEVNET_STAGE_DIR)/shared/ \
+		$(REMOTE_DEVNET_HOST):$(SHARED_DIR)/
+	@$(REMOTE_DEVNET_SSH) $(REMOTE_DEVNET_HOST) 'set -e; \
+		cd $(REMOTE_DEVNET_DIR)/devnet; \
+		docker compose build; \
+		START_MODE=auto docker compose up -d --remove-orphans; \
+		docker compose ps'
+
 _check-devnet-version-bin:
 	@if [ -z "$(VERSION)" ]; then \
 		echo "VERSION is required (e.g. VERSION=v1.12.0)"; \
@@ -217,6 +311,17 @@ _check-devnet-build-version-cfg: _check-devnet-version-bin
 	@[ -f "$$(realpath $(DEFAULT_GENESIS_FILE))" ] || (echo "Missing DEFAULT_GENESIS_FILE: $(DEFAULT_GENESIS_FILE)"; exit 1)
 	@[ -f "$$(realpath $(DEFAULT_GENESIS_EVM_FILE))" ] || (echo "Missing DEFAULT_GENESIS_EVM_FILE: $(DEFAULT_GENESIS_EVM_FILE)"; exit 1)
 	@[ -f "$$(realpath $(DEFAULT_CLAIMS_FILE))" ] || (echo "Missing DEFAULT_CLAIMS_FILE: $(DEFAULT_CLAIMS_FILE)"; exit 1)
+
+_check-devnet-external-version-cfg: _check-devnet-version-bin
+	@if [ -z "$(DEVNET_EXTERNAL_GENESIS_FILE)" ]; then \
+		echo "EXTERNAL_GENESIS_FILE is required (default: $(REMOTE_EXTERNAL_GENESIS_FILE))"; \
+		exit 1; \
+	fi
+	@[ -f "$$(realpath "$(DEVNET_EXTERNAL_GENESIS_FILE)")" ] || (echo "Missing EXTERNAL_GENESIS_FILE: $(DEVNET_EXTERNAL_GENESIS_FILE)"; exit 1)
+	@if [ -n "$(EXTERNAL_CLAIMS_FILE)" ] && [ ! -f "$(EXTERNAL_CLAIMS_FILE)" ]; then \
+		echo "Missing EXTERNAL_CLAIMS_FILE: $(EXTERNAL_CLAIMS_FILE)"; \
+		exit 1; \
+	fi
 
 .PHONY: devnet-build-1111 devnet-build-1120
 devnet-build-1111:

--- a/devnet/.gitignore
+++ b/devnet/.gitignore
@@ -3,5 +3,8 @@ bin/
 bin-*/
 logs/
 
-# Stray binary from `go build ./tests/gen-activity` without -o
+# Stray binaries from `go build ./tests/<tool>` without -o, run from devnet/:
+# Go names the binary after the package dir and drops it in the cwd. Use the
+# Makefile.devnet targets (which pass -o into bin/) instead.
 /gen-activity
+/evmigration

--- a/devnet/go.mod
+++ b/devnet/go.mod
@@ -21,6 +21,7 @@ replace (
 require (
 	cosmossdk.io/api v0.9.2
 	cosmossdk.io/math v1.5.3
+	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/LumeraProtocol/lumera v1.20.0-rc2
 	github.com/LumeraProtocol/sdk-go v1.0.9
 	github.com/cosmos/cosmos-sdk v0.53.6
@@ -150,6 +151,7 @@ require (
 	github.com/improbable-eng/grpc-web v0.15.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/compress v1.18.4 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
@@ -159,6 +161,7 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/minio/highwayhash v1.0.3 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/devnet/go.mod
+++ b/devnet/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/ethereum/go-ethereum v1.17.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/pelletier/go-toml/v2 v2.2.4
 	golang.org/x/crypto v0.48.0
 )
 
@@ -170,7 +171,6 @@ require (
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a // indirect
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/devnet/go.sum
+++ b/devnet/go.sum
@@ -119,6 +119,7 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
@@ -304,6 +305,7 @@ github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a h1:W8mUrRp6NOV
 github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a/go.mod h1:sTwzHBvIzm2RfVCGNEBZgRyjwK40bVoun3ZnGOCafNM=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
 github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
@@ -616,6 +618,7 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hdevalence/ed25519consensus v0.2.0 h1:37ICyZqdyj0lAZ8P4D1d1id3HqbbG1N3iBb1Tb4rdcU=
 github.com/hdevalence/ed25519consensus v0.2.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
+github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=

--- a/devnet/go.sum
+++ b/devnet/go.sum
@@ -89,6 +89,8 @@ github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 h1:/vQbFIOMb
 github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4/go.mod h1:hN7oaIRCjzsZ2dE+yG5k+rsdt3qcwykqK6HVGcKwsw4=
 github.com/99designs/keyring v1.2.2 h1:pZd3neh/EmUzWONb35LxQfvuY7kiSXAq3HQd97+XBn0=
 github.com/99designs/keyring v1.2.2/go.mod h1:wes/FrByc8j7lFOAGLGSNEg8f/PaI3cgTBqhFkHUrPk=
+github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkkhIiSjQ=
+github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -117,6 +119,7 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
@@ -301,6 +304,7 @@ github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a h1:W8mUrRp6NOV
 github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a/go.mod h1:sTwzHBvIzm2RfVCGNEBZgRyjwK40bVoun3ZnGOCafNM=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/danieljoos/wincred v1.2.2 h1:774zMFJrqaeYCK2W57BgAem/MLi6mtSE47MB6BOJ0i0=
 github.com/danieljoos/wincred v1.2.2/go.mod h1:w7w4Utbrz8lqeMbDAK0lkNJUv5sAOkFi7nd/ogr0Uh8=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -612,6 +616,7 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hdevalence/ed25519consensus v0.2.0 h1:37ICyZqdyj0lAZ8P4D1d1id3HqbbG1N3iBb1Tb4rdcU=
 github.com/hdevalence/ed25519consensus v0.2.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
+github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
 github.com/holiman/uint256 v1.3.2 h1:a9EgMPSC1AAaj1SZL5zIQD3WbwTuHrMGOerLjGmM/TA=
@@ -663,6 +668,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -704,6 +711,7 @@ github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -711,6 +719,7 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -722,6 +731,8 @@ github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
+github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=
 github.com/minio/highwayhash v1.0.3/go.mod h1:GGYsuwP/fPD6Y9hMiXuapVvlIUEhFhMTh0rxU3ik1LQ=
@@ -1230,6 +1241,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1324,6 +1336,7 @@ golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=

--- a/devnet/main.go
+++ b/devnet/main.go
@@ -24,10 +24,12 @@ func main() {
 	}
 
 	if useExistingGenesis {
+		sharedDir := os.Getenv("DEVNET_SHARED_DIR")
+		if sharedDir == "" {
+			sharedDir = filepath.Join("/tmp", cfg.Chain.ID, generators.SubFolderShared)
+		}
 		data, err := os.ReadFile(filepath.Join(
-			"/tmp",
-			cfg.Chain.ID,
-			generators.SubFolderShared,
+			sharedDir,
 			generators.SubFolderConfig,
 			"external_genesis.json"))
 		if err != nil {

--- a/devnet/scripts/common.sh
+++ b/devnet/scripts/common.sh
@@ -24,6 +24,23 @@ have() {
 	command -v "$1" >/dev/null 2>&1
 }
 
+lumerad_claims_start_flags() {
+	local daemon="$1"
+	local claims_file="$2"
+	local help
+
+	[ -f "${claims_file}" ] || return 0
+
+	help="$("${daemon}" start --help 2>&1 || true)"
+	if grep -q -- '--claims-path' <<<"${help}"; then
+		if grep -q -- '--skip-claims-check' <<<"${help}"; then
+			printf '%s\n' "--skip-claims-check=false --claims-path=${claims_file}"
+		else
+			printf '%s\n' "--claims-path=${claims_file}"
+		fi
+	fi
+}
+
 wait_for_file() {
 	while [[ ! -s "$1" ]]; do
 		sleep 1

--- a/devnet/scripts/configure.sh
+++ b/devnet/scripts/configure.sh
@@ -135,7 +135,7 @@ fi
 CHAIN_ID="$(jq -r '.chain.id' "${CONFIG_JSON}")"
 echo "[CONFIGURE] Lumera chain ID is $CHAIN_ID"
 
-SHARED_DIR="/tmp/${CHAIN_ID}/shared"
+SHARED_DIR="${DEVNET_SHARED_DIR:-/tmp/${CHAIN_ID}/shared}"
 CFG_DIR="${SHARED_DIR}/config"
 RELEASE_DIR="${SHARED_DIR}/release"
 

--- a/devnet/scripts/lumera-helper.sh
+++ b/devnet/scripts/lumera-helper.sh
@@ -190,11 +190,7 @@ start_local_lumera_if_needed() {
 	archive_log_file "${VALIDATOR_LOG}"
 
 	claims_local="${DAEMON_HOME}/config/claims.csv"
-	if [ -f "${claims_local}" ] &&
-		"${DAEMON}" start --help 2>&1 | grep -q 'skip-claims-check' &&
-		"${DAEMON}" start --help 2>&1 | grep -q 'claims-path'; then
-		extra_start_flags="--skip-claims-check=false --claims-path=${claims_local}"
-	fi
+	extra_start_flags="$(lumerad_claims_start_flags "${DAEMON}" "${claims_local}")"
 
 	echo "INFO: starting ${DAEMON}; logging to ${VALIDATOR_LOG}"
 	# shellcheck disable=SC2086

--- a/devnet/scripts/restart.sh
+++ b/devnet/scripts/restart.sh
@@ -24,6 +24,8 @@ LUMERA_RPC_PORT="${LUMERA_RPC_PORT:-26657}"
 LUMERA_RPC_ADDR="${LUMERA_RPC_ADDR:-http://localhost:${LUMERA_RPC_PORT}}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/common.sh"
 STOP_SCRIPT="${STOP_SCRIPT:-${SCRIPT_DIR}/stop.sh}"
 
 log() {
@@ -88,10 +90,7 @@ start_lumera() {
 	mkdir -p "$(dirname "${VALIDATOR_LOG}")" "${DAEMON_HOME}/config"
 
 	CLAIMS_LOCAL="${DAEMON_HOME}/config/claims.csv"
-	EXTRA_START_FLAGS=""
-	if [ -f "${CLAIMS_LOCAL}" ] && "${DAEMON}" start --help 2>&1 | grep -q 'skip-claims-check' && "${DAEMON}" start --help 2>&1 | grep -q 'claims-path'; then
-		EXTRA_START_FLAGS="--skip-claims-check=false --claims-path=${CLAIMS_LOCAL}"
-	fi
+	EXTRA_START_FLAGS="$(lumerad_claims_start_flags "${DAEMON}" "${CLAIMS_LOCAL}")"
 	log "Starting ${DAEMON}..."
 	# shellcheck disable=SC2086
 	"${DAEMON}" start --home "${DAEMON_HOME}" ${EXTRA_START_FLAGS} >"${VALIDATOR_LOG}" 2>&1 &

--- a/devnet/scripts/start.sh
+++ b/devnet/scripts/start.sh
@@ -331,9 +331,8 @@ start_lumera() {
 
 	echo "[BOOT] ${MONIKER}: Starting lumerad..."
 	CLAIMS_LOCAL="${DAEMON_HOME}/config/claims.csv"
-	EXTRA_START_FLAGS=""
-	if [ -f "${CLAIMS_LOCAL}" ] && "${DAEMON}" start --help 2>&1 | grep -q 'skip-claims-check' && "${DAEMON}" start --help 2>&1 | grep -q 'claims-path'; then
-		EXTRA_START_FLAGS="--skip-claims-check=false --claims-path=${CLAIMS_LOCAL}"
+	EXTRA_START_FLAGS="$(lumerad_claims_start_flags "${DAEMON}" "${CLAIMS_LOCAL}")"
+	if [ -n "${EXTRA_START_FLAGS}" ]; then
 		echo "[BOOT] ${MONIKER}: Claims CSV found, loading claim records at genesis"
 	fi
 	# shellcheck disable=SC2086

--- a/devnet/scripts/supernode-setup.sh
+++ b/devnet/scripts/supernode-setup.sh
@@ -93,6 +93,7 @@ LUMERA_RPC_ADDR="http://localhost:${LUMERA_RPC_PORT}"
 # KEY_NAME: validator's keyring key, used as --from for on-chain txs
 # SN_KEY_NAME: supernode's own keyring key (derived from MONIKER)
 KEY_NAME="${MONIKER}_key"
+VALIDATOR_BASE_KEY_NAME="${KEY_NAME}"
 SN_BASEDIR="/root/.supernode"
 SN_CONFIG="${SN_BASEDIR}/config.yml"
 SN_KEYRING_HOME="${SN_BASEDIR}/keys"
@@ -236,7 +237,77 @@ validator_is_multisig() {
 
 validator_multisig_signer_key() {
 	local idx="$1"
+	local val_num base_without_evm base_without_new_msig candidate
+	local candidates=()
+
+	candidates+=("${KEY_NAME}-signer-${idx}")
+
+	if [[ "${KEY_NAME}" == *_evm ]]; then
+		val_num="$(echo "${MONIKER}" | grep -oE '[0-9]+$' || true)"
+		if [[ -n "${val_num}" ]]; then
+			candidates+=("val${val_num}-evm-signer-${idx}")
+		fi
+		base_without_evm="${KEY_NAME%_evm}"
+		candidates+=("${base_without_evm}-new-signer-${idx}")
+	elif [[ "${KEY_NAME}" == *-new-msig ]]; then
+		base_without_new_msig="${KEY_NAME%-new-msig}"
+		candidates+=("${base_without_new_msig}-new-signer-${idx}")
+	fi
+
+	candidates+=("${VALIDATOR_BASE_KEY_NAME}-new-signer-${idx}")
+	candidates+=("${VALIDATOR_BASE_KEY_NAME}-signer-${idx}")
+
+	for candidate in "${candidates[@]}"; do
+		if daemon_key_address "${candidate}" >/dev/null 2>&1; then
+			printf '%s\n' "${candidate}"
+			return 0
+		fi
+	done
+
 	printf '%s-signer-%s\n' "${KEY_NAME}" "${idx}"
+}
+
+validator_key_valoper_address() {
+	local key_name="$1"
+	$DAEMON keys show "${key_name}" --bech val -a --keyring-backend "${KEYRING_BACKEND}" 2>/dev/null
+}
+
+staking_validator_exists() {
+	local valoper_addr="$1"
+	$DAEMON q staking validator "${valoper_addr}" --output json >/dev/null 2>&1
+}
+
+active_validator_key_candidates() {
+	local base="${VALIDATOR_BASE_KEY_NAME}"
+	local candidate seen=""
+
+	for candidate in "${base}_evm" "${base}-new-msig" "${KEY_NAME}" "${base}"; do
+		if [[ -n "${candidate}" && " ${seen} " != *" ${candidate} "* ]]; then
+			printf '%s\n' "${candidate}"
+			seen="${seen} ${candidate}"
+		fi
+	done
+}
+
+select_active_validator_key() {
+	local candidate candidate_addr candidate_valoper
+
+	while IFS= read -r candidate; do
+		[[ -z "${candidate}" ]] && continue
+		candidate_addr="$(daemon_key_address "${candidate}" || true)"
+		[[ -z "${candidate_addr}" ]] && continue
+		candidate_valoper="$(validator_key_valoper_address "${candidate}" || true)"
+		[[ -z "${candidate_valoper}" ]] && continue
+		if staking_validator_exists "${candidate_valoper}"; then
+			KEY_NAME="${candidate}"
+			VAL_ADDR="${candidate_addr}"
+			VALOPER_ADDR="${candidate_valoper}"
+			return 0
+		fi
+	done < <(active_validator_key_candidates)
+
+	VAL_ADDR="$(daemon_key_address "${KEY_NAME}" || true)"
+	VALOPER_ADDR="$(validator_key_valoper_address "${KEY_NAME}" || true)"
 }
 
 query_account_number_sequence() {
@@ -390,7 +461,35 @@ ensure_evm_key_from_mnemonic() {
 }
 
 ensure_supernode_evm_key_from_mnemonic() {
-	ensure_key_from_mnemonic_in_home "$SN_KEYRING_HOME" "supernode keyring" "$1" "$2" "eth_secp256k1" "$SN_EVM_HD_PATH"
+	local key_name="$1"
+	local mnemonic="$2"
+	local info_file backup_file timestamp
+
+	if ! command -v "$SN" >/dev/null 2>&1 || [[ ! -f "$SN_CONFIG" ]]; then
+		ensure_key_from_mnemonic_in_home "$SN_KEYRING_HOME" "supernode keyring" "$key_name" "$mnemonic" "eth_secp256k1" "$SN_EVM_HD_PATH"
+		return 0
+	fi
+
+	if supernode_keyring_can_read_key "$key_name"; then
+		echo "[SN] ${key_name} already exists in supernode keyring and is readable by ${SN}."
+		return 0
+	fi
+
+	info_file="$(supernode_keyring_info_file "$key_name")"
+	if [[ -f "$info_file" ]]; then
+		timestamp="$(date +%Y%m%d%H%M%S)"
+		backup_file="${info_file}.bak-${timestamp}"
+		echo "[SN] Backing up unreadable supernode keyring entry ${info_file} -> ${backup_file}."
+		mv "$info_file" "$backup_file"
+	fi
+
+	echo "[SN] Recovering ${key_name} in supernode keyring with ${SN}."
+	if ! "$SN" keys recover "$key_name" -d "$SN_BASEDIR" --mnemonic="$mnemonic" >/dev/null; then
+		if [[ -n "${backup_file:-}" && -f "$backup_file" && ! -f "$info_file" ]]; then
+			mv "$backup_file" "$info_file"
+		fi
+		return 1
+	fi
 }
 
 ensure_legacy_key_from_mnemonic() {
@@ -445,6 +544,29 @@ ensure_key_from_mnemonic_in_home() {
 	fi
 
 	printf '%s\n' "${mnemonic}" | run "${cmd[@]}" >/dev/null
+}
+
+supernode_keyring_info_file() {
+	local key_name="$1"
+	printf '%s/keyring-%s/%s.info\n' "$SN_KEYRING_HOME" "$KEYRING_BACKEND" "$key_name"
+}
+
+supernode_keyring_can_read_key() {
+	local key_name="$1"
+	local out
+
+	if [[ ! -f "$SN_CONFIG" ]]; then
+		return 1
+	fi
+
+	if ! out="$("$SN" keys list -d "$SN_BASEDIR" 2>/dev/null)"; then
+		return 1
+	fi
+
+	awk -v key="$key_name" '
+		NR > 2 && $1 == key { found = 1 }
+		END { exit(found ? 0 : 1) }
+	' <<<"$out"
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -1018,6 +1140,8 @@ install_supernode_binary() {
 	if [ -f "$SN_BIN_DST" ]; then
 		if cmp -s "$src" "$SN_BIN_DST"; then
 			echo "[SN] supernode binary already installed and up-to-date."
+		elif installed_binary_is_newer "$SN_BIN_DST" "$src"; then
+			echo "[SN] Installed supernode binary is newer than shared release; keeping installed binary."
 		else
 			echo "[SN] supernode binary is outdated; updating."
 			run cp -f "$src" "$SN_BIN_DST"
@@ -1029,8 +1153,10 @@ install_supernode_binary() {
 		chmod +x "$SN_BIN_DST"
 	fi
 
-	# 3) Ensure /usr/local/bin/supernode -> supernode-linux-amd64 symlink
-	local link="/usr/local/bin/supernode"
+	# 3) Ensure companion "supernode" symlink points to supernode-linux-amd64
+	local bin_dir link
+	bin_dir="$(dirname "$SN_BIN_DST")"
+	link="${bin_dir}/supernode"
 	if [ -e "$link" ] && [ ! -L "$link" ]; then
 		echo "[SN] Found regular file at $link; removing to create symlink."
 		rm -f "$link"
@@ -1038,7 +1164,7 @@ install_supernode_binary() {
 
 	# Create/update symlink; ensure it points to supernode-linux-amd64
 	(
-		cd /usr/local/bin || exit 1
+		cd "$bin_dir" || exit 1
 		if [ -L "supernode" ]; then
 			current_target="$(readlink supernode)"
 			if [ "$current_target" != "${SN}" ]; then
@@ -1052,6 +1178,34 @@ install_supernode_binary() {
 			ln -sfn "${SN}" "supernode"
 		fi
 	)
+}
+
+binary_version() {
+	local bin="$1"
+	local version
+
+	version="$("$bin" version 2>/dev/null |
+		grep -Eo 'v?[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?' |
+		head -n1 || true)"
+	normalize_version "$version"
+}
+
+installed_binary_is_newer() {
+	local installed="$1"
+	local source="$2"
+	local installed_version source_version
+
+	installed_version="$(binary_version "$installed" || true)"
+	source_version="$(binary_version "$source" || true)"
+
+	if [[ -z "$installed_version" || -z "$source_version" ]]; then
+		return 1
+	fi
+	if versions_match "$installed_version" "$source_version"; then
+		return 1
+	fi
+
+	version_ge "$installed_version" "$source_version"
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -1174,12 +1328,21 @@ configure_supernode() {
 	# Resolve all addresses needed for registration and funding
 	SN_ADDR="$(run_capture $DAEMON keys show "$SN_KEY_NAME" -a --keyring-backend "$KEYRING_BACKEND")"
 	echo "[SN] Supernode address: $SN_ADDR"
-	VAL_ADDR="$(run_capture $DAEMON keys show "$KEY_NAME" -a --keyring-backend "$KEYRING_BACKEND")"
+	select_active_validator_key
+	if [[ -z "${VAL_ADDR:-}" || -z "${VALOPER_ADDR:-}" ]]; then
+		echo "[SN] ERROR: Unable to resolve active validator key/address for ${VALIDATOR_BASE_KEY_NAME}."
+		exit 1
+	fi
+	if [[ "${KEY_NAME}" != "${VALIDATOR_BASE_KEY_NAME}" ]]; then
+		echo "[SN] Using migrated validator key ${KEY_NAME} for on-chain supernode operations."
+	fi
 	echo "[SN] Validator address: $VAL_ADDR"
-	VALOPER_ADDR="$(run_capture $DAEMON keys show "$KEY_NAME" --bech val -a --keyring-backend "$KEYRING_BACKEND")"
 	echo "[SN] Validator operator address: $VALOPER_ADDR"
 
 	GENESIS_ADDR="$(registry_account_address "${KEY_NAME}")"
+	if [[ -z "${GENESIS_ADDR}" && "${KEY_NAME}" != "${VALIDATOR_BASE_KEY_NAME}" ]]; then
+		GENESIS_ADDR="$(registry_account_address "${VALIDATOR_BASE_KEY_NAME}")"
+	fi
 	if [[ -z "${GENESIS_ADDR}" ]]; then
 		echo "[SN] ERROR: Missing validator funding address for ${KEY_NAME} in accounts registry."
 		exit 1

--- a/devnet/tests/common/migration.go
+++ b/devnet/tests/common/migration.go
@@ -251,8 +251,26 @@ func parseMigrationRecord(out string) (MigrationRecord, bool, error) {
 // appear as JSON numbers or quoted strings. These helpers accept both.
 
 func flexInt(raw json.RawMessage) (int, error) {
-	v, err := flexInt64(raw)
-	return int(v), err
+	if len(raw) == 0 {
+		return 0, nil
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		asString = strings.TrimSpace(asString)
+		if asString == "" {
+			return 0, nil
+		}
+		n, err := strconv.ParseInt(asString, 10, strconv.IntSize)
+		if err != nil {
+			return 0, fmt.Errorf("parse %q as int: %w", asString, err)
+		}
+		return int(n), nil
+	}
+	var asInt int
+	if err := json.Unmarshal(raw, &asInt); err == nil {
+		return asInt, nil
+	}
+	return 0, fmt.Errorf("unsupported numeric format: %s", string(raw))
 }
 
 func flexInt64(raw json.RawMessage) (int64, error) {

--- a/devnet/tests/common/migration.go
+++ b/devnet/tests/common/migration.go
@@ -1,0 +1,307 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// MigrationParams mirrors the governance-controlled x/evmigration params that
+// gate the migration window and bound per-block work.
+type MigrationParams struct {
+	EnableMigration         bool
+	MigrationEndTime        int64
+	MaxMigrationsPerBlock   int
+	MaxValidatorDelegations int
+	MaxMultisigSubKeys      int
+}
+
+// MigrationEstimate is the result of an evmigration migration-estimate query for
+// one legacy address.
+type MigrationEstimate struct {
+	WouldSucceed       bool
+	RejectionReason    string
+	DelegationCount    int
+	UnbondingCount     int
+	RedelegationCount  int
+	AuthzGrantCount    int
+	FeegrantCount      int
+	ActionCount        int
+	ValDelegationCount int
+	IsValidator        bool
+	IsMultisig         bool
+	BalanceSummary     string
+}
+
+// MigrationRecord is an on-chain evmigration record mapping a legacy address to
+// its new EVM-compatible address.
+type MigrationRecord struct {
+	LegacyAddress string
+	NewAddress    string
+	Height        int64
+}
+
+// MigrationStats is the global migration progress from the migration-stats query.
+type MigrationStats struct {
+	TotalMigrated           int
+	TotalLegacy             int
+	TotalLegacyStaked       int
+	TotalValidatorsMigrated int
+	TotalValidatorsLegacy   int
+}
+
+// MigrationStats queries the global migration statistics.
+func (c *ChainCLI) MigrationStats() (MigrationStats, error) {
+	out, err := c.Run("query", "evmigration", "migration-stats")
+	if err != nil {
+		return MigrationStats{}, fmt.Errorf("query migration-stats: %s: %w", truncate(out, 200), err)
+	}
+	return parseMigrationStats(out)
+}
+
+func parseMigrationStats(out string) (MigrationStats, error) {
+	payload := out
+	if extracted, ok := ExtractJSONPayload(out); ok {
+		payload = extracted
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		return MigrationStats{}, fmt.Errorf("parse migration-stats: %s: %w", truncate(payload, 200), err)
+	}
+	var s MigrationStats
+	var err error
+	if s.TotalMigrated, err = flexInt(raw["total_migrated"]); err != nil {
+		return MigrationStats{}, fmt.Errorf("migration-stats.total_migrated: %w", err)
+	}
+	if s.TotalLegacy, err = flexInt(raw["total_legacy"]); err != nil {
+		return MigrationStats{}, fmt.Errorf("migration-stats.total_legacy: %w", err)
+	}
+	if s.TotalLegacyStaked, err = flexInt(raw["total_legacy_staked"]); err != nil {
+		return MigrationStats{}, fmt.Errorf("migration-stats.total_legacy_staked: %w", err)
+	}
+	if s.TotalValidatorsMigrated, err = flexInt(raw["total_validators_migrated"]); err != nil {
+		return MigrationStats{}, fmt.Errorf("migration-stats.total_validators_migrated: %w", err)
+	}
+	if s.TotalValidatorsLegacy, err = flexInt(raw["total_validators_legacy"]); err != nil {
+		return MigrationStats{}, fmt.Errorf("migration-stats.total_validators_legacy: %w", err)
+	}
+	return s, nil
+}
+
+// MigrationParams queries the evmigration module parameters.
+func (c *ChainCLI) MigrationParams() (MigrationParams, error) {
+	out, err := c.Run("query", "evmigration", "params")
+	if err != nil {
+		return MigrationParams{}, fmt.Errorf("query evmigration params: %s: %w", truncate(out, 200), err)
+	}
+	return parseMigrationParams(out)
+}
+
+// MigrationEstimate queries the migration estimate for a legacy address.
+func (c *ChainCLI) MigrationEstimate(addr string) (MigrationEstimate, error) {
+	out, err := c.Run("query", "evmigration", "migration-estimate", addr)
+	if err != nil {
+		return MigrationEstimate{}, fmt.Errorf("query migration-estimate %s: %s: %w", addr, truncate(out, 200), err)
+	}
+	return parseMigrationEstimate(out)
+}
+
+// MigrationRecord queries the migration record for a legacy address. The bool
+// reports whether a record exists (false when the account is not yet migrated).
+func (c *ChainCLI) MigrationRecord(legacyAddr string) (MigrationRecord, bool, error) {
+	out, err := c.Run("query", "evmigration", "migration-record", legacyAddr)
+	if err != nil {
+		return MigrationRecord{}, false, fmt.Errorf("query migration-record %s: %s: %w", legacyAddr, truncate(out, 200), err)
+	}
+	return parseMigrationRecord(out)
+}
+
+// MigrationRecordByNewAddress queries the migration record by the new (EVM)
+// address. The bool reports whether a record exists.
+func (c *ChainCLI) MigrationRecordByNewAddress(newAddr string) (MigrationRecord, bool, error) {
+	out, err := c.Run("query", "evmigration", "migration-record-by-new-address", newAddr)
+	if err != nil {
+		return MigrationRecord{}, false, fmt.Errorf("query migration-record-by-new-address %s: %s: %w", newAddr, truncate(out, 200), err)
+	}
+	return parseMigrationRecord(out)
+}
+
+func parseMigrationParams(out string) (MigrationParams, error) {
+	payload := out
+	if extracted, ok := ExtractJSONPayload(out); ok {
+		payload = extracted
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &top); err != nil {
+		return MigrationParams{}, fmt.Errorf("parse evmigration params: %s: %w", truncate(payload, 200), err)
+	}
+	// Params may be wrapped in a "params" envelope or returned bare.
+	raw := top
+	if inner, ok := top["params"]; ok && len(inner) > 0 {
+		raw = map[string]json.RawMessage{}
+		if err := json.Unmarshal(inner, &raw); err != nil {
+			return MigrationParams{}, fmt.Errorf("parse evmigration params payload: %s: %w", truncate(string(inner), 200), err)
+		}
+	}
+
+	var p MigrationParams
+	var err error
+	if p.EnableMigration, err = flexBool(raw["enable_migration"]); err != nil {
+		return MigrationParams{}, fmt.Errorf("params.enable_migration: %w", err)
+	}
+	if p.MigrationEndTime, err = flexInt64(raw["migration_end_time"]); err != nil {
+		return MigrationParams{}, fmt.Errorf("params.migration_end_time: %w", err)
+	}
+	if p.MaxMigrationsPerBlock, err = flexInt(raw["max_migrations_per_block"]); err != nil {
+		return MigrationParams{}, fmt.Errorf("params.max_migrations_per_block: %w", err)
+	}
+	if p.MaxValidatorDelegations, err = flexInt(raw["max_validator_delegations"]); err != nil {
+		return MigrationParams{}, fmt.Errorf("params.max_validator_delegations: %w", err)
+	}
+	if p.MaxMultisigSubKeys, err = flexInt(raw["max_multisig_sub_keys"]); err != nil {
+		return MigrationParams{}, fmt.Errorf("params.max_multisig_sub_keys: %w", err)
+	}
+	return p, nil
+}
+
+func parseMigrationEstimate(out string) (MigrationEstimate, error) {
+	payload := out
+	if extracted, ok := ExtractJSONPayload(out); ok {
+		payload = extracted
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(payload), &raw); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("parse migration-estimate: %s: %w", truncate(payload, 200), err)
+	}
+
+	var est MigrationEstimate
+	var err error
+	if est.WouldSucceed, err = flexBool(raw["would_succeed"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.would_succeed: %w", err)
+	}
+	est.RejectionReason = flexString(raw["rejection_reason"])
+	est.BalanceSummary = flexString(raw["balance_summary"])
+	if est.DelegationCount, err = flexInt(raw["delegation_count"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.delegation_count: %w", err)
+	}
+	if est.UnbondingCount, err = flexInt(raw["unbonding_count"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.unbonding_count: %w", err)
+	}
+	if est.RedelegationCount, err = flexInt(raw["redelegation_count"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.redelegation_count: %w", err)
+	}
+	if est.AuthzGrantCount, err = flexInt(raw["authz_grant_count"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.authz_grant_count: %w", err)
+	}
+	if est.FeegrantCount, err = flexInt(raw["feegrant_count"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.feegrant_count: %w", err)
+	}
+	if est.ActionCount, err = flexInt(raw["action_count"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.action_count: %w", err)
+	}
+	if est.ValDelegationCount, err = flexInt(raw["val_delegation_count"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.val_delegation_count: %w", err)
+	}
+	if est.IsValidator, err = flexBool(raw["is_validator"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.is_validator: %w", err)
+	}
+	if est.IsMultisig, err = flexBool(raw["is_multisig"]); err != nil {
+		return MigrationEstimate{}, fmt.Errorf("migration-estimate.is_multisig: %w", err)
+	}
+	return est, nil
+}
+
+func parseMigrationRecord(out string) (MigrationRecord, bool, error) {
+	payload := out
+	if extracted, ok := ExtractJSONPayload(out); ok {
+		payload = extracted
+	}
+	var top struct {
+		Record *struct {
+			LegacyAddress string          `json:"legacy_address"`
+			NewAddress    string          `json:"new_address"`
+			Height        json.RawMessage `json:"height"`
+		} `json:"record"`
+	}
+	if err := json.Unmarshal([]byte(payload), &top); err != nil {
+		return MigrationRecord{}, false, fmt.Errorf("parse migration-record: %s: %w", truncate(payload, 200), err)
+	}
+	if top.Record == nil || (top.Record.LegacyAddress == "" && top.Record.NewAddress == "") {
+		return MigrationRecord{}, false, nil
+	}
+	height, err := flexInt64(top.Record.Height)
+	if err != nil {
+		return MigrationRecord{}, false, fmt.Errorf("migration-record.height: %w", err)
+	}
+	return MigrationRecord{
+		LegacyAddress: top.Record.LegacyAddress,
+		NewAddress:    top.Record.NewAddress,
+		Height:        height,
+	}, true, nil
+}
+
+// --- Flexible JSON scalar parsers ---
+// Cosmos SDK query output is inconsistent across versions: numeric fields may
+// appear as JSON numbers or quoted strings. These helpers accept both.
+
+func flexInt(raw json.RawMessage) (int, error) {
+	v, err := flexInt64(raw)
+	return int(v), err
+}
+
+func flexInt64(raw json.RawMessage) (int64, error) {
+	if len(raw) == 0 {
+		return 0, nil
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		asString = strings.TrimSpace(asString)
+		if asString == "" {
+			return 0, nil
+		}
+		n, err := strconv.ParseInt(asString, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("parse %q as int64: %w", asString, err)
+		}
+		return n, nil
+	}
+	var asInt64 int64
+	if err := json.Unmarshal(raw, &asInt64); err == nil {
+		return asInt64, nil
+	}
+	return 0, fmt.Errorf("unsupported numeric format: %s", string(raw))
+}
+
+func flexBool(raw json.RawMessage) (bool, error) {
+	if len(raw) == 0 {
+		return false, nil
+	}
+	var asBool bool
+	if err := json.Unmarshal(raw, &asBool); err == nil {
+		return asBool, nil
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		switch strings.TrimSpace(strings.ToLower(asString)) {
+		case "", "false", "0":
+			return false, nil
+		case "true", "1":
+			return true, nil
+		default:
+			return false, fmt.Errorf("parse %q as bool", asString)
+		}
+	}
+	return false, fmt.Errorf("unsupported bool format: %s", string(raw))
+}
+
+func flexString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var asString string
+	if err := json.Unmarshal(raw, &asString); err == nil {
+		return strings.TrimSpace(asString)
+	}
+	return strings.TrimSpace(string(raw))
+}

--- a/devnet/tests/common/migration.go
+++ b/devnet/tests/common/migration.go
@@ -260,11 +260,11 @@ func flexInt(raw json.RawMessage) (int, error) {
 		if asString == "" {
 			return 0, nil
 		}
-		n, err := strconv.ParseInt(asString, 10, strconv.IntSize)
+		n, err := strconv.Atoi(asString)
 		if err != nil {
 			return 0, fmt.Errorf("parse %q as int: %w", asString, err)
 		}
-		return int(n), nil
+		return n, nil
 	}
 	var asInt int
 	if err := json.Unmarshal(raw, &asInt); err == nil {

--- a/devnet/tests/common/migration.go
+++ b/devnet/tests/common/migration.go
@@ -219,9 +219,10 @@ func parseMigrationRecord(out string) (MigrationRecord, bool, error) {
 	}
 	var top struct {
 		Record *struct {
-			LegacyAddress string          `json:"legacy_address"`
-			NewAddress    string          `json:"new_address"`
-			Height        json.RawMessage `json:"height"`
+			LegacyAddress   string          `json:"legacy_address"`
+			NewAddress      string          `json:"new_address"`
+			Height          json.RawMessage `json:"height"`
+			MigrationHeight json.RawMessage `json:"migration_height"`
 		} `json:"record"`
 	}
 	if err := json.Unmarshal([]byte(payload), &top); err != nil {
@@ -230,7 +231,11 @@ func parseMigrationRecord(out string) (MigrationRecord, bool, error) {
 	if top.Record == nil || (top.Record.LegacyAddress == "" && top.Record.NewAddress == "") {
 		return MigrationRecord{}, false, nil
 	}
-	height, err := flexInt64(top.Record.Height)
+	heightRaw := top.Record.MigrationHeight
+	if len(heightRaw) == 0 {
+		heightRaw = top.Record.Height
+	}
+	height, err := flexInt64(heightRaw)
 	if err != nil {
 		return MigrationRecord{}, false, fmt.Errorf("migration-record.height: %w", err)
 	}

--- a/devnet/tests/common/migration_keys.go
+++ b/devnet/tests/common/migration_keys.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// recoverKeyArgs builds the `keys add --recover` argument list for importing a
+// mnemonic under an explicit key style (coin-type + algo). Explicit flags matter
+// on an EVM-enabled binary, whose default algo is eth_secp256k1: a legacy
+// (coin-118) account would otherwise derive the wrong address.
+func recoverKeyArgs(name, keyringBackend string, style KeyStyle, home string) []string {
+	args := []string{
+		"keys", "add", name,
+		"--recover",
+		"--coin-type", strconv.FormatUint(uint64(style.CoinType), 10),
+		"--algo", style.Algo,
+		"--keyring-backend", keyringBackend,
+		"--output", "json",
+	}
+	if home != "" {
+		args = append(args, "--home", home)
+	}
+	return args
+}
+
+// ImportKeyWithStyle restores a key from a mnemonic under an explicit key style
+// and returns its bech32 address. Use KeyStyleEVM to derive the coin-type-60
+// eth_secp256k1 destination key for a migration; use KeyStyleLegacy to restore a
+// coin-type-118 secp256k1 legacy key. Reruns should delete a stale key first.
+func (c *ChainCLI) ImportKeyWithStyle(name, mnemonic string, style KeyStyle) (string, error) {
+	args := recoverKeyArgs(name, c.keyringBackend(), style, c.Home)
+	cmd := exec.Command(c.Bin, args...)
+	cmd.Stdin = strings.NewReader(mnemonic + "\n")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("keys add --recover %s: %s: %w", name, strings.TrimSpace(string(out)), err)
+	}
+	return c.ShowAddress(name)
+}
+
+// claimLegacyAccountArgs builds the `tx evmigration claim-legacy-account` command
+// (without gas/broadcast flags, which SubmitTx appends). The legacy key signs.
+func claimLegacyAccountArgs(legacyKey, newKey string) []string {
+	return []string{
+		"tx", "evmigration", "claim-legacy-account", legacyKey, newKey,
+		"--from", legacyKey,
+	}
+}
+
+// ClaimLegacyAccount submits a single-sig MsgClaimLegacyAccount migrating the
+// legacy account (legacyKey) to the new EVM-compatible account (newKey), waiting
+// for inclusion. Both keys must already exist in the keyring. Returns the tx hash.
+func (c *ChainCLI) ClaimLegacyAccount(legacyKey, newKey string) (string, error) {
+	return c.SubmitTx(claimLegacyAccountArgs(legacyKey, newKey)...)
+}
+
+// DeriveEVMDestinationAddress imports the coin-type-60 eth_secp256k1 key derived
+// from the legacy mnemonic under destKeyName and returns its bech32 address.
+// This is the migration destination for a single-sig legacy account: the same
+// mnemonic deterministically yields a fresh EVM-compatible address.
+func (c *ChainCLI) DeriveEVMDestinationAddress(destKeyName, mnemonic string) (string, error) {
+	return c.ImportKeyWithStyle(destKeyName, mnemonic, KeyStyleEVM)
+}

--- a/devnet/tests/common/migration_keys_test.go
+++ b/devnet/tests/common/migration_keys_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRecoverKeyArgsEVMStyle(t *testing.T) {
+	args := recoverKeyArgs("alice-evm", "test", KeyStyleEVM, "")
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"keys add alice-evm",
+		"--recover",
+		"--coin-type 60",
+		"--algo eth_secp256k1",
+		"--keyring-backend test",
+		"--output json",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("recover args missing %q in:\n%s", want, joined)
+		}
+	}
+	if strings.Contains(joined, "--home") {
+		t.Errorf("did not expect --home when home empty:\n%s", joined)
+	}
+}
+
+func TestClaimLegacyAccountArgs(t *testing.T) {
+	args := claimLegacyAccountArgs("gen-0001", "gen-0001-evm")
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"tx evmigration claim-legacy-account gen-0001 gen-0001-evm",
+		"--from gen-0001",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("claim args missing %q in:\n%s", want, joined)
+		}
+	}
+}
+
+func TestRecoverKeyArgsLegacyStyleWithHome(t *testing.T) {
+	args := recoverKeyArgs("bob", "os", KeyStyleLegacy, "/root/.lumera")
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"--coin-type 118",
+		"--algo secp256k1",
+		"--keyring-backend os",
+		"--home /root/.lumera",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("recover args missing %q in:\n%s", want, joined)
+		}
+	}
+}

--- a/devnet/tests/common/migration_multisig.go
+++ b/devnet/tests/common/migration_multisig.go
@@ -30,7 +30,12 @@ func evmMultisigCompositeName(legacyBase string) string {
 // generateProofPayloadArgs builds `tx evmigration generate-proof-payload`. The
 // new-side signer pubkeys are supplied as a CSV of keyring key names (resolved
 // from the local keyring) and --new-threshold sets the destination K.
-func generateProofPayloadArgs(legacyAddr, kind, outPath, newSubPubKeysCSV string, newThreshold int, keyringBackend, home string) []string {
+//
+// --chain-id is REQUIRED: it is baked into the proof payload that every signer
+// signs. Omitting it makes generate-proof-payload fall back to the bech32 prefix
+// ("lumera"), so the keeper — verifying against the real chain id — rejects all
+// signatures with "migration signature verification failed".
+func generateProofPayloadArgs(legacyAddr, kind, outPath, newSubPubKeysCSV string, newThreshold int, chainID, keyringBackend, home string) []string {
 	args := []string{
 		"tx", "evmigration", "generate-proof-payload",
 		"--legacy", legacyAddr,
@@ -38,6 +43,7 @@ func generateProofPayloadArgs(legacyAddr, kind, outPath, newSubPubKeysCSV string
 		"--out", outPath,
 		"--new-sub-pub-keys", newSubPubKeysCSV,
 		"--new-threshold", strconv.Itoa(newThreshold),
+		"--chain-id", chainID,
 		"--keyring-backend", keyringBackend,
 		"--output", "json",
 	}
@@ -122,7 +128,7 @@ func (m *Multisig) MigrateMultisigProof(legacyBase, legacyAddr string, members [
 	// 2. generate-proof-payload.
 	proofPath := filepath.Join(workDir, "proof.json")
 	newSubCSV := strings.Join(newMembers, ",")
-	if out, err := m.exec(m.CLI.Bin, append(generateProofPayloadArgs(legacyAddr, "claim", proofPath, newSubCSV, threshold, m.keyring(), m.CLI.Home), m.nodeArgs()...)...); err != nil {
+	if out, err := m.exec(m.CLI.Bin, append(generateProofPayloadArgs(legacyAddr, "claim", proofPath, newSubCSV, threshold, m.CLI.ChainID, m.keyring(), m.CLI.Home), m.nodeArgs()...)...); err != nil {
 		return MultisigProofResult{}, fmt.Errorf("generate-proof-payload: %s: %w", truncate(out, 200), err)
 	}
 

--- a/devnet/tests/common/migration_multisig.go
+++ b/devnet/tests/common/migration_multisig.go
@@ -1,0 +1,175 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// evmMultisigMemberNames returns the keyring names for the destination EVM
+// multisig sub-keys derived from a legacy multisig base name. They mirror the
+// legacy members one-for-one ("evm-<base>-signer-{1..N}") so signer index i on
+// the legacy side pairs with index i on the new side during the proof flow.
+func evmMultisigMemberNames(legacyBase string, signers int) []string {
+	names := make([]string, 0, signers)
+	for i := 1; i <= signers; i++ {
+		names = append(names, fmt.Sprintf("evm-%s-signer-%d", legacyBase, i))
+	}
+	return names
+}
+
+// evmMultisigCompositeName returns the destination EVM multisig composite key
+// name for a legacy multisig base name.
+func evmMultisigCompositeName(legacyBase string) string {
+	return "evm-" + legacyBase
+}
+
+// generateProofPayloadArgs builds `tx evmigration generate-proof-payload`. The
+// new-side signer pubkeys are supplied as a CSV of keyring key names (resolved
+// from the local keyring) and --new-threshold sets the destination K.
+func generateProofPayloadArgs(legacyAddr, kind, outPath, newSubPubKeysCSV string, newThreshold int, keyringBackend, home string) []string {
+	args := []string{
+		"tx", "evmigration", "generate-proof-payload",
+		"--legacy", legacyAddr,
+		"--kind", kind,
+		"--out", outPath,
+		"--new-sub-pub-keys", newSubPubKeysCSV,
+		"--new-threshold", strconv.Itoa(newThreshold),
+		"--keyring-backend", keyringBackend,
+		"--output", "json",
+	}
+	if home != "" {
+		args = append(args, "--home", home)
+	}
+	return args
+}
+
+// signProofArgs builds `tx evmigration sign-proof` signing both the legacy side
+// (--from, a Cosmos secp256k1 sub-key) and the new side (--new-key, an
+// eth_secp256k1 sub-key) in one invocation.
+func signProofArgs(input, fromKey, newKey, outPath, chainID, keyringBackend, home string) []string {
+	args := []string{
+		"tx", "evmigration", "sign-proof", input,
+		"--from", fromKey,
+		"--new-key", newKey,
+		"--out", outPath,
+		"--chain-id", chainID,
+		"--keyring-backend", keyringBackend,
+	}
+	if home != "" {
+		args = append(args, "--home", home)
+	}
+	return args
+}
+
+// combineProofArgs builds `tx evmigration combine-proof <partials...> --out tx`.
+func combineProofArgs(partials []string, outPath string) []string {
+	args := []string{"tx", "evmigration", "combine-proof"}
+	args = append(args, partials...)
+	return append(args, "--out", outPath)
+}
+
+// submitProofArgs builds `tx evmigration submit-proof <tx>`.
+func submitProofArgs(txPath, chainID, node, keyringBackend string) []string {
+	return []string{
+		"tx", "evmigration", "submit-proof", txPath,
+		"--chain-id", chainID,
+		"--node", node,
+		"--keyring-backend", keyringBackend,
+		"--output", "json",
+		"--yes",
+	}
+}
+
+// MultisigProofResult is the outcome of a multisig proof migration.
+type MultisigProofResult struct {
+	NewName    string
+	NewAddress string
+	TxHash     string
+}
+
+// MigrateMultisigProof runs the full four-step multisig migration for a legacy
+// K-of-N multisig account whose member sub-keys (members) are already in the
+// keyring. It creates a fresh destination EVM multisig, then runs
+// generate-proof-payload -> sign-proof (×threshold) -> combine-proof ->
+// submit-proof, writing intermediate artifacts under workDir. It signs with the
+// first `threshold` members, pairing legacy index i with new index i (both sides
+// built --nosort in member order). Returns the destination key name/address and
+// the submit tx hash.
+func (m *Multisig) MigrateMultisigProof(legacyBase, legacyAddr string, members []string, threshold, signers int, workDir string) (MultisigProofResult, error) {
+	if len(members) < threshold {
+		return MultisigProofResult{}, fmt.Errorf("multisig %s has %d members, need at least %d to sign", legacyBase, len(members), threshold)
+	}
+
+	// 1. Build the destination EVM multisig (fresh eth_secp256k1 sub-keys + composite).
+	newMembers := evmMultisigMemberNames(legacyBase, signers)
+	for _, name := range newMembers {
+		if !m.CLI.HasKey(name) {
+			if _, err := m.CLI.AddKeyWithStyle(name, KeyStyleEVM); err != nil {
+				return MultisigProofResult{}, fmt.Errorf("create EVM sub-key %s: %w", name, err)
+			}
+		}
+	}
+	compositeName := evmMultisigCompositeName(legacyBase)
+	newAddr, err := m.CreateMultisigKey(compositeName, newMembers, threshold)
+	if err != nil {
+		return MultisigProofResult{}, fmt.Errorf("create destination EVM multisig %s: %w", compositeName, err)
+	}
+
+	// 2. generate-proof-payload.
+	proofPath := filepath.Join(workDir, "proof.json")
+	newSubCSV := strings.Join(newMembers, ",")
+	if out, err := m.exec(m.CLI.Bin, append(generateProofPayloadArgs(legacyAddr, "claim", proofPath, newSubCSV, threshold, m.keyring(), m.CLI.Home), m.nodeArgs()...)...); err != nil {
+		return MultisigProofResult{}, fmt.Errorf("generate-proof-payload: %s: %w", truncate(out, 200), err)
+	}
+
+	// 3. sign-proof for the first `threshold` member pairs.
+	partials := make([]string, 0, threshold)
+	for i := 0; i < threshold; i++ {
+		partial := filepath.Join(workDir, fmt.Sprintf("partial-%d.json", i+1))
+		args := signProofArgs(proofPath, members[i], newMembers[i], partial, m.CLI.ChainID, m.keyring(), m.CLI.Home)
+		if out, err := m.exec(m.CLI.Bin, args...); err != nil {
+			return MultisigProofResult{}, fmt.Errorf("sign-proof %s: %s: %w", members[i], truncate(out, 200), err)
+		}
+		partials = append(partials, partial)
+	}
+
+	// 4. combine-proof.
+	txPath := filepath.Join(workDir, "tx.json")
+	if out, err := m.exec(m.CLI.Bin, combineProofArgs(partials, txPath)...); err != nil {
+		return MultisigProofResult{}, fmt.Errorf("combine-proof: %s: %w", truncate(out, 200), err)
+	}
+
+	// 5. submit-proof.
+	out, err := m.exec(m.CLI.Bin, submitProofArgs(txPath, m.CLI.ChainID, m.CLI.RPC, m.keyring())...)
+	if err != nil {
+		return MultisigProofResult{}, fmt.Errorf("submit-proof: %s: %w", truncate(out, 200), err)
+	}
+	txHash, code, rawLog, ok := parseSyncBroadcast(out)
+	if !ok {
+		return MultisigProofResult{}, fmt.Errorf("submit-proof: no tx response: %s", truncate(out, 200))
+	}
+	if code != 0 {
+		return MultisigProofResult{}, fmt.Errorf("submit-proof rejected code=%d raw_log=%s", code, rawLog)
+	}
+	if err := m.CLI.WaitForTxInclusion(txHash, 60*time.Second); err != nil {
+		return MultisigProofResult{}, fmt.Errorf("submit-proof wait inclusion: %w", err)
+	}
+
+	return MultisigProofResult{NewName: compositeName, NewAddress: newAddr, TxHash: txHash}, nil
+}
+
+// MigrateMultisigProofTempDir runs MigrateMultisigProof using a fresh temp work
+// directory cleaned up afterward. This is the convenience entry point for
+// callers that do not need to retain the proof artifacts.
+func (c *ChainCLI) MigrateMultisigProof(legacyBase, legacyAddr string, members []string, threshold, signers int) (MultisigProofResult, error) {
+	dir, err := os.MkdirTemp("", "evmig-proof-"+legacyBase+"-*")
+	if err != nil {
+		return MultisigProofResult{}, fmt.Errorf("create work dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	return NewMultisig(c).MigrateMultisigProof(legacyBase, legacyAddr, members, threshold, signers, dir)
+}

--- a/devnet/tests/common/migration_multisig_test.go
+++ b/devnet/tests/common/migration_multisig_test.go
@@ -1,0 +1,94 @@
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProofFlowArgBuilders(t *testing.T) {
+	t.Run("generate-proof-payload", func(t *testing.T) {
+		args := generateProofPayloadArgs("lumera1legacy", "claim", "/tmp/proof.json", "evm-ms-signer-1,evm-ms-signer-2", 2, "test", "/root/.lumera")
+		joined := strings.Join(args, " ")
+		for _, want := range []string{
+			"tx evmigration generate-proof-payload",
+			"--legacy lumera1legacy",
+			"--kind claim",
+			"--out /tmp/proof.json",
+			"--new-sub-pub-keys evm-ms-signer-1,evm-ms-signer-2",
+			"--new-threshold 2",
+			"--keyring-backend test",
+			"--home /root/.lumera",
+		} {
+			if !strings.Contains(joined, want) {
+				t.Errorf("generate args missing %q in:\n%s", want, joined)
+			}
+		}
+	})
+
+	t.Run("sign-proof signs both sides", func(t *testing.T) {
+		args := signProofArgs("/tmp/proof.json", "ms-signer-1", "evm-ms-signer-1", "/tmp/partial-1.json", "lumera-devnet-1", "test", "")
+		joined := strings.Join(args, " ")
+		for _, want := range []string{
+			"tx evmigration sign-proof /tmp/proof.json",
+			"--from ms-signer-1",
+			"--new-key evm-ms-signer-1",
+			"--out /tmp/partial-1.json",
+			"--chain-id lumera-devnet-1",
+		} {
+			if !strings.Contains(joined, want) {
+				t.Errorf("sign args missing %q in:\n%s", want, joined)
+			}
+		}
+		if strings.Contains(joined, "--home") {
+			t.Errorf("did not expect --home when home empty:\n%s", joined)
+		}
+	})
+
+	t.Run("combine-proof lists all partials", func(t *testing.T) {
+		args := combineProofArgs([]string{"/tmp/p1.json", "/tmp/p2.json"}, "/tmp/tx.json")
+		joined := strings.Join(args, " ")
+		for _, want := range []string{
+			"tx evmigration combine-proof /tmp/p1.json /tmp/p2.json",
+			"--out /tmp/tx.json",
+		} {
+			if !strings.Contains(joined, want) {
+				t.Errorf("combine args missing %q in:\n%s", want, joined)
+			}
+		}
+	})
+
+	t.Run("submit-proof", func(t *testing.T) {
+		args := submitProofArgs("/tmp/tx.json", "lumera-devnet-1", "tcp://localhost:26657", "test")
+		joined := strings.Join(args, " ")
+		for _, want := range []string{
+			"tx evmigration submit-proof /tmp/tx.json",
+			"--chain-id lumera-devnet-1",
+			"--node tcp://localhost:26657",
+			"--keyring-backend test",
+			"--yes",
+		} {
+			if !strings.Contains(joined, want) {
+				t.Errorf("submit args missing %q in:\n%s", want, joined)
+			}
+		}
+	})
+}
+
+func TestEVMMultisigMemberNames(t *testing.T) {
+	got := evmMultisigMemberNames("gen-msig35-0001", 5)
+	want := []string{
+		"evm-gen-msig35-0001-signer-1", "evm-gen-msig35-0001-signer-2", "evm-gen-msig35-0001-signer-3",
+		"evm-gen-msig35-0001-signer-4", "evm-gen-msig35-0001-signer-5",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("name[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if name := evmMultisigCompositeName("gen-msig35-0001"); name != "evm-gen-msig35-0001" {
+		t.Errorf("composite name = %q, want evm-gen-msig35-0001", name)
+	}
+}

--- a/devnet/tests/common/migration_multisig_test.go
+++ b/devnet/tests/common/migration_multisig_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestProofFlowArgBuilders(t *testing.T) {
 	t.Run("generate-proof-payload", func(t *testing.T) {
-		args := generateProofPayloadArgs("lumera1legacy", "claim", "/tmp/proof.json", "evm-ms-signer-1,evm-ms-signer-2", 2, "test", "/root/.lumera")
+		args := generateProofPayloadArgs("lumera1legacy", "claim", "/tmp/proof.json", "evm-ms-signer-1,evm-ms-signer-2", 2, "lumera-devnet-1", "test", "/root/.lumera")
 		joined := strings.Join(args, " ")
 		for _, want := range []string{
 			"tx evmigration generate-proof-payload",
@@ -16,6 +16,10 @@ func TestProofFlowArgBuilders(t *testing.T) {
 			"--out /tmp/proof.json",
 			"--new-sub-pub-keys evm-ms-signer-1,evm-ms-signer-2",
 			"--new-threshold 2",
+			// --chain-id is REQUIRED: without it the payload is built with the
+			// wrong chain id (the bech32 prefix "lumera"), so every proof
+			// signature fails on-chain verification.
+			"--chain-id lumera-devnet-1",
 			"--keyring-backend test",
 			"--home /root/.lumera",
 		} {

--- a/devnet/tests/common/migration_test.go
+++ b/devnet/tests/common/migration_test.go
@@ -114,6 +114,20 @@ func TestParseMigrationRecord(t *testing.T) {
 		}
 	})
 
+	t.Run("present record with migration height", func(t *testing.T) {
+		out := `{"record": {"legacy_address": "lumera1legacy", "new_address": "lumera1new", "migration_height": "65194"}}`
+		rec, found, err := parseMigrationRecord(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !found {
+			t.Fatal("found = false, want true")
+		}
+		if rec.Height != 65194 {
+			t.Errorf("Height = %d, want 65194", rec.Height)
+		}
+	})
+
 	t.Run("absent record", func(t *testing.T) {
 		out := `{}`
 		_, found, err := parseMigrationRecord(out)

--- a/devnet/tests/common/migration_test.go
+++ b/devnet/tests/common/migration_test.go
@@ -1,6 +1,10 @@
 package common
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
 
 func TestParseMigrationEstimate(t *testing.T) {
 	t.Run("single-sig with string-encoded counts", func(t *testing.T) {
@@ -147,6 +151,48 @@ func TestParseMigrationRecord(t *testing.T) {
 		}
 		if found {
 			t.Error("found = true, want false for empty record object")
+		}
+	})
+}
+
+func TestFlexInt(t *testing.T) {
+	t.Run("empty input is zero", func(t *testing.T) {
+		got, err := flexInt(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 0 {
+			t.Errorf("flexInt(nil) = %d, want 0", got)
+		}
+	})
+
+	t.Run("string number", func(t *testing.T) {
+		got, err := flexInt(json.RawMessage(`"42"`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 42 {
+			t.Errorf("flexInt(\"42\") = %d, want 42", got)
+		}
+	})
+
+	t.Run("json number", func(t *testing.T) {
+		got, err := flexInt(json.RawMessage(`17`))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != 17 {
+			t.Errorf("flexInt(17) = %d, want 17", got)
+		}
+	})
+
+	t.Run("out of range string", func(t *testing.T) {
+		_, err := flexInt(json.RawMessage(`"9223372036854775808"`))
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "parse") {
+			t.Errorf("error = %q, want parse context", err)
 		}
 	})
 }

--- a/devnet/tests/common/migration_test.go
+++ b/devnet/tests/common/migration_test.go
@@ -1,0 +1,138 @@
+package common
+
+import "testing"
+
+func TestParseMigrationEstimate(t *testing.T) {
+	t.Run("single-sig with string-encoded counts", func(t *testing.T) {
+		out := `{
+			"delegation_count": "5",
+			"unbonding_count": "2",
+			"redelegation_count": "2",
+			"authz_grant_count": "5",
+			"feegrant_count": "3",
+			"total_touched": "19",
+			"would_succeed": true,
+			"action_count": "2",
+			"balance_summary": "4562270ulume"
+		}`
+		est, err := parseMigrationEstimate(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !est.WouldSucceed {
+			t.Error("WouldSucceed = false, want true")
+		}
+		if est.DelegationCount != 5 {
+			t.Errorf("DelegationCount = %d, want 5", est.DelegationCount)
+		}
+		if est.IsMultisig {
+			t.Error("IsMultisig = true, want false")
+		}
+		if est.BalanceSummary != "4562270ulume" {
+			t.Errorf("BalanceSummary = %q, want 4562270ulume", est.BalanceSummary)
+		}
+	})
+
+	t.Run("multisig with rejection reason", func(t *testing.T) {
+		out := `{"would_succeed": false, "is_multisig": true, "is_validator": false, "rejection_reason": "already migrated"}`
+		est, err := parseMigrationEstimate(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if est.WouldSucceed {
+			t.Error("WouldSucceed = true, want false")
+		}
+		if !est.IsMultisig {
+			t.Error("IsMultisig = false, want true")
+		}
+		if est.RejectionReason != "already migrated" {
+			t.Errorf("RejectionReason = %q, want 'already migrated'", est.RejectionReason)
+		}
+	})
+}
+
+func TestParseMigrationParams(t *testing.T) {
+	t.Run("wrapped in params envelope", func(t *testing.T) {
+		out := `{"params": {"enable_migration": true, "migration_end_time": "0", "max_migrations_per_block": "50", "max_validator_delegations": "2000", "max_multisig_sub_keys": 20}}`
+		p, err := parseMigrationParams(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !p.EnableMigration {
+			t.Error("EnableMigration = false, want true")
+		}
+		if p.MaxMigrationsPerBlock != 50 {
+			t.Errorf("MaxMigrationsPerBlock = %d, want 50", p.MaxMigrationsPerBlock)
+		}
+		if p.MaxMultisigSubKeys != 20 {
+			t.Errorf("MaxMultisigSubKeys = %d, want 20", p.MaxMultisigSubKeys)
+		}
+	})
+
+	t.Run("bare params object", func(t *testing.T) {
+		out := `{"enable_migration": false, "migration_end_time": 1781634504, "max_migrations_per_block": 10}`
+		p, err := parseMigrationParams(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if p.EnableMigration {
+			t.Error("EnableMigration = true, want false")
+		}
+		if p.MigrationEndTime != 1781634504 {
+			t.Errorf("MigrationEndTime = %d, want 1781634504", p.MigrationEndTime)
+		}
+	})
+}
+
+func TestParseMigrationStats(t *testing.T) {
+	out := `{"total_migrated": "14", "total_legacy": "104", "total_legacy_staked": "30", "total_validators_migrated": "3", "total_validators_legacy": "2"}`
+	s, err := parseMigrationStats(out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.TotalMigrated != 14 || s.TotalLegacy != 104 || s.TotalLegacyStaked != 30 ||
+		s.TotalValidatorsMigrated != 3 || s.TotalValidatorsLegacy != 2 {
+		t.Errorf("stats mismatch: %+v", s)
+	}
+}
+
+func TestParseMigrationRecord(t *testing.T) {
+	t.Run("present record", func(t *testing.T) {
+		out := `{"record": {"legacy_address": "lumera1legacy", "new_address": "lumera1new", "height": "64566"}}`
+		rec, found, err := parseMigrationRecord(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !found {
+			t.Fatal("found = false, want true")
+		}
+		if rec.LegacyAddress != "lumera1legacy" || rec.NewAddress != "lumera1new" {
+			t.Errorf("record = %+v, want legacy/new addresses set", rec)
+		}
+		if rec.Height != 64566 {
+			t.Errorf("Height = %d, want 64566", rec.Height)
+		}
+	})
+
+	t.Run("absent record", func(t *testing.T) {
+		out := `{}`
+		_, found, err := parseMigrationRecord(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Error("found = true, want false for empty response")
+		}
+	})
+
+	t.Run("empty record object is not found", func(t *testing.T) {
+		out := `{"record": {}}`
+		_, found, err := parseMigrationRecord(out)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if found {
+			t.Error("found = true, want false for empty record object")
+		}
+	})
+}

--- a/devnet/tests/common/migration_verify.go
+++ b/devnet/tests/common/migration_verify.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ValidateMigrationRecord checks that a migration record exists and maps the
+// expected legacy address to the expected new address. An empty expectedNew
+// skips the new-address check (useful when the destination is derived on-chain
+// and not known a priori).
+func ValidateMigrationRecord(rec MigrationRecord, found bool, legacyAddr, expectedNew string) error {
+	if !found {
+		return fmt.Errorf("no migration record for legacy address %s", legacyAddr)
+	}
+	if rec.LegacyAddress != "" && rec.LegacyAddress != legacyAddr {
+		return fmt.Errorf("migration record legacy address %s != expected %s", rec.LegacyAddress, legacyAddr)
+	}
+	if expectedNew != "" && rec.NewAddress != expectedNew {
+		return fmt.Errorf("migration record new address %s != expected %s", rec.NewAddress, expectedNew)
+	}
+	return nil
+}
+
+// EstimateConfirmsAlreadyMigrated reports whether a migration estimate's
+// rejection reason indicates the account is already migrated. This is the
+// post-migration invariant: the legacy address should now be rejected as
+// already migrated.
+func EstimateConfirmsAlreadyMigrated(est MigrationEstimate) bool {
+	return strings.Contains(strings.ToLower(est.RejectionReason), "already migrated")
+}
+
+// VerifyMigration confirms an account migrated correctly: the on-chain record
+// maps legacyAddr -> expectedNew (expectedNew may be empty to skip that check),
+// and a fresh estimate now rejects the legacy address as already migrated.
+func (c *ChainCLI) VerifyMigration(legacyAddr, expectedNew string) error {
+	rec, found, err := c.MigrationRecord(legacyAddr)
+	if err != nil {
+		return fmt.Errorf("verify: query migration record: %w", err)
+	}
+	if err := ValidateMigrationRecord(rec, found, legacyAddr, expectedNew); err != nil {
+		return err
+	}
+	if est, err := c.MigrationEstimate(legacyAddr); err == nil && !EstimateConfirmsAlreadyMigrated(est) && est.WouldSucceed {
+		return fmt.Errorf("verify: legacy address %s still reports migratable after migration", legacyAddr)
+	}
+	return nil
+}
+
+// WaitForMigrationRecord polls until a migration record for legacyAddr appears
+// or the timeout elapses, returning the record. Useful right after a submit when
+// indexing may lag a block.
+func (c *ChainCLI) WaitForMigrationRecord(legacyAddr string, timeout time.Duration) (MigrationRecord, error) {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		rec, found, err := c.MigrationRecord(legacyAddr)
+		if err != nil {
+			lastErr = err
+		} else if found {
+			return rec, nil
+		}
+		time.Sleep(time.Second)
+	}
+	if lastErr != nil {
+		return MigrationRecord{}, fmt.Errorf("wait for migration record %s: %w", legacyAddr, lastErr)
+	}
+	return MigrationRecord{}, fmt.Errorf("timed out waiting for migration record %s", legacyAddr)
+}

--- a/devnet/tests/common/migration_verify_test.go
+++ b/devnet/tests/common/migration_verify_test.go
@@ -1,0 +1,51 @@
+package common
+
+import "testing"
+
+func TestValidateMigrationRecord(t *testing.T) {
+	t.Run("valid mapping passes", func(t *testing.T) {
+		rec := MigrationRecord{LegacyAddress: "lumera1legacy", NewAddress: "lumera1new", Height: 100}
+		if err := ValidateMigrationRecord(rec, true, "lumera1legacy", "lumera1new"); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing record fails", func(t *testing.T) {
+		if err := ValidateMigrationRecord(MigrationRecord{}, false, "lumera1legacy", "lumera1new"); err == nil {
+			t.Error("expected error when record not found")
+		}
+	})
+
+	t.Run("new address mismatch fails", func(t *testing.T) {
+		rec := MigrationRecord{LegacyAddress: "lumera1legacy", NewAddress: "lumera1other"}
+		if err := ValidateMigrationRecord(rec, true, "lumera1legacy", "lumera1new"); err == nil {
+			t.Error("expected error on new-address mismatch")
+		}
+	})
+
+	t.Run("legacy address mismatch fails", func(t *testing.T) {
+		rec := MigrationRecord{LegacyAddress: "lumera1other", NewAddress: "lumera1new"}
+		if err := ValidateMigrationRecord(rec, true, "lumera1legacy", "lumera1new"); err == nil {
+			t.Error("expected error on legacy-address mismatch")
+		}
+	})
+
+	t.Run("empty expected new address skips that check", func(t *testing.T) {
+		rec := MigrationRecord{LegacyAddress: "lumera1legacy", NewAddress: "lumera1whatever"}
+		if err := ValidateMigrationRecord(rec, true, "lumera1legacy", ""); err != nil {
+			t.Errorf("unexpected error when expectedNew empty: %v", err)
+		}
+	})
+}
+
+func TestEstimateConfirmsAlreadyMigrated(t *testing.T) {
+	if !EstimateConfirmsAlreadyMigrated(MigrationEstimate{RejectionReason: "already migrated"}) {
+		t.Error("expected 'already migrated' rejection to confirm migrated")
+	}
+	if EstimateConfirmsAlreadyMigrated(MigrationEstimate{WouldSucceed: true}) {
+		t.Error("a would-succeed estimate must not confirm already-migrated")
+	}
+	if EstimateConfirmsAlreadyMigrated(MigrationEstimate{RejectionReason: "is a validator"}) {
+		t.Error("an unrelated rejection must not confirm already-migrated")
+	}
+}

--- a/devnet/tests/common/multisig.go
+++ b/devnet/tests/common/multisig.go
@@ -1,0 +1,166 @@
+package common
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Multisig provides the generic K-of-N multisig key + signing ceremony shared by
+// the evmigration and gen-activity tools. It is built on a *ChainCLI for
+// connection config and queries; the command execution is behind an injectable
+// seam (exec) so the ceremony orchestration is unit-testable with a fake.
+//
+// The ceremony is:
+//
+//	keys add --multisig --nosort        (composite key, key-type agnostic)
+//	tx ... --generate-only              (unsigned tx with the multisig as sender)
+//	tx sign --multisig --sign-mode amino-json   (× K members)
+//	tx multisign                        (combine the K signatures)
+//	tx broadcast --broadcast-mode sync  (+ wait for inclusion)
+//
+// --nosort keeps members in caller order so legacy/new sides agree on index
+// ordering; amino-json is required for offline multisig signing.
+type Multisig struct {
+	CLI  *ChainCLI
+	exec func(bin string, args ...string) (string, error)
+}
+
+// NewMultisig builds a Multisig over the given ChainCLI with the real command
+// executor.
+func NewMultisig(cli *ChainCLI) *Multisig {
+	return &Multisig{
+		CLI: cli,
+		exec: func(bin string, args ...string) (string, error) {
+			out, err := exec.Command(bin, args...).CombinedOutput()
+			return strings.TrimSpace(string(out)), err
+		},
+	}
+}
+
+func (m *Multisig) homeArgs() []string {
+	if m.CLI.Home == "" {
+		return nil
+	}
+	return []string{"--home", m.CLI.Home}
+}
+
+func (m *Multisig) nodeArgs() []string {
+	if m.CLI.RPC == "" {
+		return nil
+	}
+	return []string{"--node", m.CLI.RPC}
+}
+
+func (m *Multisig) keyring() string {
+	if m.CLI.KeyringBackend == "" {
+		return "test"
+	}
+	return m.CLI.KeyringBackend
+}
+
+// keyAddArgs builds `keys add <name> --multisig <m1,m2,..> --multisig-threshold K
+// --nosort`. keys add is a pure keyring op (no --node/--chain-id).
+func (m *Multisig) keyAddArgs(name string, members []string, threshold int) []string {
+	args := []string{
+		"keys", "add", name,
+		"--multisig", strings.Join(members, ","),
+		"--multisig-threshold", strconv.Itoa(threshold),
+		"--nosort",
+		"--keyring-backend", m.keyring(),
+	}
+	return append(args, m.homeArgs()...)
+}
+
+// signArgs builds `tx sign <file> --from <member> --multisig <addr>` with offline
+// account-number/sequence and amino-json sign mode.
+func (m *Multisig) signArgs(file, fromKey, multisigAddr string, accNum, seq uint64) []string {
+	args := []string{
+		"tx", "sign", file,
+		"--from", fromKey,
+		"--multisig", multisigAddr,
+		"--keyring-backend", m.keyring(),
+		"--chain-id", m.CLI.ChainID,
+		"--account-number", strconv.FormatUint(accNum, 10),
+		"--sequence", strconv.FormatUint(seq, 10),
+		"--sign-mode", "amino-json",
+		"--output", "json",
+	}
+	args = append(args, m.nodeArgs()...)
+	return append(args, m.homeArgs()...)
+}
+
+// multisignArgs builds `tx multisign <file> <name> <sig1> <sig2> ...`.
+func (m *Multisig) multisignArgs(file, name string, sigFiles []string) []string {
+	args := []string{"tx", "multisign", file, name}
+	args = append(args, sigFiles...)
+	args = append(args,
+		"--keyring-backend", m.keyring(),
+		"--chain-id", m.CLI.ChainID,
+		"--output", "json",
+	)
+	args = append(args, m.nodeArgs()...)
+	return append(args, m.homeArgs()...)
+}
+
+// broadcastArgs builds `tx broadcast <signedFile> --broadcast-mode sync`.
+func (m *Multisig) broadcastArgs(signedFile string) []string {
+	args := []string{
+		"tx", "broadcast", signedFile,
+		"--broadcast-mode", "sync",
+		"--output", "json",
+	}
+	return append(args, m.nodeArgs()...)
+}
+
+// GenBankSendArgs builds a generate-only `tx bank send` from the multisig.
+func (m *Multisig) GenBankSendArgs(name, fromAddr, toAddr, amount string, accNum, seq uint64) []string {
+	return m.genTxArgs(name, accNum, seq, "bank", "send", fromAddr, toAddr, amount)
+}
+
+// GenDelegateArgs builds a generate-only `tx staking delegate` from the multisig.
+func (m *Multisig) GenDelegateArgs(name, valoper, amount string, accNum, seq uint64) []string {
+	return m.genTxArgs(name, accNum, seq, "staking", "delegate", valoper, amount)
+}
+
+// genTxArgs builds a generate-only tx with the multisig name as --from and the
+// supplied module/positional args.
+func (m *Multisig) genTxArgs(name string, accNum, seq uint64, module, action string, positional ...string) []string {
+	args := []string{"tx", module, action}
+	args = append(args, positional...)
+	args = append(args,
+		"--from", name,
+		"--keyring-backend", m.keyring(),
+		"--chain-id", m.CLI.ChainID,
+		"--account-number", strconv.FormatUint(accNum, 10),
+		"--sequence", strconv.FormatUint(seq, 10),
+		"--gas", m.gas(),
+		"--gas-prices", m.CLI.GasPrices,
+		"--generate-only",
+		"--output", "json",
+	)
+	args = append(args, m.nodeArgs()...)
+	return append(args, m.homeArgs()...)
+}
+
+func (m *Multisig) gas() string {
+	if m.CLI.Gas == "" {
+		return "auto"
+	}
+	return m.CLI.Gas
+}
+
+// extractTxHash pulls "txhash":"..." from a broadcast/query JSON response.
+func extractTxHash(out string) string {
+	const marker = `"txhash":"`
+	idx := strings.Index(out, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := out[idx+len(marker):]
+	end := strings.IndexByte(rest, '"')
+	if end < 0 {
+		return ""
+	}
+	return strings.TrimSpace(rest[:end])
+}

--- a/devnet/tests/common/multisig.go
+++ b/devnet/tests/common/multisig.go
@@ -1,9 +1,12 @@
 package common
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Multisig provides the generic K-of-N multisig key + signing ceremony shared by
@@ -150,17 +153,131 @@ func (m *Multisig) gas() string {
 	return m.CLI.Gas
 }
 
-// extractTxHash pulls "txhash":"..." from a broadcast/query JSON response.
-func extractTxHash(out string) string {
-	const marker = `"txhash":"`
-	idx := strings.Index(out, marker)
-	if idx < 0 {
-		return ""
+// CreateMultisigKey creates (or reuses) a K-of-N composite key over the given
+// member key names. Rerun-safe: an existing composite is returned as-is. Reuse
+// is keyed by name only — a stale composite created with different members or
+// threshold is reused as-is, so callers that change membership must delete the
+// old key first.
+func (m *Multisig) CreateMultisigKey(name string, members []string, threshold int) (string, error) {
+	if threshold < 1 {
+		return "", fmt.Errorf("invalid multisig threshold %d", threshold)
 	}
-	rest := out[idx+len(marker):]
-	end := strings.IndexByte(rest, '"')
-	if end < 0 {
-		return ""
+	if len(members) < threshold {
+		return "", fmt.Errorf("multisig %s has %d members, need >= threshold %d", name, len(members), threshold)
 	}
-	return strings.TrimSpace(rest[:end])
+	if m.CLI.HasKey(name) {
+		return m.CLI.ShowAddress(name)
+	}
+	out, err := m.exec(m.CLI.Bin, m.keyAddArgs(name, members, threshold)...)
+	if err != nil {
+		return "", fmt.Errorf("keys add multisig %s: %s: %w", name, out, err)
+	}
+	return m.CLI.ShowAddress(name)
+}
+
+// SignAndBroadcastFile collects `threshold` member signatures over an unsigned
+// tx file, combines them with `tx multisign`, broadcasts the result (sync), and
+// waits for inclusion. Returns the tx hash. Temp signature files are removed.
+func (m *Multisig) SignAndBroadcastFile(unsignedFile, name, multisigAddr string, members []string, threshold int, accNum, seq uint64) (string, error) {
+	if len(members) < threshold {
+		return "", fmt.Errorf("multisig %s has %d members, need >= %d signers", name, len(members), threshold)
+	}
+
+	sigFiles := make([]string, threshold)
+	for i := range sigFiles {
+		f, err := os.CreateTemp("", fmt.Sprintf("multisig-sig%d-*.json", i+1))
+		if err != nil {
+			return "", fmt.Errorf("create temp sig file: %w", err)
+		}
+		_ = f.Close()
+		sigFiles[i] = f.Name()
+		defer func(path string) { _ = os.Remove(path) }(sigFiles[i])
+	}
+
+	for i, member := range members[:threshold] {
+		out, err := m.exec(m.CLI.Bin, m.signArgs(unsignedFile, member, multisigAddr, accNum, seq)...)
+		if err != nil {
+			return "", fmt.Errorf("sign with %s: %s: %w", member, out, err)
+		}
+		if err := os.WriteFile(sigFiles[i], []byte(out), 0o600); err != nil {
+			return "", fmt.Errorf("write sig %s: %w", sigFiles[i], err)
+		}
+	}
+
+	signedFile, err := os.CreateTemp("", "multisig-signed-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create temp signed file: %w", err)
+	}
+	_ = signedFile.Close()
+	defer func() { _ = os.Remove(signedFile.Name()) }()
+
+	msignOut, err := m.exec(m.CLI.Bin, m.multisignArgs(unsignedFile, name, sigFiles)...)
+	if err != nil {
+		return "", fmt.Errorf("multisign: %s: %w", msignOut, err)
+	}
+	if err := os.WriteFile(signedFile.Name(), []byte(msignOut), 0o600); err != nil {
+		return "", fmt.Errorf("write signed tx: %w", err)
+	}
+
+	bcastOut, err := m.exec(m.CLI.Bin, m.broadcastArgs(signedFile.Name())...)
+	if err != nil {
+		return "", fmt.Errorf("broadcast: %s: %w", bcastOut, err)
+	}
+	// A sync broadcast returns exit 0 even when CheckTx rejects the tx, so the
+	// response code must be inspected — otherwise a rejected ceremony tx would
+	// poll to a misleading timeout instead of surfacing the rejection reason.
+	txHash, code, rawLog, ok := parseSyncBroadcast(bcastOut)
+	if !ok {
+		return "", fmt.Errorf("broadcast: unparseable response: %s", bcastOut)
+	}
+	if code != 0 {
+		return txHash, fmt.Errorf("broadcast rejected code=%d raw_log=%s", code, rawLog)
+	}
+	if txHash == "" {
+		return "", fmt.Errorf("broadcast: missing txhash in response: %s", bcastOut)
+	}
+	if err := m.waitForTxIncluded(txHash, 45*time.Second); err != nil {
+		return txHash, err
+	}
+	return txHash, nil
+}
+
+// waitForTxIncluded polls `query tx <hash>` through the exec seam until the tx
+// is committed (code 0) or the timeout elapses. It mirrors
+// ChainCLI.WaitForTxInclusion but routes through m.exec so the whole ceremony —
+// including the inclusion wait — is testable behind a single injectable seam.
+func (m *Multisig) waitForTxIncluded(txHash string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		out, err := m.exec(m.CLI.Bin, m.queryTxArgs(txHash)...)
+		if err == nil {
+			if _, code, rawLog, ok := parseSyncBroadcast(out); ok {
+				if code != 0 {
+					return fmt.Errorf("tx %s failed code=%d raw_log=%s", txHash, code, rawLog)
+				}
+				return nil
+			}
+		}
+		if !time.Now().Before(deadline) {
+			return fmt.Errorf("timeout waiting for tx %s inclusion", txHash)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+// queryTxArgs builds `query tx <hash>` with the standard chain/node/home flags.
+func (m *Multisig) queryTxArgs(txHash string) []string {
+	args := []string{"query", "tx", txHash, "--chain-id", m.CLI.ChainID, "--output", "json"}
+	args = append(args, m.nodeArgs()...)
+	return append(args, m.homeArgs()...)
+}
+
+// BuildUnsignedToFile generates an unsigned tx (generate-only) using args and
+// writes it to outFile, for the caller to feed into SignAndBroadcastFile.
+func (m *Multisig) BuildUnsignedToFile(outFile string, args []string) error {
+	out, err := m.exec(m.CLI.Bin, args...)
+	if err != nil {
+		return fmt.Errorf("generate unsigned tx: %s: %w", out, err)
+	}
+	return os.WriteFile(outFile, []byte(out), 0o600)
 }

--- a/devnet/tests/common/multisig_test.go
+++ b/devnet/tests/common/multisig_test.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -88,5 +89,108 @@ func TestBroadcastArgsSyncMode(t *testing.T) {
 	}
 	if !contains(args, "--broadcast-mode") || !contains(args, "sync") {
 		t.Errorf("broadcast must be sync mode: %v", args)
+	}
+}
+
+// fakeExec records command invocations and returns canned outputs keyed by a
+// substring match of the joined args (first match wins).
+type fakeExec struct {
+	calls  [][]string
+	canned []cannedResponse
+}
+
+type cannedResponse struct {
+	match  string
+	output string
+	err    error
+}
+
+func (f *fakeExec) run(bin string, args ...string) (string, error) {
+	f.calls = append(f.calls, args)
+	joined := strings.Join(args, " ")
+	for _, c := range f.canned {
+		if strings.Contains(joined, c.match) {
+			return c.output, c.err
+		}
+	}
+	return "", nil
+}
+
+func (f *fakeExec) calledWith(sub string) bool {
+	for _, c := range f.calls {
+		if strings.Contains(strings.Join(c, " "), sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSignAndBroadcastRunsCeremonyInOrder(t *testing.T) {
+	m := testMultisig()
+	fe := &fakeExec{canned: []cannedResponse{
+		{match: "tx sign", output: `{"some":"sig"}`},
+		{match: "tx multisign", output: `{"signed":"tx"}`},
+		{match: "tx broadcast", output: `{"txhash":"ABC123","code":0}`},
+		{match: "query tx ABC123", output: `{"code":0,"txhash":"ABC123"}`},
+	}}
+	m.exec = fe.run
+
+	txHash, err := m.SignAndBroadcastFile("/tmp/unsigned.json", "msig", "lumera1msig",
+		[]string{"s1", "s2", "s3"}, 2, 7, 3)
+	if err != nil {
+		t.Fatalf("SignAndBroadcastFile: %v", err)
+	}
+	if txHash != "ABC123" {
+		t.Errorf("txHash = %q, want ABC123", txHash)
+	}
+	if !fe.calledWith("tx sign /tmp/unsigned.json --from s1") {
+		t.Error("missing sign with s1")
+	}
+	if !fe.calledWith("tx sign /tmp/unsigned.json --from s2") {
+		t.Error("missing sign with s2")
+	}
+	if fe.calledWith("--from s3") {
+		t.Error("must not sign with the 3rd member when threshold=2")
+	}
+	if !fe.calledWith("tx multisign") || !fe.calledWith("tx broadcast") {
+		t.Error("missing multisign/broadcast step")
+	}
+	// The inclusion wait must run through the exec seam (not a real node).
+	if !fe.calledWith("query tx ABC123") {
+		t.Error("inclusion wait did not run through the exec seam (no query tx)")
+	}
+}
+
+func TestSignAndBroadcastRejectsTooFewMembers(t *testing.T) {
+	m := testMultisig()
+	m.exec = (&fakeExec{}).run
+	_, err := m.SignAndBroadcastFile("/tmp/u.json", "msig", "lumera1msig", []string{"s1"}, 2, 7, 3)
+	if err == nil {
+		t.Error("expected error when members < threshold")
+	}
+}
+
+// TestSignAndBroadcastFailsOnRejectedCode verifies a non-zero CheckTx code from
+// the sync broadcast is surfaced as an error (not silently polled to timeout).
+func TestSignAndBroadcastFailsOnRejectedCode(t *testing.T) {
+	m := testMultisig()
+	fe := &fakeExec{canned: []cannedResponse{
+		{match: "tx sign", output: `{"some":"sig"}`},
+		{match: "tx multisign", output: `{"signed":"tx"}`},
+		{match: "tx broadcast", output: `{"txhash":"BAD","code":11,"raw_log":"insufficient fee"}`},
+	}}
+	m.exec = fe.run
+
+	_, err := m.SignAndBroadcastFile("/tmp/unsigned.json", "msig", "lumera1msig",
+		[]string{"s1", "s2", "s3"}, 2, 7, 3)
+	if err == nil {
+		t.Fatal("expected error for rejected broadcast (code=11)")
+	}
+	if !strings.Contains(err.Error(), "code=11") {
+		t.Errorf("error = %q, want it to mention code=11", err)
+	}
+	// Must fail fast at broadcast, never reaching the inclusion poll.
+	if fe.calledWith("query tx") {
+		t.Error("must not poll query tx after a rejected broadcast")
 	}
 }

--- a/devnet/tests/common/multisig_test.go
+++ b/devnet/tests/common/multisig_test.go
@@ -1,0 +1,92 @@
+package common
+
+import (
+	"testing"
+)
+
+func testMultisig() *Multisig {
+	cli := &ChainCLI{
+		Bin: "lumerad", ChainID: "lumera-devnet-1", RPC: "tcp://localhost:26657",
+		Home: "/home/u/.lumera", KeyringBackend: "test",
+		Gas: "500000", GasPrices: "0.025ulume",
+	}
+	return NewMultisig(cli)
+}
+
+func contains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestKeyAddArgsUsesNosortAndThreshold(t *testing.T) {
+	m := testMultisig()
+	args := m.keyAddArgs("msig", []string{"s1", "s2", "s3"}, 2)
+	if !contains(args, "--nosort") {
+		t.Errorf("keys add multisig must pass --nosort: %v", args)
+	}
+	if !contains(args, "--multisig") || !contains(args, "s1,s2,s3") {
+		t.Errorf("keys add must pass --multisig members joined: %v", args)
+	}
+	if !contains(args, "--multisig-threshold") || !contains(args, "2") {
+		t.Errorf("keys add must pass --multisig-threshold 2: %v", args)
+	}
+	if !contains(args, "--home") || !contains(args, "/home/u/.lumera") {
+		t.Errorf("keys add must pass --home when set: %v", args)
+	}
+}
+
+func TestSignArgsUsesAminoJSONAndMultisig(t *testing.T) {
+	m := testMultisig()
+	args := m.signArgs("/tmp/unsigned.json", "s1", "lumera1msig", 7, 3)
+	if !contains(args, "--sign-mode") || !contains(args, "amino-json") {
+		t.Errorf("sign must use amino-json: %v", args)
+	}
+	if !contains(args, "--multisig") || !contains(args, "lumera1msig") {
+		t.Errorf("sign must reference the multisig address: %v", args)
+	}
+	if !contains(args, "--from") || !contains(args, "s1") {
+		t.Errorf("sign must set --from member: %v", args)
+	}
+	if !contains(args, "--account-number") || !contains(args, "7") ||
+		!contains(args, "--sequence") || !contains(args, "3") {
+		t.Errorf("sign must pass offline account-number/sequence: %v", args)
+	}
+}
+
+func TestMultisignArgsConsumesSigFiles(t *testing.T) {
+	m := testMultisig()
+	args := m.multisignArgs("/tmp/unsigned.json", "msig", []string{"/tmp/s1.json", "/tmp/s2.json"})
+	for _, want := range []string{"multisign", "/tmp/unsigned.json", "msig", "/tmp/s1.json", "/tmp/s2.json"} {
+		if !contains(args, want) {
+			t.Errorf("multisign args missing %q: %v", want, args)
+		}
+	}
+}
+
+func TestGenBankSendArgsIsGenerateOnly(t *testing.T) {
+	m := testMultisig()
+	args := m.GenBankSendArgs("msig", "lumera1msig", "lumera1peer", "5ulume", 7, 3)
+	if !contains(args, "--generate-only") {
+		t.Errorf("unsigned tx must be generate-only: %v", args)
+	}
+	for _, want := range []string{"send", "lumera1msig", "lumera1peer", "5ulume"} {
+		if !contains(args, want) {
+			t.Errorf("bank send args missing %q: %v", want, args)
+		}
+	}
+}
+
+func TestBroadcastArgsSyncMode(t *testing.T) {
+	m := testMultisig()
+	args := m.broadcastArgs("/tmp/signed.json")
+	if !contains(args, "broadcast") || !contains(args, "/tmp/signed.json") {
+		t.Errorf("broadcast args missing file: %v", args)
+	}
+	if !contains(args, "--broadcast-mode") || !contains(args, "sync") {
+		t.Errorf("broadcast must be sync mode: %v", args)
+	}
+}

--- a/devnet/tests/common/vesting.go
+++ b/devnet/tests/common/vesting.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// VestingType labels the vesting/locked account variants gen-activity creates.
+type VestingType string
+
+const (
+	VestingContinuous      VestingType = "continuous"
+	VestingDelayed         VestingType = "delayed"
+	VestingPermanentLocked VestingType = "permanent_locked"
+)
+
+// VestingCreateArgs builds `tx vesting create-vesting-account <to> <amount>
+// <end-unix> [--delayed] --from <funder>`. Gas/broadcast/keyring/node flags are
+// appended by ChainCLI.SubmitTx, so they are intentionally absent here.
+func VestingCreateArgs(funderKey, to, amount string, endUnix int64, delayed bool) []string {
+	args := []string{
+		"tx", "vesting", "create-vesting-account",
+		to, amount, strconv.FormatInt(endUnix, 10),
+		"--from", funderKey,
+	}
+	if delayed {
+		args = append(args, "--delayed")
+	}
+	return args
+}
+
+// PermanentLockedArgs builds `tx vesting create-permanent-locked-account <to>
+// <amount> --from <funder>`.
+func PermanentLockedArgs(funderKey, to, amount string) []string {
+	return []string{
+		"tx", "vesting", "create-permanent-locked-account",
+		to, amount,
+		"--from", funderKey,
+	}
+}
+
+// CreateVestingAccount creates a continuous (delayed=false) or delayed/cliff
+// (delayed=true) vesting account funded with amount, signed by funderKey. It
+// waits for inclusion (SubmitTx semantics) and returns the tx hash.
+func (c *ChainCLI) CreateVestingAccount(funderKey, to, amount string, endUnix int64, delayed bool) (string, error) {
+	txHash, err := c.SubmitTx(VestingCreateArgs(funderKey, to, amount, endUnix, delayed)...)
+	if err != nil {
+		return txHash, fmt.Errorf("create vesting account %s: %w", to, err)
+	}
+	return txHash, nil
+}
+
+// CreatePermanentLockedAccount creates a PermanentLockedAccount funded with
+// amount, signed by funderKey.
+func (c *ChainCLI) CreatePermanentLockedAccount(funderKey, to, amount string) (string, error) {
+	txHash, err := c.SubmitTx(PermanentLockedArgs(funderKey, to, amount)...)
+	if err != nil {
+		return txHash, fmt.Errorf("create permanent-locked account %s: %w", to, err)
+	}
+	return txHash, nil
+}

--- a/devnet/tests/common/vesting_test.go
+++ b/devnet/tests/common/vesting_test.go
@@ -1,0 +1,46 @@
+package common
+
+import "testing"
+
+func vcontains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestVestingCreateArgsContinuous(t *testing.T) {
+	args := VestingCreateArgs("faucet", "lumera1to", "5000000ulume", 1800000000, false)
+	for _, want := range []string{"vesting", "create-vesting-account", "lumera1to", "5000000ulume", "1800000000"} {
+		if !vcontains(args, want) {
+			t.Errorf("continuous vesting args missing %q: %v", want, args)
+		}
+	}
+	if !vcontains(args, "--from") || !vcontains(args, "faucet") {
+		t.Errorf("must sign with funder: %v", args)
+	}
+	if vcontains(args, "--delayed") {
+		t.Errorf("continuous vesting must NOT pass --delayed: %v", args)
+	}
+}
+
+func TestVestingCreateArgsDelayed(t *testing.T) {
+	args := VestingCreateArgs("faucet", "lumera1to", "5000000ulume", 1800000000, true)
+	if !vcontains(args, "--delayed") {
+		t.Errorf("delayed vesting must pass --delayed: %v", args)
+	}
+}
+
+func TestPermanentLockedArgs(t *testing.T) {
+	args := PermanentLockedArgs("faucet", "lumera1to", "5000000ulume")
+	for _, want := range []string{"vesting", "create-permanent-locked-account", "lumera1to", "5000000ulume"} {
+		if !vcontains(args, want) {
+			t.Errorf("permanent-locked args missing %q: %v", want, args)
+		}
+	}
+	if !vcontains(args, "--from") || !vcontains(args, "faucet") {
+		t.Errorf("must sign with funder: %v", args)
+	}
+}

--- a/devnet/tests/evmigration/multisig.go
+++ b/devnet/tests/evmigration/multisig.go
@@ -19,7 +19,25 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"gen/tests/common"
 )
+
+// commonMultisig builds a *common.Multisig from the evmigration flag globals so
+// the generic ceremony is shared with gen-activity. Gas is fixed (matches the
+// values used across this tool) so generate-only/offline signing works.
+func commonMultisig() *common.Multisig {
+	cli := &common.ChainCLI{
+		Bin:            *flagBin,
+		ChainID:        *flagChainID,
+		RPC:            *flagRPC,
+		Home:           *flagHome,
+		KeyringBackend: "test",
+		Gas:            *flagGas,
+		GasPrices:      *flagGasPrices,
+	}
+	return common.NewMultisig(cli)
+}
 
 // multisigKeyNames is a fixed set of key names used by this mode. Using
 // well-known names makes reruns and manual inspection easier.
@@ -255,42 +273,11 @@ func ensureMultisigMembers(memberNames []string) error {
 }
 
 func ensureMultisigCompositeKey(multisigKeyName string, members []string, threshold int) (string, error) {
-	if keyExists(multisigKeyName) {
-		log.Printf("  multisig key %s already in keyring, reusing", multisigKeyName)
-		return getAddress(multisigKeyName)
-	}
-
-	// `keys add` is a pure keyring operation; it rejects --node, so skip
-	// buildLumeraArgs here and only append --home when set.
-	//
-	// --nosort keeps members in caller-supplied order. Without it Cosmos SDK
-	// sorts the LegacyAminoPubKey's sub-keys by raw pubkey bytes, which makes
-	// the legacy (cosmos secp256k1) and new (eth_secp256k1) sides land on
-	// different orderings even for matching logical signers (signer-N <->
-	// new-signer-N). That breaks ValidateProofPair's mirror-source rule
-	// (legacy_proof.signer_indices == new_proof.signer_indices) at combine-proof
-	// time. With --nosort on both sides, signer-N consistently lives at
-	// index N-1 on both legacy and new.
-	args := []string{
-		"keys", "add", multisigKeyName,
-		"--multisig", strings.Join(members, ","),
-		"--multisig-threshold", fmt.Sprintf("%d", threshold),
-		"--nosort",
-		"--keyring-backend", "test",
-	}
-	if *flagHome != "" {
-		args = append(args, "--home", *flagHome)
-	}
-	cmd := exec.Command(*flagBin, args...)
-	out, err := cmd.CombinedOutput()
+	addr, err := commonMultisig().CreateMultisigKey(multisigKeyName, members, threshold)
 	if err != nil {
-		return "", fmt.Errorf("keys add multisig %s: %s\n%w", multisigKeyName, string(out), err)
+		return "", err
 	}
-	log.Printf("  created multisig key %s", multisigKeyName)
-	addr, err := getAddress(multisigKeyName)
-	if err != nil {
-		return "", fmt.Errorf("get multisig address %s: %w", multisigKeyName, err)
-	}
+	log.Printf("  multisig key %s -> %s", multisigKeyName, addr)
 	return addr, nil
 }
 
@@ -305,121 +292,12 @@ func registerMultisigPubKey(multisigKeyName, multisigAddr string, members []stri
 		return fmt.Errorf("multisig %s has %d members, need at least %d signers", multisigKeyName, len(members), defaultMultisigThreshold)
 	}
 
-	// Temp files for the unsigned tx and per-member signatures.
 	unsignedFile := tmpFile("multisig-unsigned-*.json")
 	defer os.Remove(unsignedFile)
-
-	sigFiles := make([]string, len(members))
-	for i := range members {
-		sigFiles[i] = tmpFile(fmt.Sprintf("multisig-sig%d-*.json", i+1))
-		defer os.Remove(sigFiles[i]) //nolint:gocritic // intentional deferred cleanup
+	if err := buildUnsignedMultisigBankSendTx(multisigKeyName, multisigAddr, multisigAddr, multisigSelfSendAmt, unsignedFile); err != nil {
+		return err
 	}
-	signedFile := tmpFile("multisig-signed-*.json")
-	defer os.Remove(signedFile)
-
-	// 1. Generate unsigned tx (generate-only).
-	accNum, seq, err := queryAccountNumberAndSequence(multisigAddr)
-	if err != nil {
-		// Account may not exist yet if funding tx hasn't landed — retry once.
-		if waitErr := waitForAccountOnChain(multisigAddr, 30*time.Second); waitErr != nil {
-			return fmt.Errorf("wait for multisig account on-chain: %w", waitErr)
-		}
-		accNum, seq, err = queryAccountNumberAndSequence(multisigAddr)
-		if err != nil {
-			return fmt.Errorf("query account number/sequence for %s: %w", multisigAddr, err)
-		}
-	}
-
-	unsignedArgs := buildLumeraArgs(
-		"tx", "bank", "send",
-		multisigAddr, multisigAddr, multisigSelfSendAmt,
-		"--from", multisigKeyName,
-		"--keyring-backend", "test",
-		"--chain-id", *flagChainID,
-		"--account-number", fmt.Sprintf("%d", accNum),
-		"--sequence", fmt.Sprintf("%d", seq),
-		"--gas", *flagGas,
-		"--gas-prices", *flagGasPrices,
-		"--generate-only",
-		"--output", "json",
-	)
-	cmd := exec.Command(*flagBin, unsignedArgs...)
-	unsignedOut, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("generate unsigned self-send tx: %s\n%w", string(unsignedOut), err)
-	}
-	if err := os.WriteFile(unsignedFile, unsignedOut, 0o600); err != nil {
-		return fmt.Errorf("write unsigned tx to %s: %w", unsignedFile, err)
-	}
-
-	// 2. Each member signs the unsigned tx.
-	for i, member := range members[:defaultMultisigThreshold] {
-		signArgs := buildLumeraArgs(
-			"tx", "sign", unsignedFile,
-			"--from", member,
-			"--multisig", multisigAddr,
-			"--keyring-backend", "test",
-			"--chain-id", *flagChainID,
-			"--account-number", fmt.Sprintf("%d", accNum),
-			"--sequence", fmt.Sprintf("%d", seq),
-			"--sign-mode", "amino-json",
-			"--output", "json",
-		)
-		cmd = exec.Command(*flagBin, signArgs...)
-		sigOut, sigErr := cmd.CombinedOutput()
-		if sigErr != nil {
-			return fmt.Errorf("sign tx with %s: %s\n%w", member, string(sigOut), sigErr)
-		}
-		if err := os.WriteFile(sigFiles[i], sigOut, 0o600); err != nil {
-			return fmt.Errorf("write signature %s to %s: %w", member, sigFiles[i], err)
-		}
-		log.Printf("  signed with %s -> %s", member, sigFiles[i])
-	}
-
-	// 3. Combine signatures via tx multisign.
-	multisignArgs := buildLumeraArgs(
-		"tx", "multisign", unsignedFile, multisigKeyName,
-		sigFiles[0], sigFiles[1],
-		"--keyring-backend", "test",
-		"--chain-id", *flagChainID,
-		"--output", "json",
-	)
-	cmd = exec.Command(*flagBin, multisignArgs...)
-	msignOut, msignErr := cmd.CombinedOutput()
-	if msignErr != nil {
-		return fmt.Errorf("tx multisign: %s\n%w", string(msignOut), msignErr)
-	}
-	if err := os.WriteFile(signedFile, msignOut, 0o600); err != nil {
-		return fmt.Errorf("write signed tx to %s: %w", signedFile, err)
-	}
-
-	// 4. Broadcast the signed tx and wait for inclusion.
-	broadcastArgs := buildLumeraArgs(
-		"tx", "broadcast", signedFile,
-		"--broadcast-mode", "sync",
-		"--output", "json",
-	)
-	cmd = exec.Command(*flagBin, broadcastArgs...)
-	bcastOut, bcastErr := cmd.CombinedOutput()
-	bcastStr := strings.TrimSpace(string(bcastOut))
-	if bcastErr != nil {
-		return fmt.Errorf("broadcast multisig self-send: %s\n%w", bcastStr, bcastErr)
-	}
-
-	// Extract tx hash and wait for inclusion.
-	txHash := extractTxHash(bcastStr)
-	if txHash != "" {
-		code, rawLog, err := waitForTxResult(txHash, 45*time.Second)
-		if err != nil {
-			return fmt.Errorf("wait for self-send tx %s: %w", txHash, err)
-		}
-		if code != 0 {
-			return fmt.Errorf("self-send tx failed code=%d raw_log=%s", code, rawLog)
-		}
-	}
-
-	log.Printf("  multisig self-send confirmed (hash: %s)", txHash)
-	return nil
+	return signAndBroadcastMultisigTx(unsignedFile, multisigKeyName, multisigAddr, members)
 }
 
 // buildUnsignedMultisigBankSendTx generates an unsigned bank-send tx with
@@ -431,34 +309,12 @@ func buildUnsignedMultisigBankSendTx(multisigKeyName, multisigAddr, toAddr, amou
 		if waitErr := waitForAccountOnChain(multisigAddr, 30*time.Second); waitErr != nil {
 			return fmt.Errorf("wait for multisig account on-chain: %w", waitErr)
 		}
-		accNum, seq, err = queryAccountNumberAndSequence(multisigAddr)
-		if err != nil {
+		if accNum, seq, err = queryAccountNumberAndSequence(multisigAddr); err != nil {
 			return fmt.Errorf("query account number/sequence for %s: %w", multisigAddr, err)
 		}
 	}
-
-	unsignedArgs := buildLumeraArgs(
-		"tx", "bank", "send",
-		multisigAddr, toAddr, amount,
-		"--from", multisigKeyName,
-		"--keyring-backend", "test",
-		"--chain-id", *flagChainID,
-		"--account-number", fmt.Sprintf("%d", accNum),
-		"--sequence", fmt.Sprintf("%d", seq),
-		"--gas", *flagGas,
-		"--gas-prices", *flagGasPrices,
-		"--generate-only",
-		"--output", "json",
-	)
-	cmd := exec.Command(*flagBin, unsignedArgs...)
-	unsignedOut, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("generate unsigned multisig bank-send tx: %s\n%w", string(unsignedOut), err)
-	}
-	if err := os.WriteFile(outFile, unsignedOut, 0o600); err != nil {
-		return fmt.Errorf("write unsigned multisig bank-send tx to %s: %w", outFile, err)
-	}
-	return nil
+	m := commonMultisig()
+	return m.BuildUnsignedToFile(outFile, m.GenBankSendArgs(multisigKeyName, multisigAddr, toAddr, amount, accNum, seq))
 }
 
 func buildUnsignedMultisigDelegateTx(multisigKeyName, multisigAddr, validatorAddr, amount, outFile string) error {
@@ -467,114 +323,23 @@ func buildUnsignedMultisigDelegateTx(multisigKeyName, multisigAddr, validatorAdd
 		if waitErr := waitForAccountOnChain(multisigAddr, 30*time.Second); waitErr != nil {
 			return fmt.Errorf("wait for multisig account on-chain: %w", waitErr)
 		}
-		accNum, seq, err = queryAccountNumberAndSequence(multisigAddr)
-		if err != nil {
+		if accNum, seq, err = queryAccountNumberAndSequence(multisigAddr); err != nil {
 			return fmt.Errorf("query account number/sequence for %s: %w", multisigAddr, err)
 		}
 	}
-
-	unsignedArgs := buildLumeraArgs(
-		"tx", "staking", "delegate",
-		validatorAddr, amount,
-		"--from", multisigKeyName,
-		"--keyring-backend", "test",
-		"--chain-id", *flagChainID,
-		"--account-number", fmt.Sprintf("%d", accNum),
-		"--sequence", fmt.Sprintf("%d", seq),
-		"--gas", *flagGas,
-		"--gas-prices", *flagGasPrices,
-		"--generate-only",
-		"--output", "json",
-	)
-	cmd := exec.Command(*flagBin, unsignedArgs...)
-	unsignedOut, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("generate unsigned multisig delegate tx: %s\n%w", string(unsignedOut), err)
-	}
-	if err := os.WriteFile(outFile, unsignedOut, 0o600); err != nil {
-		return fmt.Errorf("write unsigned multisig delegate tx to %s: %w", outFile, err)
-	}
-	return nil
+	m := commonMultisig()
+	return m.BuildUnsignedToFile(outFile, m.GenDelegateArgs(multisigKeyName, validatorAddr, amount, accNum, seq))
 }
 
 func signAndBroadcastMultisigTx(unsignedFile, multisigKeyName, multisigAddr string, members []string) error {
-	if len(members) < defaultMultisigThreshold {
-		return fmt.Errorf("multisig %s has %d members, need at least %d", multisigKeyName, len(members), defaultMultisigThreshold)
-	}
-
 	accNum, seq, err := queryAccountNumberAndSequence(multisigAddr)
 	if err != nil {
 		return fmt.Errorf("query account number/sequence for %s: %w", multisigAddr, err)
 	}
-
-	sigFiles := make([]string, defaultMultisigThreshold)
-	for i := range sigFiles {
-		sigFiles[i] = tmpFile(fmt.Sprintf("multisig-sig%d-*.json", i+1))
-		defer os.Remove(sigFiles[i]) //nolint:gocritic // intentional deferred cleanup
-	}
-	signedFile := tmpFile("multisig-signed-*.json")
-	defer os.Remove(signedFile)
-
-	for i, member := range members[:defaultMultisigThreshold] {
-		signArgs := buildLumeraArgs(
-			"tx", "sign", unsignedFile,
-			"--from", member,
-			"--multisig", multisigAddr,
-			"--keyring-backend", "test",
-			"--chain-id", *flagChainID,
-			"--account-number", fmt.Sprintf("%d", accNum),
-			"--sequence", fmt.Sprintf("%d", seq),
-			"--sign-mode", "amino-json",
-			"--output", "json",
-		)
-		cmd := exec.Command(*flagBin, signArgs...)
-		sigOut, sigErr := cmd.CombinedOutput()
-		if sigErr != nil {
-			return fmt.Errorf("sign tx with %s: %s\n%w", member, string(sigOut), sigErr)
-		}
-		if err := os.WriteFile(sigFiles[i], sigOut, 0o600); err != nil {
-			return fmt.Errorf("write signature %s to %s: %w", member, sigFiles[i], err)
-		}
-	}
-
-	multisignArgs := buildLumeraArgs(
-		"tx", "multisign", unsignedFile, multisigKeyName,
-		sigFiles[0], sigFiles[1],
-		"--keyring-backend", "test",
-		"--chain-id", *flagChainID,
-		"--output", "json",
+	_, err = commonMultisig().SignAndBroadcastFile(
+		unsignedFile, multisigKeyName, multisigAddr, members, defaultMultisigThreshold, accNum, seq,
 	)
-	cmd := exec.Command(*flagBin, multisignArgs...)
-	msignOut, msignErr := cmd.CombinedOutput()
-	if msignErr != nil {
-		return fmt.Errorf("tx multisign: %s\n%w", string(msignOut), msignErr)
-	}
-	if err := os.WriteFile(signedFile, msignOut, 0o600); err != nil {
-		return fmt.Errorf("write signed tx to %s: %w", signedFile, err)
-	}
-
-	broadcastArgs := buildLumeraArgs(
-		"tx", "broadcast", signedFile,
-		"--broadcast-mode", "sync",
-		"--output", "json",
-	)
-	cmd = exec.Command(*flagBin, broadcastArgs...)
-	bcastOut, bcastErr := cmd.CombinedOutput()
-	bcastStr := strings.TrimSpace(string(bcastOut))
-	if bcastErr != nil {
-		return fmt.Errorf("broadcast multisig tx: %s\n%w", bcastStr, bcastErr)
-	}
-	txHash := extractTxHash(bcastStr)
-	if txHash != "" {
-		code, rawLog, err := waitForTxResult(txHash, 45*time.Second)
-		if err != nil {
-			return fmt.Errorf("wait for multisig tx %s: %w", txHash, err)
-		}
-		if code != 0 {
-			return fmt.Errorf("multisig tx failed code=%d raw_log=%s", code, rawLog)
-		}
-	}
-	return nil
+	return err
 }
 
 // createNewEVMKey creates (or reuses) the eth_secp256k1 destination key.

--- a/devnet/tests/evmigration/multisig.go
+++ b/devnet/tests/evmigration/multisig.go
@@ -138,18 +138,6 @@ func ensureNewMultisigFixture() (compositeAddr string, subKeyNames []string, err
 	return addr, subKeys, nil
 }
 
-// getLegacyMultisigKeys returns the 3 legacy sub-key names and the composite
-// key name for the default multisig fixture (suitable for CLI invocations).
-func getLegacyMultisigKeys() (subKeys []string, compositeName string) {
-	return []string{multisigSigner1Name, multisigSigner2Name, multisigSigner3Name}, multisigAccountName
-}
-
-// getNewMultisigKeys returns the 3 new-side eth sub-key names and the new
-// composite key name for the default multisig fixture.
-func getNewMultisigKeys() (subKeys []string, compositeName string) {
-	return []string{multisigNewSigner1Name, multisigNewSigner2Name, multisigNewSigner3Name}, multisigNewCompositeName
-}
-
 // RunMultisigMigration is the main entry point for the "multisig" mode. It
 // orchestrates the full flow end-to-end and returns an error if any step fails.
 func RunMultisigMigration() error {
@@ -293,7 +281,7 @@ func registerMultisigPubKey(multisigKeyName, multisigAddr string, members []stri
 	}
 
 	unsignedFile := tmpFile("multisig-unsigned-*.json")
-	defer os.Remove(unsignedFile)
+	defer func() { _ = os.Remove(unsignedFile) }()
 	if err := buildUnsignedMultisigBankSendTx(multisigKeyName, multisigAddr, multisigAddr, multisigSelfSendAmt, unsignedFile); err != nil {
 		return err
 	}
@@ -377,23 +365,23 @@ func createOrReuseFreshEVMKey(keyName string) (AccountRecord, error) {
 // introduced by Tasks 14/15/17:
 //
 //  1. generate-proof-payload --legacy <legacyAddr>
-//       --new-sub-pub-keys <comma-list of new-side eth sub-key names>
-//       --new-threshold <K> --kind <kind> --out proof.json
+//     --new-sub-pub-keys <comma-list of new-side eth sub-key names>
+//     --new-threshold <K> --kind <kind> --out proof.json
 //  2. sign-proof proof.json --from <legacy-sub[0]> --new-key <new-sub[0]>
 //  3. sign-proof proof.json --from <legacy-sub[2]> --new-key <new-sub[2]>
 //     (indices 0 and 2 satisfy a 2-of-3 threshold on both sides).
 //  4. combine-proof proof.json --out tx.json
 //  5. submit-proof tx.json --chain-id <id>
 //     (no --from: migration txs are unsigned at the Cosmos layer; authorization
-//      is embedded in the legacy/new proofs.)
+//     is embedded in the legacy/new proofs.)
 func runFourStepMigrationMultisig(
 	kind, legacyAddr string, legacyMembers []string,
 	newCompositeAddr string, newSubKeyNames []string, newThreshold int,
 ) error {
 	proofFile := tmpFile("multisig-proof-*.json")
-	defer os.Remove(proofFile)
+	defer func() { _ = os.Remove(proofFile) }()
 	txFile := tmpFile("multisig-tx-*.json")
-	defer os.Remove(txFile)
+	defer func() { _ = os.Remove(txFile) }()
 
 	if kind == "" {
 		kind = "claim"
@@ -564,7 +552,9 @@ func tmpFile(pattern string) string {
 	if err != nil {
 		log.Fatalf("create temp file %s: %v", pattern, err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		log.Fatalf("close temp file %s: %v", f.Name(), err)
+	}
 	return f.Name()
 }
 
@@ -879,7 +869,7 @@ func signAndBroadcastMsgEditValidator(
 	}
 
 	unsignedFile := tmpFile("edit-val-unsigned-*.json")
-	defer os.Remove(unsignedFile)
+	defer func() { _ = os.Remove(unsignedFile) }()
 
 	// 1. Generate the unsigned edit-validator tx (generate-only).
 	accNum, seq, err := queryAccountNumberAndSequence(newCompositeAddr)

--- a/devnet/tests/evmigration/query_migration.go
+++ b/devnet/tests/evmigration/query_migration.go
@@ -9,7 +9,24 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"gen/tests/common"
 )
+
+// evmigCLI builds a common.ChainCLI from this tool's connection flags so the
+// shared migration query/parsing primitives can be reused instead of the local
+// duplicates.
+func evmigCLI() *common.ChainCLI {
+	return &common.ChainCLI{
+		Bin:            *flagBin,
+		ChainID:        *flagChainID,
+		RPC:            *flagRPC,
+		Home:           *flagHome,
+		KeyringBackend: "test",
+		Gas:            *flagGas,
+		GasPrices:      *flagGasPrices,
+	}
+}
 
 const (
 	protoPermanentLockedAccountType  = "/cosmos.vesting.v1beta1.PermanentLockedAccount"
@@ -48,48 +65,25 @@ type migrationParams struct {
 }
 
 // queryMigrationEstimate queries the evmigration module for a migration estimate
-// for the given legacy address.
+// for the given legacy address. It delegates to the shared common helper and
+// maps the result onto this tool's local type.
 func queryMigrationEstimate(addr string) (migrationEstimate, error) {
-	out, err := run("query", "evmigration", "migration-estimate", addr)
+	est, err := evmigCLI().MigrationEstimate(addr)
 	if err != nil {
-		return migrationEstimate{}, fmt.Errorf("query migration-estimate: %s\n%w", out, err)
+		return migrationEstimate{}, err
 	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(out), &raw); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate: %s\n%w", truncate(out, 300), err)
-	}
-
-	estimate := migrationEstimate{}
-	if estimate.WouldSucceed, err = parseFlexibleJSONBool(raw["would_succeed"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.would_succeed: %w", err)
-	}
-	estimate.RejectionReason = parseFlexibleJSONString(raw["rejection_reason"])
-	if estimate.DelegationCount, err = parseFlexibleJSONInt(raw["delegation_count"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.delegation_count: %w", err)
-	}
-	if estimate.UnbondingCount, err = parseFlexibleJSONInt(raw["unbonding_count"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.unbonding_count: %w", err)
-	}
-	if estimate.RedelegationCount, err = parseFlexibleJSONInt(raw["redelegation_count"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.redelegation_count: %w", err)
-	}
-	if estimate.AuthzGrantCount, err = parseFlexibleJSONInt(raw["authz_grant_count"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.authz_grant_count: %w", err)
-	}
-	if estimate.FeegrantCount, err = parseFlexibleJSONInt(raw["feegrant_count"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.feegrant_count: %w", err)
-	}
-	if estimate.ActionCount, err = parseFlexibleJSONInt(raw["action_count"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.action_count: %w", err)
-	}
-	if estimate.ValDelegationCount, err = parseFlexibleJSONInt(raw["val_delegation_count"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.val_delegation_count: %w", err)
-	}
-	if estimate.IsValidator, err = parseFlexibleJSONBool(raw["is_validator"]); err != nil {
-		return migrationEstimate{}, fmt.Errorf("parse migration-estimate.is_validator: %w", err)
-	}
-
-	return estimate, nil
+	return migrationEstimate{
+		WouldSucceed:       est.WouldSucceed,
+		RejectionReason:    est.RejectionReason,
+		DelegationCount:    est.DelegationCount,
+		UnbondingCount:     est.UnbondingCount,
+		RedelegationCount:  est.RedelegationCount,
+		AuthzGrantCount:    est.AuthzGrantCount,
+		FeegrantCount:      est.FeegrantCount,
+		ActionCount:        est.ActionCount,
+		ValDelegationCount: est.ValDelegationCount,
+		IsValidator:        est.IsValidator,
+	}, nil
 }
 
 // queryAccountNumberAndSequence returns the on-chain account number and sequence
@@ -372,35 +366,20 @@ func waitForAccountOnChain(addr string, timeout time.Duration) error {
 	return fmt.Errorf("account %s not available on-chain after %s: %w", addr, timeout, lastErr)
 }
 
-// queryMigrationStats queries the global migration statistics from the evmigration module.
+// queryMigrationStats queries the global migration statistics from the
+// evmigration module via the shared common helper.
 func queryMigrationStats() (migrationStats, error) {
-	out, err := run("query", "evmigration", "migration-stats")
+	s, err := evmigCLI().MigrationStats()
 	if err != nil {
-		return migrationStats{}, fmt.Errorf("query migration-stats: %s\n%w", out, err)
+		return migrationStats{}, err
 	}
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(out), &raw); err != nil {
-		return migrationStats{}, fmt.Errorf("parse migration-stats: %s\n%w", truncate(out, 300), err)
-	}
-
-	stats := migrationStats{}
-	if stats.TotalMigrated, err = parseFlexibleJSONInt(raw["total_migrated"]); err != nil {
-		return migrationStats{}, fmt.Errorf("parse migration-stats.total_migrated: %w", err)
-	}
-	if stats.TotalLegacy, err = parseFlexibleJSONInt(raw["total_legacy"]); err != nil {
-		return migrationStats{}, fmt.Errorf("parse migration-stats.total_legacy: %w", err)
-	}
-	if stats.TotalLegacyStaked, err = parseFlexibleJSONInt(raw["total_legacy_staked"]); err != nil {
-		return migrationStats{}, fmt.Errorf("parse migration-stats.total_legacy_staked: %w", err)
-	}
-	if stats.TotalValidatorsMigrated, err = parseFlexibleJSONInt(raw["total_validators_migrated"]); err != nil {
-		return migrationStats{}, fmt.Errorf("parse migration-stats.total_validators_migrated: %w", err)
-	}
-	if stats.TotalValidatorsLegacy, err = parseFlexibleJSONInt(raw["total_validators_legacy"]); err != nil {
-		return migrationStats{}, fmt.Errorf("parse migration-stats.total_validators_legacy: %w", err)
-	}
-
-	return stats, nil
+	return migrationStats{
+		TotalMigrated:           s.TotalMigrated,
+		TotalLegacy:             s.TotalLegacy,
+		TotalLegacyStaked:       s.TotalLegacyStaked,
+		TotalValidatorsMigrated: s.TotalValidatorsMigrated,
+		TotalValidatorsLegacy:   s.TotalValidatorsLegacy,
+	}, nil
 }
 
 // queryLegacyAccountAddresses returns the addresses of all accounts still in
@@ -425,148 +404,20 @@ func queryLegacyAccountAddresses() ([]string, error) {
 	return addrs, nil
 }
 
-// queryMigrationParams queries the evmigration module parameters.
+// queryMigrationParams queries the evmigration module parameters via the shared
+// common helper.
 func queryMigrationParams() (migrationParams, error) {
-	out, err := run("query", "evmigration", "params")
+	p, err := evmigCLI().MigrationParams()
 	if err != nil {
-		return migrationParams{}, fmt.Errorf("query evmigration params: %s\n%w", out, err)
+		return migrationParams{}, err
 	}
-
-	var top map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(out), &top); err != nil {
-		return migrationParams{}, fmt.Errorf("parse evmigration params: %s\n%w", truncate(out, 300), err)
-	}
-
-	paramsRaw := top["params"]
-	if len(paramsRaw) == 0 {
-		paramsRaw = []byte(out)
-	}
-
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(paramsRaw, &raw); err != nil {
-		return migrationParams{}, fmt.Errorf("parse evmigration params payload: %s\n%w", truncate(string(paramsRaw), 300), err)
-	}
-
-	params := migrationParams{}
-	if params.EnableMigration, err = parseFlexibleJSONBool(raw["enable_migration"]); err != nil {
-		return migrationParams{}, fmt.Errorf("parse params.enable_migration: %w", err)
-	}
-	if params.MigrationEndTime, err = parseFlexibleJSONInt64(raw["migration_end_time"]); err != nil {
-		return migrationParams{}, fmt.Errorf("parse params.migration_end_time: %w", err)
-	}
-	if params.MaxMigrationsPerBlock, err = parseFlexibleJSONInt(raw["max_migrations_per_block"]); err != nil {
-		return migrationParams{}, fmt.Errorf("parse params.max_migrations_per_block: %w", err)
-	}
-	if params.MaxValidatorDelegations, err = parseFlexibleJSONInt(raw["max_validator_delegations"]); err != nil {
-		return migrationParams{}, fmt.Errorf("parse params.max_validator_delegations: %w", err)
-	}
-
-	return params, nil
+	return migrationParams{
+		EnableMigration:         p.EnableMigration,
+		MigrationEndTime:        p.MigrationEndTime,
+		MaxMigrationsPerBlock:   p.MaxMigrationsPerBlock,
+		MaxValidatorDelegations: p.MaxValidatorDelegations,
+	}, nil
 }
 
-// --- Flexible JSON parsers ---
-// Cosmos SDK query output is inconsistent across versions: numeric fields may
-// appear as JSON numbers or as quoted strings. These helpers handle both.
-
-// parseFlexibleJSONInt parses an int from JSON that may be a number or a quoted string.
-func parseFlexibleJSONInt(raw json.RawMessage) (int, error) {
-	if len(raw) == 0 {
-		return 0, nil
-	}
-
-	var asString string
-	if err := json.Unmarshal(raw, &asString); err == nil {
-		asString = strings.TrimSpace(asString)
-		if asString == "" {
-			return 0, nil
-		}
-		n, err := strconv.Atoi(asString)
-		if err != nil {
-			return 0, fmt.Errorf("parse %q as int: %w", asString, err)
-		}
-		return n, nil
-	}
-
-	var asInt int
-	if err := json.Unmarshal(raw, &asInt); err == nil {
-		return asInt, nil
-	}
-
-	var asInt64 int64
-	if err := json.Unmarshal(raw, &asInt64); err == nil {
-		return int(asInt64), nil
-	}
-
-	return 0, fmt.Errorf("unsupported numeric format: %s", string(raw))
-}
-
-// parseFlexibleJSONInt64 parses an int64 from JSON that may be a number or a quoted string.
-func parseFlexibleJSONInt64(raw json.RawMessage) (int64, error) {
-	if len(raw) == 0 {
-		return 0, nil
-	}
-
-	var asString string
-	if err := json.Unmarshal(raw, &asString); err == nil {
-		asString = strings.TrimSpace(asString)
-		if asString == "" {
-			return 0, nil
-		}
-		n, err := strconv.ParseInt(asString, 10, 64)
-		if err != nil {
-			return 0, fmt.Errorf("parse %q as int64: %w", asString, err)
-		}
-		return n, nil
-	}
-
-	var asInt64 int64
-	if err := json.Unmarshal(raw, &asInt64); err == nil {
-		return asInt64, nil
-	}
-
-	var asInt int
-	if err := json.Unmarshal(raw, &asInt); err == nil {
-		return int64(asInt), nil
-	}
-
-	return 0, fmt.Errorf("unsupported numeric format: %s", string(raw))
-}
-
-// parseFlexibleJSONBool parses a bool from JSON that may be a boolean or a quoted string.
-func parseFlexibleJSONBool(raw json.RawMessage) (bool, error) {
-	if len(raw) == 0 {
-		return false, nil
-	}
-
-	var asBool bool
-	if err := json.Unmarshal(raw, &asBool); err == nil {
-		return asBool, nil
-	}
-
-	var asString string
-	if err := json.Unmarshal(raw, &asString); err == nil {
-		asString = strings.TrimSpace(strings.ToLower(asString))
-		switch asString {
-		case "", "false", "0":
-			return false, nil
-		case "true", "1":
-			return true, nil
-		default:
-			return false, fmt.Errorf("parse %q as bool", asString)
-		}
-	}
-
-	return false, fmt.Errorf("unsupported bool format: %s", string(raw))
-}
-
-// parseFlexibleJSONString parses a string from JSON, falling back to raw content if unquoted.
-func parseFlexibleJSONString(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var asString string
-	if err := json.Unmarshal(raw, &asString); err == nil {
-		return strings.TrimSpace(asString)
-	}
-	return strings.TrimSpace(string(raw))
-}
+// Flexible JSON scalar parsing now lives in the shared common package
+// (common/migration.go); the query helpers above delegate to it.

--- a/devnet/tests/gen-activity/activity_plan.go
+++ b/devnet/tests/gen-activity/activity_plan.go
@@ -106,19 +106,23 @@ func buildActivityPlans(accounts []*AccountRecord, validators []string, rng *ran
 	return plans
 }
 
+// activityTargets returns the funded accounts that take part in the regular
+// single-sig activity mix. Multisig composites are excluded: they cannot sign an
+// ordinary single-sig --from tx and have their own dedicated exercise path
+// (exerciseMultisigAccounts), so including them here would only produce
+// guaranteed-failing delegate/bank-send/action attempts.
 func activityTargets(reg *ActivityRegistry, newRecords []*AccountRecord, includeExisting bool) []*AccountRecord {
+	var out []*AccountRecord
 	if includeExisting {
-		var out []*AccountRecord
 		for _, rec := range reg.Accounts {
-			if rec.Funded {
+			if rec.Funded && rec.Multisig == nil {
 				out = append(out, rec)
 			}
 		}
 		return out
 	}
-	var out []*AccountRecord
 	for _, rec := range newRecords {
-		if rec.Funded {
+		if rec.Funded && rec.Multisig == nil {
 			out = append(out, rec)
 		}
 	}

--- a/devnet/tests/gen-activity/config.go
+++ b/devnet/tests/gen-activity/config.go
@@ -38,6 +38,9 @@ type Config struct {
 	NumMultisig23 int // 2-of-3 multisig accounts
 	NumMultisig35 int // 3-of-5 multisig accounts
 
+	VestingPercent     int // percent of regular accounts created as vesting (0-100)
+	NumPermanentLocked int // dedicated PermanentLocked accounts
+
 	// Rerun modes.
 	AddAccounts      bool
 	ActivityExisting bool
@@ -91,6 +94,12 @@ func (c *Config) Validate() error {
 	}
 	if c.NumMultisig35 < 0 {
 		return fmt.Errorf("-num-multisig35-accounts must be >= 0, got %d", c.NumMultisig35)
+	}
+	if c.VestingPercent < 0 || c.VestingPercent > 100 {
+		return fmt.Errorf("-vesting-percent must be in [0,100], got %d", c.VestingPercent)
+	}
+	if c.NumPermanentLocked < 0 {
+		return fmt.Errorf("-num-permanent-locked-accounts must be >= 0, got %d", c.NumPermanentLocked)
 	}
 
 	coin, err := common.ValidateMaxAccountAmount(c.MaxAccountAmount)

--- a/devnet/tests/gen-activity/config.go
+++ b/devnet/tests/gen-activity/config.go
@@ -77,6 +77,9 @@ func (c *Config) Validate() error {
 	if c.AccountsPath == "" {
 		return fmt.Errorf("-accounts is required")
 	}
+	if c.AddAccounts && c.ActivityExisting {
+		return fmt.Errorf("-add-accounts and -activity-existing are mutually exclusive")
+	}
 	if c.NumAccounts < 0 {
 		return fmt.Errorf("-num-accounts must be >= 0, got %d", c.NumAccounts)
 	}

--- a/devnet/tests/gen-activity/config.go
+++ b/devnet/tests/gen-activity/config.go
@@ -7,6 +7,15 @@ import (
 	"gen/tests/common"
 )
 
+// Run modes. The legacy boolean flags (AddAccounts/ActivityExisting) fold into
+// these via resolveMode; the unset state means ModeFresh.
+const (
+	ModeFresh            = "fresh"
+	ModeAddAccounts      = "add-accounts"
+	ModeActivityExisting = "activity-existing"
+	ModeMigrate          = "migrate"
+)
+
 // Config holds the parsed command-line configuration for the activity
 // generator.
 type Config struct {
@@ -23,6 +32,10 @@ type Config struct {
 	ConfigPath string
 	Chain      string
 	Wizard     bool
+
+	// Mode is the explicit run mode (fresh|add-accounts|activity-existing|
+	// migrate). Empty means "derive from the legacy boolean flags below".
+	Mode string
 
 	// Funding signer.
 	FundingKey string
@@ -60,31 +73,79 @@ type Config struct {
 	// Parsed/validated values, populated by Validate.
 	maxAmount    common.Coin
 	actionStates []common.ActionState
+	resolvedMode string
+}
+
+// resolveMode reconciles the explicit Mode field with the legacy boolean flags
+// (AddAccounts/ActivityExisting) into a single canonical mode, returning an
+// error on any contradiction. The unset state means ModeFresh.
+func (c *Config) resolveMode() (string, error) {
+	// Mode implied by the legacy boolean flags.
+	boolMode := ""
+	switch {
+	case c.AddAccounts && c.ActivityExisting:
+		return "", fmt.Errorf("-add-accounts and -activity-existing are mutually exclusive")
+	case c.AddAccounts:
+		boolMode = ModeAddAccounts
+	case c.ActivityExisting:
+		boolMode = ModeActivityExisting
+	}
+
+	if c.Mode == "" {
+		if boolMode == "" {
+			return ModeFresh, nil
+		}
+		return boolMode, nil
+	}
+
+	switch c.Mode {
+	case ModeFresh, ModeAddAccounts, ModeActivityExisting, ModeMigrate:
+	default:
+		return "", fmt.Errorf("invalid -mode %q (want fresh|add-accounts|activity-existing|migrate)", c.Mode)
+	}
+
+	// An explicit mode must not contradict a legacy boolean flag.
+	if boolMode != "" && boolMode != c.Mode {
+		return "", fmt.Errorf("-mode %q conflicts with -%s", c.Mode, boolMode)
+	}
+	return c.Mode, nil
 }
 
 // Validate checks the configuration and populates parsed values (maxAmount,
 // actionStates). It returns the first error encountered.
 func (c *Config) Validate() error {
+	mode, err := c.resolveMode()
+	if err != nil {
+		return err
+	}
+	c.resolvedMode = mode
+
+	// Requirements common to every mode.
 	if c.Bin == "" {
 		return fmt.Errorf("-bin is required")
 	}
 	if c.ChainID == "" {
 		return fmt.Errorf("-chain-id is required")
 	}
-	if c.FundingKey == "" {
-		return fmt.Errorf("-funding-key is required")
-	}
 	if c.AccountsPath == "" {
 		return fmt.Errorf("-accounts is required")
 	}
-	if c.AddAccounts && c.ActivityExisting {
-		return fmt.Errorf("-add-accounts and -activity-existing are mutually exclusive")
+	if c.Parallelism < 1 {
+		return fmt.Errorf("-parallelism must be >= 1, got %d", c.Parallelism)
+	}
+
+	// Migrate mode signs with the legacy accounts and uses evmigration fee
+	// handling, so it needs neither a funder key nor any generation/activity
+	// settings. Skip those checks.
+	if mode == ModeMigrate {
+		return nil
+	}
+
+	if c.FundingKey == "" {
+		return fmt.Errorf("-funding-key is required")
 	}
 	if c.NumAccounts < 0 {
 		return fmt.Errorf("-num-accounts must be >= 0, got %d", c.NumAccounts)
-	}
-	if c.Parallelism < 1 {
-		return fmt.Errorf("-parallelism must be >= 1, got %d", c.Parallelism)
 	}
 	if c.FundingBatchSize < 1 {
 		return fmt.Errorf("-funding-batch-size must be >= 1, got %d", c.FundingBatchSize)

--- a/devnet/tests/gen-activity/config.go
+++ b/devnet/tests/gen-activity/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	KeyringBackend string
 	EVMCutoverVer  string
 
+	// Config file + chain selection + mode.
+	ConfigPath string
+	Chain      string
+	Wizard     bool
+
 	// Funding signer.
 	FundingKey string
 
@@ -27,6 +32,11 @@ type Config struct {
 	NumAccounts      int
 	MaxAccountAmount string
 	AccountPrefix    string
+
+	// Multisig account generation. Behavior implemented in the multisig plan;
+	// validated here so the flag/wizard surface is complete.
+	NumMultisig23 int // 2-of-3 multisig accounts
+	NumMultisig35 int // 3-of-5 multisig accounts
 
 	// Rerun modes.
 	AddAccounts      bool
@@ -75,6 +85,12 @@ func (c *Config) Validate() error {
 	}
 	if c.MaxActionsPerRun < 0 {
 		return fmt.Errorf("-max-actions-per-run must be >= 0, got %d", c.MaxActionsPerRun)
+	}
+	if c.NumMultisig23 < 0 {
+		return fmt.Errorf("-num-multisig23-accounts must be >= 0, got %d", c.NumMultisig23)
+	}
+	if c.NumMultisig35 < 0 {
+		return fmt.Errorf("-num-multisig35-accounts must be >= 0, got %d", c.NumMultisig35)
 	}
 
 	coin, err := common.ValidateMaxAccountAmount(c.MaxAccountAmount)

--- a/devnet/tests/gen-activity/config_test.go
+++ b/devnet/tests/gen-activity/config_test.go
@@ -103,6 +103,38 @@ func TestConfigValidate(t *testing.T) {
 	})
 }
 
+func TestConfigValidateVesting(t *testing.T) {
+	t.Run("valid vesting-percent passes", func(t *testing.T) {
+		c := validConfig()
+		c.VestingPercent = 30
+		c.NumPermanentLocked = 2
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("vesting-percent over 100 fails", func(t *testing.T) {
+		c := validConfig()
+		c.VestingPercent = 101
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for vesting-percent > 100")
+		}
+	})
+	t.Run("negative vesting-percent fails", func(t *testing.T) {
+		c := validConfig()
+		c.VestingPercent = -1
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for negative vesting-percent")
+		}
+	})
+	t.Run("negative num-permanent-locked fails", func(t *testing.T) {
+		c := validConfig()
+		c.NumPermanentLocked = -1
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for negative num-permanent-locked-accounts")
+		}
+	})
+}
+
 func TestConfigValidateMultisigCounts(t *testing.T) {
 	t.Run("zero multisig counts pass", func(t *testing.T) {
 		c := validConfig()

--- a/devnet/tests/gen-activity/config_test.go
+++ b/devnet/tests/gen-activity/config_test.go
@@ -101,6 +101,15 @@ func TestConfigValidate(t *testing.T) {
 			t.Error("expected error for negative num-accounts")
 		}
 	})
+
+	t.Run("add-accounts and activity-existing are mutually exclusive", func(t *testing.T) {
+		c := validConfig()
+		c.AddAccounts = true
+		c.ActivityExisting = true
+		if err := c.Validate(); err == nil {
+			t.Error("expected error when both add-accounts and activity-existing are set")
+		}
+	})
 }
 
 func TestConfigValidateVesting(t *testing.T) {

--- a/devnet/tests/gen-activity/config_test.go
+++ b/devnet/tests/gen-activity/config_test.go
@@ -102,3 +102,30 @@ func TestConfigValidate(t *testing.T) {
 		}
 	})
 }
+
+func TestConfigValidateMultisigCounts(t *testing.T) {
+	t.Run("zero multisig counts pass", func(t *testing.T) {
+		c := validConfig()
+		c.NumMultisig23 = 0
+		c.NumMultisig35 = 0
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("negative num-multisig23 fails", func(t *testing.T) {
+		c := validConfig()
+		c.NumMultisig23 = -1
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for negative num-multisig23-accounts")
+		}
+	})
+
+	t.Run("negative num-multisig35 fails", func(t *testing.T) {
+		c := validConfig()
+		c.NumMultisig35 = -2
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for negative num-multisig35-accounts")
+		}
+	})
+}

--- a/devnet/tests/gen-activity/configfile.go
+++ b/devnet/tests/gen-activity/configfile.go
@@ -22,6 +22,7 @@ type ChainSection struct {
 	Home             *string `toml:"home"`
 	KeyringBackend   *string `toml:"keyring-backend"`
 	EVMCutoverVer    *string `toml:"evm-cutover-version"`
+	Mode             *string `toml:"mode"`
 	FundingKey       *string `toml:"funding-key"`
 	AccountsPath     *string `toml:"accounts"`
 	NumAccounts      *int    `toml:"num-accounts"`
@@ -140,6 +141,7 @@ func applyLayer(c *Config, sec ChainSection, setFlags map[string]bool) error {
 	str("home", sec.Home, &c.Home)
 	str("keyring-backend", sec.KeyringBackend, &c.KeyringBackend)
 	str("evm-cutover-version", sec.EVMCutoverVer, &c.EVMCutoverVer)
+	str("mode", sec.Mode, &c.Mode)
 	str("funding-key", sec.FundingKey, &c.FundingKey)
 	str("accounts", sec.AccountsPath, &c.AccountsPath)
 	str("max-account-amount", sec.MaxAccountAmount, &c.MaxAccountAmount)

--- a/devnet/tests/gen-activity/configfile.go
+++ b/devnet/tests/gen-activity/configfile.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"time"
 
 	toml "github.com/pelletier/go-toml/v2"
 )
@@ -14,25 +15,34 @@ import (
 // from an explicit zero value; nil means "not set in this section". Keys mirror
 // the CLI flag names so config and flags map one-to-one.
 type ChainSection struct {
-	Bin                *string `toml:"bin"`
-	RPC                *string `toml:"rpc"`
-	GRPC               *string `toml:"grpc"`
-	ChainID            *string `toml:"chain-id"`
-	Home               *string `toml:"home"`
-	KeyringBackend     *string `toml:"keyring-backend"`
-	EVMCutoverVer      *string `toml:"evm-cutover-version"`
-	FundingKey         *string `toml:"funding-key"`
-	AccountsPath       *string `toml:"accounts"`
-	NumAccounts        *int    `toml:"num-accounts"`
-	MaxAccountAmount   *string `toml:"max-account-amount"`
-	AccountPrefix      *string `toml:"account-prefix"`
-	Actions            *bool   `toml:"actions"`
-	FundingBatchSize   *int    `toml:"funding-batch-size"`
-	Parallelism        *int    `toml:"parallelism"`
-	NumMultisig23      *int    `toml:"num-multisig23-accounts"`
-	NumMultisig35      *int    `toml:"num-multisig35-accounts"`
-	VestingPercent     *int    `toml:"vesting-percent"`
-	NumPermanentLocked *int    `toml:"num-permanent-locked-accounts"`
+	Bin              *string `toml:"bin"`
+	RPC              *string `toml:"rpc"`
+	GRPC             *string `toml:"grpc"`
+	ChainID          *string `toml:"chain-id"`
+	Home             *string `toml:"home"`
+	KeyringBackend   *string `toml:"keyring-backend"`
+	EVMCutoverVer    *string `toml:"evm-cutover-version"`
+	FundingKey       *string `toml:"funding-key"`
+	AccountsPath     *string `toml:"accounts"`
+	NumAccounts      *int    `toml:"num-accounts"`
+	MaxAccountAmount *string `toml:"max-account-amount"`
+	AccountPrefix    *string `toml:"account-prefix"`
+	AddAccounts      *bool   `toml:"add-accounts"`
+	ActivityExisting *bool   `toml:"activity-existing"`
+	Actions          *bool   `toml:"actions"`
+	RequireActions   *bool   `toml:"require-actions"`
+	MaxActionsPerRun *int    `toml:"max-actions-per-run"`
+	ActionStates     *string `toml:"action-states"`
+	// ActionReadinessTimeout mirrors the CLI duration flag, represented as a
+	// string in TOML (for example, "30s" or "3m").
+	ActionReadinessTimeout *string `toml:"action-readiness-timeout"`
+	FundingBatchSize       *int    `toml:"funding-batch-size"`
+	Parallelism            *int    `toml:"parallelism"`
+	DryRun                 *bool   `toml:"dry-run"`
+	NumMultisig23          *int    `toml:"num-multisig23-accounts"`
+	NumMultisig35          *int    `toml:"num-multisig35-accounts"`
+	VestingPercent         *int    `toml:"vesting-percent"`
+	NumPermanentLocked     *int    `toml:"num-permanent-locked-accounts"`
 }
 
 // FileConfig is the parsed gen-activity-config.toml: a shared [common] section
@@ -78,7 +88,9 @@ func ApplyFileConfig(c *Config, fc *FileConfig, chain string, setFlags map[strin
 	if fc == nil {
 		return nil
 	}
-	applyLayer(c, fc.Common, setFlags)
+	if err := applyLayer(c, fc.Common, setFlags); err != nil {
+		return err
+	}
 	if chain == "" {
 		return nil
 	}
@@ -86,15 +98,14 @@ func ApplyFileConfig(c *Config, fc *FileConfig, chain string, setFlags map[strin
 	if !ok {
 		return fmt.Errorf("chain %q not found in config (available: %v)", chain, fc.ChainNames())
 	}
-	applyLayer(c, sec, setFlags)
-	return nil
+	return applyLayer(c, sec, setFlags)
 }
 
 // applyLayer overlays the non-nil fields of sec onto c, skipping any field
 // whose corresponding flag name appears in setFlags (so explicit CLI flags are
 // never clobbered). The flag names here MUST match those registered in
 // configureFlags.
-func applyLayer(c *Config, sec ChainSection, setFlags map[string]bool) {
+func applyLayer(c *Config, sec ChainSection, setFlags map[string]bool) error {
 	str := func(flagName string, src *string, dst *string) {
 		if src != nil && !setFlags[flagName] {
 			*dst = *src
@@ -110,6 +121,17 @@ func applyLayer(c *Config, sec ChainSection, setFlags map[string]bool) {
 			*dst = *src
 		}
 	}
+	durationf := func(flagName string, src *string, dst *time.Duration) error {
+		if src == nil || setFlags[flagName] {
+			return nil
+		}
+		d, err := time.ParseDuration(*src)
+		if err != nil {
+			return fmt.Errorf("%s: parse duration %q: %w", flagName, *src, err)
+		}
+		*dst = d
+		return nil
+	}
 
 	str("bin", sec.Bin, &c.Bin)
 	str("rpc", sec.RPC, &c.RPC)
@@ -122,14 +144,24 @@ func applyLayer(c *Config, sec ChainSection, setFlags map[string]bool) {
 	str("accounts", sec.AccountsPath, &c.AccountsPath)
 	str("max-account-amount", sec.MaxAccountAmount, &c.MaxAccountAmount)
 	str("account-prefix", sec.AccountPrefix, &c.AccountPrefix)
+	str("action-states", sec.ActionStates, &c.ActionStates)
 	intf("num-accounts", sec.NumAccounts, &c.NumAccounts)
+	intf("max-actions-per-run", sec.MaxActionsPerRun, &c.MaxActionsPerRun)
 	intf("funding-batch-size", sec.FundingBatchSize, &c.FundingBatchSize)
 	intf("parallelism", sec.Parallelism, &c.Parallelism)
 	intf("num-multisig23-accounts", sec.NumMultisig23, &c.NumMultisig23)
 	intf("num-multisig35-accounts", sec.NumMultisig35, &c.NumMultisig35)
 	intf("vesting-percent", sec.VestingPercent, &c.VestingPercent)
 	intf("num-permanent-locked-accounts", sec.NumPermanentLocked, &c.NumPermanentLocked)
+	boolf("add-accounts", sec.AddAccounts, &c.AddAccounts)
+	boolf("activity-existing", sec.ActivityExisting, &c.ActivityExisting)
 	boolf("actions", sec.Actions, &c.Actions)
+	boolf("require-actions", sec.RequireActions, &c.RequireActions)
+	boolf("dry-run", sec.DryRun, &c.DryRun)
+	if err := durationf("action-readiness-timeout", sec.ActionReadinessTimeout, &c.ActionReadinessTimeout); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ChainNames returns the configured chain names in sorted order (stable wizard

--- a/devnet/tests/gen-activity/configfile.go
+++ b/devnet/tests/gen-activity/configfile.go
@@ -29,8 +29,10 @@ type ChainSection struct {
 	Actions          *bool   `toml:"actions"`
 	FundingBatchSize *int    `toml:"funding-batch-size"`
 	Parallelism      *int    `toml:"parallelism"`
-	NumMultisig23    *int    `toml:"num-multisig23-accounts"`
-	NumMultisig35    *int    `toml:"num-multisig35-accounts"`
+	NumMultisig23      *int    `toml:"num-multisig23-accounts"`
+	NumMultisig35      *int    `toml:"num-multisig35-accounts"`
+	VestingPercent     *int    `toml:"vesting-percent"`
+	NumPermanentLocked *int    `toml:"num-permanent-locked-accounts"`
 }
 
 // FileConfig is the parsed gen-activity-config.toml: a shared [common] section
@@ -125,6 +127,8 @@ func applyLayer(c *Config, sec ChainSection, setFlags map[string]bool) {
 	intf("parallelism", sec.Parallelism, &c.Parallelism)
 	intf("num-multisig23-accounts", sec.NumMultisig23, &c.NumMultisig23)
 	intf("num-multisig35-accounts", sec.NumMultisig35, &c.NumMultisig35)
+	intf("vesting-percent", sec.VestingPercent, &c.VestingPercent)
+	intf("num-permanent-locked-accounts", sec.NumPermanentLocked, &c.NumPermanentLocked)
 	boolf("actions", sec.Actions, &c.Actions)
 }
 

--- a/devnet/tests/gen-activity/configfile.go
+++ b/devnet/tests/gen-activity/configfile.go
@@ -66,6 +66,68 @@ func strictUnmarshal(data []byte, v any) error {
 	return d.Decode(v)
 }
 
+// ApplyFileConfig layers a parsed FileConfig onto c following the precedence
+// defaults < [common] < [chains.<chain>] < explicit CLI flags. setFlags is the
+// set of flag names the user passed on the command line (collected via
+// flag.Visit); fields whose flag was set are never overwritten by the config.
+// An empty chain applies only [common]; a non-empty chain that is absent from
+// the file is an error.
+func ApplyFileConfig(c *Config, fc *FileConfig, chain string, setFlags map[string]bool) error {
+	if fc == nil {
+		return nil
+	}
+	applyLayer(c, fc.Common, setFlags)
+	if chain == "" {
+		return nil
+	}
+	sec, ok := fc.Chains[chain]
+	if !ok {
+		return fmt.Errorf("chain %q not found in config (available: %v)", chain, fc.ChainNames())
+	}
+	applyLayer(c, sec, setFlags)
+	return nil
+}
+
+// applyLayer overlays the non-nil fields of sec onto c, skipping any field
+// whose corresponding flag name appears in setFlags (so explicit CLI flags are
+// never clobbered). The flag names here MUST match those registered in
+// configureFlags.
+func applyLayer(c *Config, sec ChainSection, setFlags map[string]bool) {
+	str := func(flagName string, src *string, dst *string) {
+		if src != nil && !setFlags[flagName] {
+			*dst = *src
+		}
+	}
+	intf := func(flagName string, src *int, dst *int) {
+		if src != nil && !setFlags[flagName] {
+			*dst = *src
+		}
+	}
+	boolf := func(flagName string, src *bool, dst *bool) {
+		if src != nil && !setFlags[flagName] {
+			*dst = *src
+		}
+	}
+
+	str("bin", sec.Bin, &c.Bin)
+	str("rpc", sec.RPC, &c.RPC)
+	str("grpc", sec.GRPC, &c.GRPC)
+	str("chain-id", sec.ChainID, &c.ChainID)
+	str("home", sec.Home, &c.Home)
+	str("keyring-backend", sec.KeyringBackend, &c.KeyringBackend)
+	str("evm-cutover-version", sec.EVMCutoverVer, &c.EVMCutoverVer)
+	str("funding-key", sec.FundingKey, &c.FundingKey)
+	str("accounts", sec.AccountsPath, &c.AccountsPath)
+	str("max-account-amount", sec.MaxAccountAmount, &c.MaxAccountAmount)
+	str("account-prefix", sec.AccountPrefix, &c.AccountPrefix)
+	intf("num-accounts", sec.NumAccounts, &c.NumAccounts)
+	intf("funding-batch-size", sec.FundingBatchSize, &c.FundingBatchSize)
+	intf("parallelism", sec.Parallelism, &c.Parallelism)
+	intf("num-multisig23-accounts", sec.NumMultisig23, &c.NumMultisig23)
+	intf("num-multisig35-accounts", sec.NumMultisig35, &c.NumMultisig35)
+	boolf("actions", sec.Actions, &c.Actions)
+}
+
 // ChainNames returns the configured chain names in sorted order (stable wizard
 // menu ordering).
 func (fc *FileConfig) ChainNames() []string {

--- a/devnet/tests/gen-activity/configfile.go
+++ b/devnet/tests/gen-activity/configfile.go
@@ -14,21 +14,21 @@ import (
 // from an explicit zero value; nil means "not set in this section". Keys mirror
 // the CLI flag names so config and flags map one-to-one.
 type ChainSection struct {
-	Bin              *string `toml:"bin"`
-	RPC              *string `toml:"rpc"`
-	GRPC             *string `toml:"grpc"`
-	ChainID          *string `toml:"chain-id"`
-	Home             *string `toml:"home"`
-	KeyringBackend   *string `toml:"keyring-backend"`
-	EVMCutoverVer    *string `toml:"evm-cutover-version"`
-	FundingKey       *string `toml:"funding-key"`
-	AccountsPath     *string `toml:"accounts"`
-	NumAccounts      *int    `toml:"num-accounts"`
-	MaxAccountAmount *string `toml:"max-account-amount"`
-	AccountPrefix    *string `toml:"account-prefix"`
-	Actions          *bool   `toml:"actions"`
-	FundingBatchSize *int    `toml:"funding-batch-size"`
-	Parallelism      *int    `toml:"parallelism"`
+	Bin                *string `toml:"bin"`
+	RPC                *string `toml:"rpc"`
+	GRPC               *string `toml:"grpc"`
+	ChainID            *string `toml:"chain-id"`
+	Home               *string `toml:"home"`
+	KeyringBackend     *string `toml:"keyring-backend"`
+	EVMCutoverVer      *string `toml:"evm-cutover-version"`
+	FundingKey         *string `toml:"funding-key"`
+	AccountsPath       *string `toml:"accounts"`
+	NumAccounts        *int    `toml:"num-accounts"`
+	MaxAccountAmount   *string `toml:"max-account-amount"`
+	AccountPrefix      *string `toml:"account-prefix"`
+	Actions            *bool   `toml:"actions"`
+	FundingBatchSize   *int    `toml:"funding-batch-size"`
+	Parallelism        *int    `toml:"parallelism"`
 	NumMultisig23      *int    `toml:"num-multisig23-accounts"`
 	NumMultisig35      *int    `toml:"num-multisig35-accounts"`
 	VestingPercent     *int    `toml:"vesting-percent"`

--- a/devnet/tests/gen-activity/configfile.go
+++ b/devnet/tests/gen-activity/configfile.go
@@ -69,6 +69,9 @@ func strictUnmarshal(data []byte, v any) error {
 // ChainNames returns the configured chain names in sorted order (stable wizard
 // menu ordering).
 func (fc *FileConfig) ChainNames() []string {
+	if fc == nil {
+		return nil
+	}
 	names := make([]string, 0, len(fc.Chains))
 	for name := range fc.Chains {
 		names = append(names, name)

--- a/devnet/tests/gen-activity/configfile.go
+++ b/devnet/tests/gen-activity/configfile.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// ChainSection holds the config values for one chain (or the shared [common]
+// section). Every field is a pointer so an absent TOML key is distinguishable
+// from an explicit zero value; nil means "not set in this section". Keys mirror
+// the CLI flag names so config and flags map one-to-one.
+type ChainSection struct {
+	Bin              *string `toml:"bin"`
+	RPC              *string `toml:"rpc"`
+	GRPC             *string `toml:"grpc"`
+	ChainID          *string `toml:"chain-id"`
+	Home             *string `toml:"home"`
+	KeyringBackend   *string `toml:"keyring-backend"`
+	EVMCutoverVer    *string `toml:"evm-cutover-version"`
+	FundingKey       *string `toml:"funding-key"`
+	AccountsPath     *string `toml:"accounts"`
+	NumAccounts      *int    `toml:"num-accounts"`
+	MaxAccountAmount *string `toml:"max-account-amount"`
+	AccountPrefix    *string `toml:"account-prefix"`
+	Actions          *bool   `toml:"actions"`
+	FundingBatchSize *int    `toml:"funding-batch-size"`
+	Parallelism      *int    `toml:"parallelism"`
+	NumMultisig23    *int    `toml:"num-multisig23-accounts"`
+	NumMultisig35    *int    `toml:"num-multisig35-accounts"`
+}
+
+// FileConfig is the parsed gen-activity-config.toml: a shared [common] section
+// plus any number of named [chains.<name>] sections.
+type FileConfig struct {
+	Common ChainSection            `toml:"common"`
+	Chains map[string]ChainSection `toml:"chains"`
+}
+
+// LoadFileConfig reads and strictly decodes the TOML config at path. A missing
+// file returns (nil, nil) so the caller can fall back to pure flag behavior; an
+// unparseable file or an unknown key is a hard error.
+func LoadFileConfig(path string) (*FileConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var fc FileConfig
+	if err := strictUnmarshal(data, &fc); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	return &fc, nil
+}
+
+// strictUnmarshal decodes TOML with unknown keys rejected so typos in the
+// config file surface as errors instead of being silently ignored.
+func strictUnmarshal(data []byte, v any) error {
+	d := toml.NewDecoder(bytes.NewReader(data))
+	d.DisallowUnknownFields()
+	return d.Decode(v)
+}
+
+// ChainNames returns the configured chain names in sorted order (stable wizard
+// menu ordering).
+func (fc *FileConfig) ChainNames() []string {
+	names := make([]string, 0, len(fc.Chains))
+	for name := range fc.Chains {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/devnet/tests/gen-activity/configfile_test.go
+++ b/devnet/tests/gen-activity/configfile_test.go
@@ -93,3 +93,65 @@ func TestLoadFileConfigRejectsUnknownKey(t *testing.T) {
 		t.Error("expected error for unknown TOML key (strict decoding)")
 	}
 }
+
+func TestApplyFileConfigPrecedence(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, sampleTOML))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+
+	t.Run("common then chain overlay onto unset fields", func(t *testing.T) {
+		c := &Config{}
+		setFlags := map[string]bool{} // nothing set explicitly
+		if err := ApplyFileConfig(c, fc, "devnet", setFlags); err != nil {
+			t.Fatalf("ApplyFileConfig: %v", err)
+		}
+		if c.FundingKey != "faucet" { // from [common]
+			t.Errorf("FundingKey = %q, want faucet", c.FundingKey)
+		}
+		if c.Parallelism != 8 { // from [common]
+			t.Errorf("Parallelism = %d, want 8", c.Parallelism)
+		}
+		if c.ChainID != "lumera-devnet-1" { // from [chains.devnet]
+			t.Errorf("ChainID = %q, want lumera-devnet-1", c.ChainID)
+		}
+	})
+
+	t.Run("explicit flags win over config", func(t *testing.T) {
+		c := &Config{FundingKey: "cli-funder", Parallelism: 99}
+		setFlags := map[string]bool{"funding-key": true, "parallelism": true}
+		if err := ApplyFileConfig(c, fc, "devnet", setFlags); err != nil {
+			t.Fatalf("ApplyFileConfig: %v", err)
+		}
+		if c.FundingKey != "cli-funder" {
+			t.Errorf("FundingKey = %q, want cli-funder (flag wins)", c.FundingKey)
+		}
+		if c.Parallelism != 99 {
+			t.Errorf("Parallelism = %d, want 99 (flag wins)", c.Parallelism)
+		}
+		if c.ChainID != "lumera-devnet-1" { // not set as flag → config applies
+			t.Errorf("ChainID = %q, want lumera-devnet-1", c.ChainID)
+		}
+	})
+
+	t.Run("unknown chain errors", func(t *testing.T) {
+		c := &Config{}
+		err := ApplyFileConfig(c, fc, "nosuchchain", map[string]bool{})
+		if err == nil {
+			t.Error("expected error for unknown chain name")
+		}
+	})
+
+	t.Run("empty chain applies only common", func(t *testing.T) {
+		c := &Config{}
+		if err := ApplyFileConfig(c, fc, "", map[string]bool{}); err != nil {
+			t.Fatalf("ApplyFileConfig: %v", err)
+		}
+		if c.FundingKey != "faucet" {
+			t.Errorf("FundingKey = %q, want faucet (common)", c.FundingKey)
+		}
+		if c.ChainID != "" {
+			t.Errorf("ChainID = %q, want empty (no chain selected)", c.ChainID)
+		}
+	})
+}

--- a/devnet/tests/gen-activity/configfile_test.go
+++ b/devnet/tests/gen-activity/configfile_test.go
@@ -154,4 +154,18 @@ func TestApplyFileConfigPrecedence(t *testing.T) {
 			t.Errorf("ChainID = %q, want empty (no chain selected)", c.ChainID)
 		}
 	})
+
+	t.Run("chain section overrides common for an overlapping key", func(t *testing.T) {
+		overlap, err := LoadFileConfig(writeTempTOML(t, "[common]\nfunding-key = \"common-funder\"\n[chains.devnet]\nfunding-key = \"chain-funder\"\n"))
+		if err != nil {
+			t.Fatalf("LoadFileConfig: %v", err)
+		}
+		c := &Config{}
+		if err := ApplyFileConfig(c, overlap, "devnet", map[string]bool{}); err != nil {
+			t.Fatalf("ApplyFileConfig: %v", err)
+		}
+		if c.FundingKey != "chain-funder" {
+			t.Errorf("FundingKey = %q, want chain-funder (chain layer must override common)", c.FundingKey)
+		}
+	})
 }

--- a/devnet/tests/gen-activity/configfile_test.go
+++ b/devnet/tests/gen-activity/configfile_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const sampleTOML = `
+[common]
+bin = "lumerad"
+funding-key = "faucet"
+parallelism = 8
+
+[chains.devnet]
+rpc = "tcp://localhost:26657"
+chain-id = "lumera-devnet-1"
+accounts = "accounts-devnet.json"
+
+[chains.testnet]
+rpc = "https://rpc.testnet:443"
+chain-id = "lumera-testnet-1"
+`
+
+func writeTempTOML(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gen-activity-config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp toml: %v", err)
+	}
+	return path
+}
+
+func TestLoadFileConfigMissingFileReturnsNil(t *testing.T) {
+	fc, err := LoadFileConfig(filepath.Join(t.TempDir(), "does-not-exist.toml"))
+	if err != nil {
+		t.Fatalf("unexpected error for missing file: %v", err)
+	}
+	if fc != nil {
+		t.Fatalf("expected nil FileConfig for missing file, got %+v", fc)
+	}
+}
+
+func TestLoadFileConfigParsesSections(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, sampleTOML))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	if fc == nil {
+		t.Fatal("expected non-nil FileConfig")
+	}
+	if fc.Common.FundingKey == nil || *fc.Common.FundingKey != "faucet" {
+		t.Errorf("common funding-key not parsed: %+v", fc.Common.FundingKey)
+	}
+	if fc.Common.Parallelism == nil || *fc.Common.Parallelism != 8 {
+		t.Errorf("common parallelism not parsed: %+v", fc.Common.Parallelism)
+	}
+	dev, ok := fc.Chains["devnet"]
+	if !ok {
+		t.Fatal("devnet chain section missing")
+	}
+	if dev.ChainID == nil || *dev.ChainID != "lumera-devnet-1" {
+		t.Errorf("devnet chain-id not parsed: %+v", dev.ChainID)
+	}
+	if want := []string{"devnet", "testnet"}; !reflect.DeepEqual(fc.ChainNames(), want) {
+		t.Errorf("ChainNames() = %v, want %v (sorted)", fc.ChainNames(), want)
+	}
+}
+
+func TestLoadFileConfigRejectsUnknownKey(t *testing.T) {
+	_, err := LoadFileConfig(writeTempTOML(t, "[common]\nbogus-key = 1\n"))
+	if err == nil {
+		t.Error("expected error for unknown TOML key (strict decoding)")
+	}
+}

--- a/devnet/tests/gen-activity/configfile_test.go
+++ b/devnet/tests/gen-activity/configfile_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 )
 
 const sampleTOML = `
@@ -91,6 +92,39 @@ func TestLoadFileConfigRejectsUnknownKey(t *testing.T) {
 	_, err := LoadFileConfig(writeTempTOML(t, "[common]\nbogus-key = 1\n"))
 	if err == nil {
 		t.Error("expected error for unknown TOML key (strict decoding)")
+	}
+}
+
+func TestApplyFileConfigSupportsRuntimeFlagKeys(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, `
+[common]
+add-accounts = true
+activity-existing = true
+require-actions = true
+max-actions-per-run = 2
+action-states = "pending"
+action-readiness-timeout = "30s"
+dry-run = true
+`))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+
+	c := &Config{}
+	if err := ApplyFileConfig(c, fc, "", map[string]bool{}); err != nil {
+		t.Fatalf("ApplyFileConfig: %v", err)
+	}
+	if !c.AddAccounts || !c.ActivityExisting || !c.RequireActions || !c.DryRun {
+		t.Errorf("boolean runtime flags not applied: %+v", c)
+	}
+	if c.MaxActionsPerRun != 2 {
+		t.Errorf("MaxActionsPerRun = %d, want 2", c.MaxActionsPerRun)
+	}
+	if c.ActionStates != "pending" {
+		t.Errorf("ActionStates = %q, want pending", c.ActionStates)
+	}
+	if c.ActionReadinessTimeout != 30*time.Second {
+		t.Errorf("ActionReadinessTimeout = %s, want 30s", c.ActionReadinessTimeout)
 	}
 }
 

--- a/devnet/tests/gen-activity/configfile_test.go
+++ b/devnet/tests/gen-activity/configfile_test.go
@@ -128,6 +128,20 @@ dry-run = true
 	}
 }
 
+func TestApplyFileConfigAppliesMode(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, "[common]\nmode = \"migrate\"\n"))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	c := &Config{}
+	if err := ApplyFileConfig(c, fc, "", map[string]bool{}); err != nil {
+		t.Fatalf("ApplyFileConfig: %v", err)
+	}
+	if c.Mode != ModeMigrate {
+		t.Errorf("Mode = %q, want %q", c.Mode, ModeMigrate)
+	}
+}
+
 func TestApplyFileConfigPrecedence(t *testing.T) {
 	fc, err := LoadFileConfig(writeTempTOML(t, sampleTOML))
 	if err != nil {

--- a/devnet/tests/gen-activity/configfile_test.go
+++ b/devnet/tests/gen-activity/configfile_test.go
@@ -68,6 +68,25 @@ func TestLoadFileConfigParsesSections(t *testing.T) {
 	}
 }
 
+// TestLoadFileConfigPointerDistinguishesZeroFromAbsent guards the load-bearing
+// pointer-field behavior the config layering relies on: a key explicitly set to
+// its zero value must yield a non-nil pointer, while an absent key stays nil.
+func TestLoadFileConfigPointerDistinguishesZeroFromAbsent(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, "[common]\nparallelism = 0\n"))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	if fc.Common.Parallelism == nil {
+		t.Fatal("explicit parallelism=0 must yield a non-nil pointer (not absent)")
+	}
+	if *fc.Common.Parallelism != 0 {
+		t.Errorf("parallelism = %d, want 0", *fc.Common.Parallelism)
+	}
+	if fc.Common.Home != nil {
+		t.Errorf("absent home must stay nil, got %q", *fc.Common.Home)
+	}
+}
+
 func TestLoadFileConfigRejectsUnknownKey(t *testing.T) {
 	_, err := LoadFileConfig(writeTempTOML(t, "[common]\nbogus-key = 1\n"))
 	if err == nil {

--- a/devnet/tests/gen-activity/flow_test.go
+++ b/devnet/tests/gen-activity/flow_test.go
@@ -49,6 +49,23 @@ func TestPlannedNewAccountCount(t *testing.T) {
 			t.Errorf("got %d, want 0", got)
 		}
 	})
+
+	t.Run("multisig and dedicated permanent locked accounts do not satisfy regular account target", func(t *testing.T) {
+		reg := withAccounts(4)
+		reg.UpsertAccount(&AccountRecord{
+			AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0001", Address: "msig"},
+			Multisig:        &MultisigInfo{Threshold: 2, Signers: 3},
+		})
+		reg.UpsertAccount(&AccountRecord{
+			AccountIdentity: common.AccountIdentity{Name: "gen-plock-0001", Address: "plock"},
+			Vesting:         &VestingInfo{Type: string(common.VestingPermanentLocked)},
+		})
+
+		cfg := &Config{NumAccounts: 5}
+		if got := plannedNewAccountCount(cfg, reg); got != 1 {
+			t.Errorf("got %d, want 1", got)
+		}
+	})
 }
 
 func TestReconcilePreservesAccountKeyStyle(t *testing.T) {

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -23,7 +23,23 @@ const defaultEVMCutoverVer = "v1.20.0"
 const usageDescription = "tests-gen-activity generates realistic account activity against a live Lumera devnet chain."
 
 func main() {
-	cfg := parseFlags()
+	cfg := &Config{}
+	configureFlags(flag.CommandLine, cfg)
+	flag.Parse()
+
+	wizard, err := resolveConfig(cfg, flag.CommandLine)
+	if err != nil {
+		log.Fatalf("configuration: %v", err)
+	}
+
+	if wizard {
+		fc, _ := LoadFileConfig(cfg.ConfigPath)
+		if err := runWizard(cfg, fc, newSurveyPrompter(), run); err != nil {
+			log.Fatalf("wizard: %v", err)
+		}
+		return
+	}
+
 	if err := cfg.Validate(); err != nil {
 		log.Fatalf("invalid configuration: %v", err)
 	}
@@ -32,11 +48,28 @@ func main() {
 	}
 }
 
-func parseFlags() *Config {
-	c := &Config{}
-	configureFlags(flag.CommandLine, c)
-	flag.Parse()
-	return c
+// resolveConfig loads any config file referenced by cfg.ConfigPath, layers it
+// onto cfg honoring CLI-flag precedence, and reports whether the tool should run
+// in wizard mode (no flags passed, or -w/-wizard). fs must be the FlagSet that
+// already parsed the command line (so fs.Visit/fs.NFlag reflect what the user
+// set).
+func resolveConfig(cfg *Config, fs *flag.FlagSet) (wizard bool, err error) {
+	setFlags := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
+
+	fc, err := LoadFileConfig(cfg.ConfigPath)
+	if err != nil {
+		return false, err
+	}
+	if fc == nil && setFlags["config"] {
+		return false, fmt.Errorf("config file %q not found", cfg.ConfigPath)
+	}
+	if err := ApplyFileConfig(cfg, fc, cfg.Chain, setFlags); err != nil {
+		return false, err
+	}
+
+	wizard = cfg.Wizard || fs.NFlag() == 0
+	return wizard, nil
 }
 
 func configureFlags(fs *flag.FlagSet, c *Config) {

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -97,6 +97,8 @@ func configureFlags(fs *flag.FlagSet, c *Config) {
 	fs.IntVar(&c.NumAccounts, "num-accounts", 10, "number of accounts to generate")
 	fs.IntVar(&c.NumMultisig23, "num-multisig23-accounts", 0, "number of 2-of-3 multisig accounts to generate")
 	fs.IntVar(&c.NumMultisig35, "num-multisig35-accounts", 0, "number of 3-of-5 multisig accounts to generate")
+	fs.IntVar(&c.VestingPercent, "vesting-percent", 0, "percent of regular accounts to create as continuous/delayed vesting (0-100)")
+	fs.IntVar(&c.NumPermanentLocked, "num-permanent-locked-accounts", 0, "number of dedicated PermanentLocked accounts to generate")
 	fs.StringVar(&c.MaxAccountAmount, "max-account-amount", "10000000ulume", "upper bound for per-account funding")
 	fs.StringVar(&c.AccountPrefix, "account-prefix", "gen", "name prefix for generated accounts")
 	fs.BoolVar(&c.AddAccounts, "add-accounts", false, "add -num-accounts new users to an existing registry")

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -405,9 +405,11 @@ func reconcile(reg *ActivityRegistry, cfg *Config, keyStyle common.KeyStyle) {
 	reg.KeyStyle = keyStyle.Name()
 }
 
-// plannedNewAccountCount determines how many new accounts to allocate. On a
-// fresh registry it fills up to -num-accounts; -add-accounts always adds
-// -num-accounts more; -activity-existing alone adds none.
+// plannedNewAccountCount determines how many new regular accounts to allocate.
+// On a fresh registry it fills up to -num-accounts; -add-accounts always adds
+// -num-accounts more; -activity-existing alone adds none. Dedicated multisig
+// composites and permanent-locked fixtures have their own knobs, so they do not
+// satisfy the regular account target.
 func plannedNewAccountCount(cfg *Config, reg *ActivityRegistry) int {
 	if cfg.AddAccounts {
 		return cfg.NumAccounts
@@ -415,10 +417,24 @@ func plannedNewAccountCount(cfg *Config, reg *ActivityRegistry) int {
 	if cfg.ActivityExisting {
 		return 0
 	}
-	if deficit := cfg.NumAccounts - len(reg.Accounts); deficit > 0 {
+	if deficit := cfg.NumAccounts - regularAccountCount(reg); deficit > 0 {
 		return deficit
 	}
 	return 0
+}
+
+func regularAccountCount(reg *ActivityRegistry) int {
+	count := 0
+	for _, rec := range reg.Accounts {
+		if rec.Multisig != nil {
+			continue
+		}
+		if rec.Vesting != nil && rec.Vesting.Type == string(common.VestingPermanentLocked) {
+			continue
+		}
+		count++
+	}
+	return count
 }
 
 func printPlan(cfg *Config, reg *ActivityRegistry, plannedNames []string) {

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -96,7 +96,7 @@ func configureFlags(fs *flag.FlagSet, c *Config) {
 	fs.StringVar(&c.Home, "home", "", "lumerad home directory")
 	fs.StringVar(&c.KeyringBackend, "keyring-backend", "test", "local funder keyring backend")
 	fs.StringVar(&c.EVMCutoverVer, "evm-cutover-version", defaultEVMCutoverVer, "lumerad version where accounts switch to coin-type 60")
-	fs.StringVar(&c.FundingKey, "funding-key", "", "funder key name in the local keyring (required)")
+	fs.StringVar(&c.FundingKey, "funding-key", "governance_key", "funder key name in the local keyring")
 	fs.StringVar(&c.AccountsPath, "accounts", "devnet/tests/gen-activity/accounts.json", "registry file path")
 	fs.IntVar(&c.NumAccounts, "num-accounts", 10, "number of accounts to generate")
 	fs.IntVar(&c.NumMultisig23, "num-multisig23-accounts", 0, "number of 2-of-3 multisig accounts to generate")
@@ -112,9 +112,9 @@ func configureFlags(fs *flag.FlagSet, c *Config) {
 	fs.IntVar(&c.MaxActionsPerRun, "max-actions-per-run", 3, "cap action uploads/registrations per run")
 	fs.StringVar(&c.ActionStates, "action-states", "pending,done,approved", "target action states to generate")
 	fs.DurationVar(&c.ActionReadinessTimeout, "action-readiness-timeout", 180*time.Second, "time to wait for usable active supernodes")
-	fs.IntVar(&c.FundingBatchSize, "funding-batch-size", 10, "funder transfers to pipeline before waiting for inclusion")
+	fs.IntVar(&c.FundingBatchSize, "funding-batch-size", 1, "funder transfers to pipeline before waiting for inclusion")
 	fs.IntVar(&c.Parallelism, "parallelism", 5, "maximum concurrent per-account activity workers")
-	fs.BoolVar(&c.DryRun, "dry-run", false, "print planned accounts/activity without submitting txs")
+	fs.BoolVar(&c.DryRun, "dry-run", true, "print planned accounts/activity without submitting txs")
 }
 
 // run executes the runtime flow described in the design. Steps 1-6 are

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -49,6 +49,10 @@ func configureFlags(fs *flag.FlagSet, c *Config) {
 	}
 
 	fs.StringVar(&c.Bin, "bin", "lumerad", "lumerad binary path")
+	fs.StringVar(&c.ConfigPath, "config", "gen-activity-config.toml", "path to gen-activity TOML config file (optional)")
+	fs.StringVar(&c.Chain, "chain", "", "named chain section from the config file (e.g. devnet, testnet, mainnet)")
+	fs.BoolVar(&c.Wizard, "wizard", false, "run the interactive wizard (also the default when no flags are passed)")
+	fs.BoolVar(&c.Wizard, "w", false, "shorthand for -wizard")
 	fs.StringVar(&c.RPC, "rpc", "tcp://localhost:26657", "CometBFT RPC endpoint")
 	fs.StringVar(&c.GRPC, "grpc", "localhost:9090", "gRPC endpoint")
 	fs.StringVar(&c.ChainID, "chain-id", "", "chain ID (required)")
@@ -58,6 +62,8 @@ func configureFlags(fs *flag.FlagSet, c *Config) {
 	fs.StringVar(&c.FundingKey, "funding-key", "", "funder key name in the local keyring (required)")
 	fs.StringVar(&c.AccountsPath, "accounts", "devnet/tests/gen-activity/accounts.json", "registry file path")
 	fs.IntVar(&c.NumAccounts, "num-accounts", 10, "number of accounts to generate")
+	fs.IntVar(&c.NumMultisig23, "num-multisig23-accounts", 0, "number of 2-of-3 multisig accounts to generate")
+	fs.IntVar(&c.NumMultisig35, "num-multisig35-accounts", 0, "number of 3-of-5 multisig accounts to generate")
 	fs.StringVar(&c.MaxAccountAmount, "max-account-amount", "10000000ulume", "upper bound for per-account funding")
 	fs.StringVar(&c.AccountPrefix, "account-prefix", "gen", "name prefix for generated accounts")
 	fs.BoolVar(&c.AddAccounts, "add-accounts", false, "add -num-accounts new users to an existing registry")

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -173,6 +173,16 @@ func run(cfg *Config) error {
 	}
 	log.Printf("generated %d new account(s); registry saved", len(newRecs))
 
+	// Generate multisig accounts (2-of-3 / 3-of-5) alongside regular accounts.
+	var newMultisig []*AccountRecord
+	if specs := multisigPlan(cfg.NumMultisig23, cfg.NumMultisig35); len(specs) > 0 && !cfg.ActivityExisting {
+		newMultisig = generateMultisigAccounts(cli, reg, cfg.AccountPrefix, specs, keyStyle)
+		if err := reg.Save(cfg.AccountsPath, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("save registry after multisig key generation: %w", err)
+		}
+		log.Printf("generated %d new multisig account(s)", len(newMultisig))
+	}
+
 	// Step 9: fund unfunded accounts via the single-funder batcher.
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	chain := &cliFundingChain{cli: cli, funderKey: cfg.FundingKey, funderAddr: funderAddr, blockWait: 30 * time.Second}
@@ -189,6 +199,13 @@ func run(cfg *Config) error {
 	}
 	if fundErr != nil {
 		return fmt.Errorf("funding phase: %w", fundErr)
+	}
+
+	// Register multisig pubkeys on-chain and exercise each with one multisign
+	// bank-send to a peer. Non-fatal: a failure logs and continues.
+	exerciseMultisigAccounts(cli, reg, newMultisig, cfg)
+	if err := reg.Save(cfg.AccountsPath, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("save registry after multisig exercise: %w", err)
 	}
 
 	// Step 10: per-account activity mix. Only funded accounts can transact, and

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -31,14 +31,14 @@ func main() {
 	configureFlags(flag.CommandLine, cfg)
 	flag.Parse()
 
-	wizard, err := resolveConfig(cfg, flag.CommandLine)
+	wizard, setFlags, err := resolveConfig(cfg, flag.CommandLine)
 	if err != nil {
 		log.Fatalf("configuration: %v", err)
 	}
 
 	if wizard {
 		fc, _ := LoadFileConfig(cfg.ConfigPath)
-		if err := runWizard(cfg, fc, newSurveyPrompter(), run); err != nil {
+		if err := runWizard(cfg, fc, setFlags, newSurveyPrompter(), run); err != nil {
 			log.Fatalf("wizard: %v", err)
 		}
 		return
@@ -57,23 +57,25 @@ func main() {
 // in wizard mode (no flags passed, or -w/-wizard). fs must be the FlagSet that
 // already parsed the command line (so fs.Visit/fs.NFlag reflect what the user
 // set).
-func resolveConfig(cfg *Config, fs *flag.FlagSet) (wizard bool, err error) {
-	setFlags := map[string]bool{}
+// The returned setFlags map records which CLI flags the user set explicitly; the
+// wizard reuses it so a later chain re-seed cannot clobber those overrides.
+func resolveConfig(cfg *Config, fs *flag.FlagSet) (wizard bool, setFlags map[string]bool, err error) {
+	setFlags = map[string]bool{}
 	fs.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
 
 	fc, err := LoadFileConfig(cfg.ConfigPath)
 	if err != nil {
-		return false, err
+		return false, setFlags, err
 	}
 	if fc == nil && setFlags["config"] {
-		return false, fmt.Errorf("config file %q not found", cfg.ConfigPath)
+		return false, setFlags, fmt.Errorf("config file %q not found", cfg.ConfigPath)
 	}
 	if err := ApplyFileConfig(cfg, fc, cfg.Chain, setFlags); err != nil {
-		return false, err
+		return false, setFlags, err
 	}
 
 	wizard = cfg.Wizard || fs.NFlag() == 0
-	return wizard, nil
+	return wizard, setFlags, nil
 }
 
 func configureFlags(fs *flag.FlagSet, c *Config) {

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -20,6 +20,10 @@ import (
 
 const defaultEVMCutoverVer = "v1.20.0"
 
+// vestingGasTopUp is the small liquid balance sent to each vesting/locked
+// account so it can pay transaction fees (locked balances cannot cover gas).
+const vestingGasTopUp = "1000000ulume"
+
 const usageDescription = "tests-gen-activity generates realistic account activity against a live Lumera devnet chain."
 
 func main() {
@@ -185,15 +189,40 @@ func run(cfg *Config) error {
 		log.Printf("generated %d new multisig account(s)", len(newMultisig))
 	}
 
-	// Step 9: fund unfunded accounts via the single-funder batcher.
+	// Designate a random share of new regular accounts as vesting, and generate
+	// dedicated permanent-locked accounts. Tagged BEFORE funding so the funding
+	// split routes them to the vesting funder (vesting/locked accounts must be
+	// created at funding time).
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+	if !cfg.ActivityExisting {
+		lockedAmount := common.Coin{Amount: randomFundingAmount(cfg.maxAmount.Amount, rng), Denom: common.ChainDenom}.String()
+		if sel := planVesting(newRecs, cfg.VestingPercent, lockedAmount, rng, time.Now().Unix()); len(sel) > 0 {
+			log.Printf("designated %d/%d new account(s) as vesting", len(sel), len(newRecs))
+		}
+		if cfg.NumPermanentLocked > 0 {
+			plocked := generatePermanentLockedAccounts(cli, reg, cfg.AccountPrefix, cfg.NumPermanentLocked, keyStyle, lockedAmount, time.Now().UTC().Format(time.RFC3339))
+			log.Printf("generated %d permanent-locked account(s)", len(plocked))
+		}
+		if err := reg.Save(cfg.AccountsPath, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("save registry after vesting designation: %w", err)
+		}
+	}
+
+	// Step 9: fund unfunded accounts via the single-funder batcher.
 	chain := &cliFundingChain{cli: cli, funderKey: cfg.FundingKey, funderAddr: funderAddr, blockWait: 30 * time.Second}
-	targets := unfundedTargets(reg)
+	bankTargets, vestingTargets := splitFundingTargets(reg)
 	amountFor := func(*AccountRecord) string {
 		return common.Coin{Amount: randomFundingAmount(cfg.maxAmount.Amount, rng), Denom: common.ChainDenom}.String()
 	}
-	funded, fundErr := FundAccounts(chain, targets, amountFor, cfg.FundingBatchSize, 3)
-	log.Printf("funded %d/%d account(s)", funded, len(targets))
+	funded, fundErr := FundAccounts(chain, bankTargets, amountFor, cfg.FundingBatchSize, 3)
+	log.Printf("funded %d/%d bank account(s)", funded, len(bankTargets))
+
+	// Vesting/locked accounts are created-and-funded via create-* txs + a liquid
+	// top-up so they can pay gas.
+	if len(vestingTargets) > 0 {
+		vfunded := fundVestingAccounts(cli, cfg.FundingKey, funderAddr, vestingTargets, vestingGasTopUp)
+		log.Printf("funded %d/%d vesting/locked account(s)", vfunded, len(vestingTargets))
+	}
 
 	// Step 11: persist after funding regardless of partial failure.
 	if err := reg.Save(cfg.AccountsPath, time.Now().UTC().Format(time.RFC3339)); err != nil {

--- a/devnet/tests/gen-activity/main.go
+++ b/devnet/tests/gen-activity/main.go
@@ -107,6 +107,7 @@ func configureFlags(fs *flag.FlagSet, c *Config) {
 	fs.IntVar(&c.NumPermanentLocked, "num-permanent-locked-accounts", 0, "number of dedicated PermanentLocked accounts to generate")
 	fs.StringVar(&c.MaxAccountAmount, "max-account-amount", "10000000ulume", "upper bound for per-account funding")
 	fs.StringVar(&c.AccountPrefix, "account-prefix", "gen", "name prefix for generated accounts")
+	fs.StringVar(&c.Mode, "mode", "", "run mode: fresh|add-accounts|activity-existing|migrate (default fresh; -add-accounts/-activity-existing are shorthands)")
 	fs.BoolVar(&c.AddAccounts, "add-accounts", false, "add -num-accounts new users to an existing registry")
 	fs.BoolVar(&c.ActivityExisting, "activity-existing", false, "generate more activity for existing accounts")
 	fs.BoolVar(&c.Actions, "actions", true, "include CASCADE action activity")
@@ -123,6 +124,12 @@ func configureFlags(fs *flag.FlagSet, c *Config) {
 // read-only; -dry-run stops after printing the plan and never mutates the
 // keyring or registry.
 func run(cfg *Config) error {
+	// Migrate mode is a distinct flow: it migrates existing registry accounts to
+	// their EVM-compatible counterparts instead of generating/funding accounts.
+	if cfg.resolvedMode == ModeMigrate {
+		return runMigrateMode(cfg)
+	}
+
 	// Step 2: detect key style from the current lumerad runtime.
 	keyStyle := detectKeyStyle(cfg.Bin, cfg.EVMCutoverVer)
 	log.Printf("key style: %s (algo=%s coin-type=%d)", keyStyle.Name(), keyStyle.Algo, keyStyle.CoinType)

--- a/devnet/tests/gen-activity/main_test.go
+++ b/devnet/tests/gen-activity/main_test.go
@@ -69,7 +69,7 @@ func TestResolveConfigAppliesFileAndDetectsWizard(t *testing.T) {
 		path := writeTempTOML(t, sampleTOML)
 		cfg.ConfigPath = path
 
-		wizard, err := resolveConfig(cfg, fs)
+		wizard, _, err := resolveConfig(cfg, fs)
 		if err != nil {
 			t.Fatalf("resolveConfig: %v", err)
 		}
@@ -89,7 +89,7 @@ func TestResolveConfigAppliesFileAndDetectsWizard(t *testing.T) {
 		if err := fs.Parse([]string{"-chain", "devnet", "-config", path}); err != nil {
 			t.Fatalf("parse: %v", err)
 		}
-		wizard, err := resolveConfig(cfg, fs)
+		wizard, _, err := resolveConfig(cfg, fs)
 		if err != nil {
 			t.Fatalf("resolveConfig: %v", err)
 		}
@@ -109,7 +109,7 @@ func TestResolveConfigAppliesFileAndDetectsWizard(t *testing.T) {
 		if err := fs.Parse([]string{"-w", "-config", path}); err != nil {
 			t.Fatalf("parse: %v", err)
 		}
-		wizard, err := resolveConfig(cfg, fs)
+		wizard, _, err := resolveConfig(cfg, fs)
 		if err != nil {
 			t.Fatalf("resolveConfig: %v", err)
 		}
@@ -125,7 +125,7 @@ func TestResolveConfigAppliesFileAndDetectsWizard(t *testing.T) {
 		if err := fs.Parse([]string{"-config", filepath.Join(t.TempDir(), "nope.toml"), "-chain", "devnet"}); err != nil {
 			t.Fatalf("parse: %v", err)
 		}
-		if _, err := resolveConfig(cfg, fs); err == nil {
+		if _, _, err := resolveConfig(cfg, fs); err == nil {
 			t.Error("expected error when explicit -config path is missing")
 		}
 	})

--- a/devnet/tests/gen-activity/main_test.go
+++ b/devnet/tests/gen-activity/main_test.go
@@ -32,6 +32,25 @@ func TestHelpUsageIncludesDescription(t *testing.T) {
 	}
 }
 
+func TestConfigureFlagsRegistersNewFlags(t *testing.T) {
+	var cfg Config
+	fs := flag.NewFlagSet("tests-gen-activity", flag.ContinueOnError)
+	configureFlags(fs, &cfg)
+
+	for _, name := range []string{
+		"config", "chain", "wizard", "w",
+		"num-multisig23-accounts", "num-multisig35-accounts",
+	} {
+		if fs.Lookup(name) == nil {
+			t.Errorf("flag -%s not registered", name)
+		}
+	}
+
+	if got := fs.Lookup("config").DefValue; got != "gen-activity-config.toml" {
+		t.Errorf("-config default = %q, want gen-activity-config.toml", got)
+	}
+}
+
 func TestDetectKeyStyleFallsBackToLegacy(t *testing.T) {
 	got := detectKeyStyle(filepath.Join(t.TempDir(), "missing-lumerad"), "v1.11.0")
 	if got != common.KeyStyleLegacy {

--- a/devnet/tests/gen-activity/main_test.go
+++ b/devnet/tests/gen-activity/main_test.go
@@ -57,3 +57,76 @@ func TestDetectKeyStyleFallsBackToLegacy(t *testing.T) {
 		t.Fatalf("detectKeyStyle fallback = %+v, want legacy", got)
 	}
 }
+
+func TestResolveConfigAppliesFileAndDetectsWizard(t *testing.T) {
+	t.Run("no flags -> wizard mode, common applied", func(t *testing.T) {
+		cfg := &Config{}
+		fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+		configureFlags(fs, cfg)
+		if err := fs.Parse([]string{}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		path := writeTempTOML(t, sampleTOML)
+		cfg.ConfigPath = path
+
+		wizard, err := resolveConfig(cfg, fs)
+		if err != nil {
+			t.Fatalf("resolveConfig: %v", err)
+		}
+		if !wizard {
+			t.Error("expected wizard=true when no flags passed")
+		}
+		if cfg.FundingKey != "faucet" {
+			t.Errorf("FundingKey = %q, want faucet (from common)", cfg.FundingKey)
+		}
+	})
+
+	t.Run("flags passed -> command-line mode", func(t *testing.T) {
+		cfg := &Config{}
+		fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+		configureFlags(fs, cfg)
+		path := writeTempTOML(t, sampleTOML)
+		if err := fs.Parse([]string{"-chain", "devnet", "-config", path}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		wizard, err := resolveConfig(cfg, fs)
+		if err != nil {
+			t.Fatalf("resolveConfig: %v", err)
+		}
+		if wizard {
+			t.Error("expected wizard=false when flags passed")
+		}
+		if cfg.ChainID != "lumera-devnet-1" {
+			t.Errorf("ChainID = %q, want lumera-devnet-1 (chain layered)", cfg.ChainID)
+		}
+	})
+
+	t.Run("-w forces wizard even with flags", func(t *testing.T) {
+		cfg := &Config{}
+		fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+		configureFlags(fs, cfg)
+		path := writeTempTOML(t, sampleTOML)
+		if err := fs.Parse([]string{"-w", "-config", path}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		wizard, err := resolveConfig(cfg, fs)
+		if err != nil {
+			t.Fatalf("resolveConfig: %v", err)
+		}
+		if !wizard {
+			t.Error("expected wizard=true when -w passed")
+		}
+	})
+
+	t.Run("explicit missing -config is an error", func(t *testing.T) {
+		cfg := &Config{}
+		fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+		configureFlags(fs, cfg)
+		if err := fs.Parse([]string{"-config", filepath.Join(t.TempDir(), "nope.toml"), "-chain", "devnet"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if _, err := resolveConfig(cfg, fs); err == nil {
+			t.Error("expected error when explicit -config path is missing")
+		}
+	})
+}

--- a/devnet/tests/gen-activity/migrate_exec.go
+++ b/devnet/tests/gen-activity/migrate_exec.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"fmt"
+
+	"gen/tests/common"
+)
+
+// migrationChain is the chain seam the migration executor depends on. It is
+// satisfied in production by *common.ChainCLI and in tests by a fake, so the
+// executor's control flow is unit-testable without a live chain.
+type migrationChain interface {
+	MigrationRecord(legacyAddr string) (common.MigrationRecord, bool, error)
+	MigrationEstimate(addr string) (common.MigrationEstimate, error)
+	HasKey(name string) bool
+	ShowAddress(name string) (string, error)
+	ImportKeyWithStyle(name, mnemonic string, style common.KeyStyle) (string, error)
+	ClaimLegacyAccount(legacyKey, newKey string) (string, error)
+	MigrateMultisigProof(legacyBase, legacyAddr string, members []string, threshold, signers int) (common.MultisigProofResult, error)
+}
+
+// migrationResult is the outcome of attempting one account's migration. It is
+// produced by a worker and applied to the registry by the single coordinator.
+type migrationResult struct {
+	Item       migrationWorkItem
+	Status     string // migrated, already_migrated, skipped, failed
+	NewName    string
+	NewAddress string
+	TxHash     string
+	Height     int64
+	Reason     string // skip/reject reason
+	Err        error
+	Planned    bool // dry-run: nothing was submitted, registry must not change
+}
+
+// migrationExecutor runs individual account migrations against a migrationChain,
+// emitting correlated log lines for every lifecycle step.
+type migrationExecutor struct {
+	chain migrationChain
+	log   *migrationLogger
+}
+
+// evmKeyName is the keyring name for an account's EVM-compatible destination key.
+func evmKeyName(legacyName string) string { return legacyName + "-evm" }
+
+// migrateOne executes the full lifecycle for one work item and returns its
+// result. In dry-run it stops after the estimate, never importing keys or
+// submitting a tx. Multisig items are dispatched to the four-step flow.
+func (e *migrationExecutor) migrateOne(item migrationWorkItem, dryRun bool) migrationResult {
+	rec := item.Rec
+	cid := item.CorrelationID
+	e.log.logf(cid, "queued: account=%s type=%s kind=%s addr=%s", rec.Name, item.AccountType, item.Kind, rec.Address)
+
+	// 1. Already migrated on-chain? Authoritative skip.
+	if mr, found, err := e.chain.MigrationRecord(rec.Address); err != nil {
+		return e.fail(item, fmt.Errorf("query migration-record: %w", err))
+	} else if found {
+		e.log.logf(cid, "already migrated on-chain -> %s (height %d)", mr.NewAddress, mr.Height)
+		return migrationResult{Item: item, Status: MigrationStatusAlreadyMigrated, NewAddress: mr.NewAddress, Height: mr.Height}
+	}
+
+	// 2. Estimate — confirms migratability and surfaces the rejection reason.
+	est, err := e.chain.MigrationEstimate(rec.Address)
+	if err != nil {
+		return e.fail(item, fmt.Errorf("query migration-estimate: %w", err))
+	}
+	e.log.logf(cid, "estimate: would_succeed=%v multisig=%v validator=%v delegations=%d balance=%q",
+		est.WouldSucceed, est.IsMultisig, est.IsValidator, est.DelegationCount, est.BalanceSummary)
+	if !est.WouldSucceed {
+		e.log.logf(cid, "SKIP: estimate rejects migration: %s", est.RejectionReason)
+		return migrationResult{Item: item, Status: MigrationStatusSkipped, Reason: est.RejectionReason}
+	}
+
+	// 3. Dry-run stops before any mutation.
+	if dryRun {
+		e.log.logf(cid, "dry-run: would migrate %s (%s) via %s flow", rec.Name, item.AccountType, item.Kind)
+		return migrationResult{Item: item, Planned: true}
+	}
+
+	// 4. Dispatch by flow.
+	switch item.Kind {
+	case migrationKindMultisig:
+		return e.migrateMultisig(item)
+	default:
+		return e.migrateSingleSig(item)
+	}
+}
+
+// migrateSingleSig migrates a regular/vesting/permanent-locked legacy account by
+// deriving an EVM-compatible destination key from the same mnemonic and
+// submitting a single-sig claim.
+func (e *migrationExecutor) migrateSingleSig(item migrationWorkItem) migrationResult {
+	rec := item.Rec
+	cid := item.CorrelationID
+
+	if rec.Mnemonic == "" {
+		return e.fail(item, fmt.Errorf("no recorded mnemonic; cannot derive keys"))
+	}
+
+	// Ensure the legacy signing key is in the keyring.
+	legacyName := rec.Name
+	if !e.chain.HasKey(legacyName) {
+		if _, err := e.chain.ImportKeyWithStyle(legacyName, rec.Mnemonic, common.KeyStyleLegacy); err != nil {
+			return e.fail(item, fmt.Errorf("import legacy key: %w", err))
+		}
+		e.log.logf(cid, "imported legacy key %s", legacyName)
+	}
+
+	// Derive (or reuse) the EVM-compatible destination key.
+	newName := evmKeyName(legacyName)
+	var newAddr string
+	if e.chain.HasKey(newName) {
+		addr, err := e.chain.ShowAddress(newName)
+		if err != nil {
+			return e.fail(item, fmt.Errorf("resolve existing destination key: %w", err))
+		}
+		newAddr = addr
+	} else {
+		addr, err := e.chain.ImportKeyWithStyle(newName, rec.Mnemonic, common.KeyStyleEVM)
+		if err != nil {
+			return e.fail(item, fmt.Errorf("derive EVM destination key: %w", err))
+		}
+		newAddr = addr
+	}
+	e.log.logf(cid, "destination EVM key %s -> %s", newName, newAddr)
+
+	// Submit the claim and wait for inclusion (ClaimLegacyAccount waits).
+	e.log.logf(cid, "submitting claim-legacy-account %s -> %s", rec.Address, newAddr)
+	txHash, err := e.chain.ClaimLegacyAccount(legacyName, newName)
+	if err != nil {
+		return e.fail(item, fmt.Errorf("claim-legacy-account: %w", err))
+	}
+	e.log.logf(cid, "claim included: tx=%s", txHash)
+
+	return e.finalizeMigration(item, newName, newAddr, txHash)
+}
+
+// finalizeMigration verifies the on-chain migration record using the shared
+// validator and returns the migrated result. A validation warning does not fail
+// the result (the tx already committed); it is logged for troubleshooting.
+func (e *migrationExecutor) finalizeMigration(item migrationWorkItem, newName, newAddr, txHash string) migrationResult {
+	rec := item.Rec
+	cid := item.CorrelationID
+	height := int64(0)
+
+	mr, found, qerr := e.chain.MigrationRecord(rec.Address)
+	switch {
+	case qerr != nil:
+		e.log.logf(cid, "WARN: post-migration record query failed: %v", qerr)
+	case common.ValidateMigrationRecord(mr, found, rec.Address, newAddr) != nil:
+		// Destination may be derived on-chain; re-validate without pinning the
+		// expected new address and adopt the recorded one.
+		if err := common.ValidateMigrationRecord(mr, found, rec.Address, ""); err != nil {
+			e.log.logf(cid, "WARN: post-migration validation: %v", err)
+		} else {
+			if mr.NewAddress != "" {
+				newAddr = mr.NewAddress
+			}
+			height = mr.Height
+		}
+	default:
+		height = mr.Height
+	}
+
+	e.log.logf(cid, "MIGRATED: %s -> %s tx=%s height=%d", rec.Address, newAddr, txHash, height)
+	return migrationResult{
+		Item: item, Status: MigrationStatusMigrated,
+		NewName: newName, NewAddress: newAddr, TxHash: txHash, Height: height,
+	}
+}
+
+// migrateMultisig migrates a legacy K-of-N multisig account via the four-step
+// proof flow: it creates a fresh destination EVM multisig and runs
+// generate -> sign(×K) -> combine -> submit. The member sub-keys must already
+// be in the keyring (gen-activity creates them at generation time).
+func (e *migrationExecutor) migrateMultisig(item migrationWorkItem) migrationResult {
+	rec := item.Rec
+	cid := item.CorrelationID
+	if rec.Multisig == nil || len(rec.Multisig.MemberNames) == 0 {
+		return e.fail(item, fmt.Errorf("multisig metadata missing member names"))
+	}
+	ms := rec.Multisig
+	e.log.logf(cid, "multisig proof flow: %d-of-%d members=%v", ms.Threshold, ms.Signers, ms.MemberNames)
+
+	res, err := e.chain.MigrateMultisigProof(rec.Name, rec.Address, ms.MemberNames, ms.Threshold, ms.Signers)
+	if err != nil {
+		return e.fail(item, fmt.Errorf("multisig proof migration: %w", err))
+	}
+
+	return e.finalizeMigration(item, res.NewName, res.NewAddress, res.TxHash)
+}
+
+// fail logs and wraps a failed migration result.
+func (e *migrationExecutor) fail(item migrationWorkItem, err error) migrationResult {
+	e.log.logf(item.CorrelationID, "FAILED: %v", err)
+	return migrationResult{Item: item, Status: MigrationStatusFailed, Err: err}
+}

--- a/devnet/tests/gen-activity/migrate_exec.go
+++ b/devnet/tests/gen-activity/migrate_exec.go
@@ -182,6 +182,32 @@ func (e *migrationExecutor) migrateMultisig(item migrationWorkItem) migrationRes
 	ms := rec.Multisig
 	e.log.logf(cid, "multisig proof flow: %d-of-%d members=%v", ms.Threshold, ms.Signers, ms.MemberNames)
 
+	// Ensure every legacy member sub-key is in the keyring before the ceremony.
+	// The proof flow signs with these keys; unlike single-sig, they cannot be
+	// derived on the fly. Import any missing key from its stored mnemonic; if a
+	// key is missing and unrecoverable, fail fast BEFORE creating destination
+	// keys so the run leaves no orphan keys and the operator gets a clear reason.
+	var missing []string
+	for _, m := range multisigMembers(ms) {
+		if e.chain.HasKey(m.Name) {
+			continue
+		}
+		if m.Mnemonic == "" {
+			missing = append(missing, m.Name)
+			continue
+		}
+		if _, err := e.chain.ImportKeyWithStyle(m.Name, m.Mnemonic, common.KeyStyleLegacy); err != nil {
+			return e.fail(item, fmt.Errorf("import multisig member %s from stored mnemonic: %w", m.Name, err))
+		}
+		e.log.logf(cid, "imported missing member key %s from stored mnemonic", m.Name)
+	}
+	if len(missing) > 0 {
+		return e.fail(item, fmt.Errorf(
+			"multisig member keys not in keyring and no stored mnemonic to import them: %v; "+
+				"run from the keyring that generated them (--home/--keyring-backend) or regenerate the "+
+				"registry so member mnemonics are recorded", missing))
+	}
+
 	res, err := e.chain.MigrateMultisigProof(rec.Name, rec.Address, ms.MemberNames, ms.Threshold, ms.Signers)
 	if err != nil {
 		return e.fail(item, fmt.Errorf("multisig proof migration: %w", err))

--- a/devnet/tests/gen-activity/migrate_exec_test.go
+++ b/devnet/tests/gen-activity/migrate_exec_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"gen/tests/common"
+)
+
+// fakeMigrationChain is a scripted migrationChain for unit-testing the executor.
+type fakeMigrationChain struct {
+	records     map[string]common.MigrationRecord // legacy addr -> record (present == migrated)
+	estimate    common.MigrationEstimate
+	estimateErr error
+	keys        map[string]bool
+	importAddr  map[string]string // key name -> address returned by import
+	claimHash   string
+	claimErr    error
+
+	multisigResult common.MultisigProofResult
+	multisigErr    error
+
+	// call tracking
+	claimCalls    int
+	multisigCalls int
+	importCalls   []string
+}
+
+func (f *fakeMigrationChain) MigrationRecord(addr string) (common.MigrationRecord, bool, error) {
+	r, ok := f.records[addr]
+	return r, ok, nil
+}
+func (f *fakeMigrationChain) MigrationEstimate(addr string) (common.MigrationEstimate, error) {
+	return f.estimate, f.estimateErr
+}
+func (f *fakeMigrationChain) HasKey(name string) bool { return f.keys[name] }
+func (f *fakeMigrationChain) ShowAddress(name string) (string, error) {
+	if a, ok := f.importAddr[name]; ok {
+		return a, nil
+	}
+	return "lumera1" + name, nil
+}
+func (f *fakeMigrationChain) ImportKeyWithStyle(name, mnemonic string, style common.KeyStyle) (string, error) {
+	f.importCalls = append(f.importCalls, name)
+	if f.keys == nil {
+		f.keys = map[string]bool{}
+	}
+	f.keys[name] = true
+	if a, ok := f.importAddr[name]; ok {
+		return a, nil
+	}
+	return "lumera1" + name, nil
+}
+func (f *fakeMigrationChain) ClaimLegacyAccount(legacyKey, newKey string) (string, error) {
+	f.claimCalls++
+	if f.claimErr != nil {
+		return "", f.claimErr
+	}
+	return f.claimHash, nil
+}
+
+func (f *fakeMigrationChain) MigrateMultisigProof(legacyBase, legacyAddr string, members []string, threshold, signers int) (common.MultisigProofResult, error) {
+	f.multisigCalls++
+	if f.multisigErr != nil {
+		return common.MultisigProofResult{}, f.multisigErr
+	}
+	return f.multisigResult, nil
+}
+
+func singleSigItem() migrationWorkItem {
+	rec := legacyRec("gen-0001", "lumera1legacy", "seed words here")
+	return migrationWorkItem{Index: 1, Rec: rec, Kind: migrationKindSingleSig, AccountType: "regular", CorrelationID: "migrate gen-0001 #1"}
+}
+
+func newTestExecutor(chain migrationChain) (*migrationExecutor, *bytes.Buffer) {
+	var buf bytes.Buffer
+	lg := newMigrationLogger(&buf)
+	lg.now = fixedClock()
+	return &migrationExecutor{chain: chain, log: lg}, &buf
+}
+
+func TestMigrateOneSingleSigHappyPath(t *testing.T) {
+	chain := &fakeMigrationChain{
+		records:    map[string]common.MigrationRecord{},
+		estimate:   common.MigrationEstimate{WouldSucceed: true, DelegationCount: 5, BalanceSummary: "100ulume"},
+		keys:       map[string]bool{"gen-0001": true}, // legacy key already in keyring
+		importAddr: map[string]string{"gen-0001-evm": "lumera1newevm"},
+		claimHash:  "TXHASH123",
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(singleSigItem(), false)
+
+	if res.Status != MigrationStatusMigrated {
+		t.Fatalf("status = %q, want migrated (err=%v)", res.Status, res.Err)
+	}
+	if res.NewAddress != "lumera1newevm" {
+		t.Errorf("NewAddress = %q, want lumera1newevm", res.NewAddress)
+	}
+	if res.TxHash != "TXHASH123" {
+		t.Errorf("TxHash = %q, want TXHASH123", res.TxHash)
+	}
+	if chain.claimCalls != 1 {
+		t.Errorf("claimCalls = %d, want 1", chain.claimCalls)
+	}
+}
+
+func TestMigrateOneAlreadyMigrated(t *testing.T) {
+	chain := &fakeMigrationChain{
+		records: map[string]common.MigrationRecord{
+			"lumera1legacy": {LegacyAddress: "lumera1legacy", NewAddress: "lumera1existing"},
+		},
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(singleSigItem(), false)
+
+	if res.Status != MigrationStatusAlreadyMigrated {
+		t.Fatalf("status = %q, want already_migrated", res.Status)
+	}
+	if res.NewAddress != "lumera1existing" {
+		t.Errorf("NewAddress = %q, want lumera1existing", res.NewAddress)
+	}
+	if chain.claimCalls != 0 {
+		t.Errorf("claimCalls = %d, want 0 (no submit when already migrated)", chain.claimCalls)
+	}
+}
+
+func TestMigrateOneSkippedWhenEstimateRejects(t *testing.T) {
+	chain := &fakeMigrationChain{
+		records:  map[string]common.MigrationRecord{},
+		estimate: common.MigrationEstimate{WouldSucceed: false, RejectionReason: "blocked"},
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(singleSigItem(), false)
+
+	if res.Status != MigrationStatusSkipped {
+		t.Fatalf("status = %q, want skipped", res.Status)
+	}
+	if chain.claimCalls != 0 {
+		t.Errorf("claimCalls = %d, want 0 when estimate rejects", chain.claimCalls)
+	}
+}
+
+func TestMigrateOneDryRunDoesNotSubmit(t *testing.T) {
+	chain := &fakeMigrationChain{
+		records:  map[string]common.MigrationRecord{},
+		estimate: common.MigrationEstimate{WouldSucceed: true},
+		keys:     map[string]bool{"gen-0001": true},
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(singleSigItem(), true)
+
+	if !res.Planned {
+		t.Errorf("Planned = false, want true in dry-run")
+	}
+	if chain.claimCalls != 0 {
+		t.Errorf("claimCalls = %d, want 0 in dry-run", chain.claimCalls)
+	}
+	if len(chain.importCalls) != 0 {
+		t.Errorf("importCalls = %v, want none in dry-run", chain.importCalls)
+	}
+}
+
+func multisigItem() migrationWorkItem {
+	rec := &AccountRecord{AccountIdentity: common.AccountIdentity{Name: "gen-msig35-0001", Address: "lumera1ms", KeyStyle: "legacy"}}
+	rec.Multisig = &MultisigInfo{
+		MemberNames: []string{"gen-msig35-0001-signer-1", "gen-msig35-0001-signer-2", "gen-msig35-0001-signer-3", "gen-msig35-0001-signer-4", "gen-msig35-0001-signer-5"},
+		Threshold:   3, Signers: 5,
+	}
+	return migrationWorkItem{Index: 1, Rec: rec, Kind: migrationKindMultisig, AccountType: "multisig-3-of-5", CorrelationID: "migrate gen-msig35-0001 #1"}
+}
+
+func TestMigrateOneMultisigHappyPath(t *testing.T) {
+	chain := &fakeMigrationChain{
+		records:        map[string]common.MigrationRecord{},
+		estimate:       common.MigrationEstimate{WouldSucceed: true, IsMultisig: true},
+		multisigResult: common.MultisigProofResult{NewName: "evm-gen-msig35-0001", NewAddress: "lumera1newms", TxHash: "MSTX"},
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(multisigItem(), false)
+
+	if res.Status != MigrationStatusMigrated {
+		t.Fatalf("status = %q, want migrated (err=%v)", res.Status, res.Err)
+	}
+	if res.NewAddress != "lumera1newms" || res.TxHash != "MSTX" {
+		t.Errorf("result = %+v, want new=lumera1newms tx=MSTX", res)
+	}
+	if chain.multisigCalls != 1 {
+		t.Errorf("multisigCalls = %d, want 1", chain.multisigCalls)
+	}
+	if chain.claimCalls != 0 {
+		t.Errorf("claimCalls = %d, want 0 (multisig path must not use single-sig claim)", chain.claimCalls)
+	}
+}
+
+func TestMigrateOneMultisigDryRunDoesNotSubmit(t *testing.T) {
+	chain := &fakeMigrationChain{
+		records:  map[string]common.MigrationRecord{},
+		estimate: common.MigrationEstimate{WouldSucceed: true, IsMultisig: true},
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(multisigItem(), true)
+	if !res.Planned {
+		t.Error("Planned = false, want true in dry-run")
+	}
+	if chain.multisigCalls != 0 {
+		t.Errorf("multisigCalls = %d, want 0 in dry-run", chain.multisigCalls)
+	}
+}
+
+func TestMigrateOneFailedClaim(t *testing.T) {
+	chain := &fakeMigrationChain{
+		records:  map[string]common.MigrationRecord{},
+		estimate: common.MigrationEstimate{WouldSucceed: true},
+		keys:     map[string]bool{"gen-0001": true},
+		claimErr: fmt.Errorf("broadcast rejected"),
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(singleSigItem(), false)
+
+	if res.Status != MigrationStatusFailed {
+		t.Fatalf("status = %q, want failed", res.Status)
+	}
+	if res.Err == nil {
+		t.Error("expected Err to be set on failed claim")
+	}
+}

--- a/devnet/tests/gen-activity/migrate_exec_test.go
+++ b/devnet/tests/gen-activity/migrate_exec_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"gen/tests/common"
@@ -176,8 +177,12 @@ func multisigItem() migrationWorkItem {
 
 func TestMigrateOneMultisigHappyPath(t *testing.T) {
 	chain := &fakeMigrationChain{
-		records:        map[string]common.MigrationRecord{},
-		estimate:       common.MigrationEstimate{WouldSucceed: true, IsMultisig: true},
+		records:  map[string]common.MigrationRecord{},
+		estimate: common.MigrationEstimate{WouldSucceed: true, IsMultisig: true},
+		keys: map[string]bool{ // all member keys already in keyring
+			"gen-msig35-0001-signer-1": true, "gen-msig35-0001-signer-2": true,
+			"gen-msig35-0001-signer-3": true, "gen-msig35-0001-signer-4": true, "gen-msig35-0001-signer-5": true,
+		},
 		multisigResult: common.MultisigProofResult{NewName: "evm-gen-msig35-0001", NewAddress: "lumera1newms", TxHash: "MSTX"},
 	}
 	ex, _ := newTestExecutor(chain)
@@ -211,6 +216,59 @@ func TestMigrateOneMultisigDryRunDoesNotSubmit(t *testing.T) {
 	}
 	if chain.multisigCalls != 0 {
 		t.Errorf("multisigCalls = %d, want 0 in dry-run", chain.multisigCalls)
+	}
+}
+
+func TestMigrateMultisigImportsMissingMembersFromMnemonic(t *testing.T) {
+	item := multisigItem()
+	// Attach member material with mnemonics; keyring starts empty.
+	var members []MultisigMember
+	for _, n := range item.Rec.Multisig.MemberNames {
+		members = append(members, MultisigMember{Name: n, Mnemonic: "seed-" + n})
+	}
+	item.Rec.Multisig.Members = members
+
+	chain := &fakeMigrationChain{
+		records:        map[string]common.MigrationRecord{},
+		estimate:       common.MigrationEstimate{WouldSucceed: true, IsMultisig: true},
+		keys:           map[string]bool{}, // members NOT present -> must be imported
+		multisigResult: common.MultisigProofResult{NewName: "evm-gen-msig35-0001", NewAddress: "lumera1newms", TxHash: "MSTX"},
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(item, false)
+
+	if res.Status != MigrationStatusMigrated {
+		t.Fatalf("status = %q, want migrated (err=%v)", res.Status, res.Err)
+	}
+	if chain.multisigCalls != 1 {
+		t.Errorf("multisigCalls = %d, want 1", chain.multisigCalls)
+	}
+	// All five members should have been imported from their stored mnemonics.
+	if len(chain.importCalls) != 5 {
+		t.Errorf("importCalls = %v, want 5 member imports", chain.importCalls)
+	}
+}
+
+func TestMigrateMultisigFailsFastWhenMembersMissingNoMnemonic(t *testing.T) {
+	item := multisigItem() // MemberNames only, no Members mnemonics
+	chain := &fakeMigrationChain{
+		records:  map[string]common.MigrationRecord{},
+		estimate: common.MigrationEstimate{WouldSucceed: true, IsMultisig: true},
+		keys:     map[string]bool{}, // members absent and unrecoverable
+	}
+	ex, _ := newTestExecutor(chain)
+
+	res := ex.migrateOne(item, false)
+
+	if res.Status != MigrationStatusFailed {
+		t.Fatalf("status = %q, want failed", res.Status)
+	}
+	if chain.multisigCalls != 0 {
+		t.Errorf("multisigCalls = %d, want 0 (must fail before the ceremony / destination keys)", chain.multisigCalls)
+	}
+	if res.Err == nil || !strings.Contains(res.Err.Error(), "gen-msig35-0001-signer-1") {
+		t.Errorf("error should name the missing member keys, got: %v", res.Err)
 	}
 }
 

--- a/devnet/tests/gen-activity/migrate_log.go
+++ b/devnet/tests/gen-activity/migrate_log.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+// migrationLogger writes correlated, timestamped, single-line log records for
+// migrate mode. Every line is emitted under a mutex so concurrent workers never
+// interleave mid-line, and each line carries a correlation id (the per-account
+// work tag) so an interleaved run is still traceable.
+type migrationLogger struct {
+	mu  sync.Mutex
+	out io.Writer
+	now func() time.Time
+}
+
+func newMigrationLogger(out io.Writer) *migrationLogger {
+	return &migrationLogger{out: out, now: time.Now}
+}
+
+// logf writes one whole line: "<RFC3339 UTC ts> [<corrID>] <message>".
+func (l *migrationLogger) logf(corrID, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	ts := l.now().UTC().Format(time.RFC3339)
+	line := fmt.Sprintf("%s [%s] %s\n", ts, corrID, msg)
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	_, _ = io.WriteString(l.out, line)
+}

--- a/devnet/tests/gen-activity/migrate_log_test.go
+++ b/devnet/tests/gen-activity/migrate_log_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func fixedClock() func() time.Time {
+	ts := time.Date(2026, 6, 16, 18, 25, 4, 0, time.UTC)
+	return func() time.Time { return ts }
+}
+
+func TestMigrationLoggerFormatsCorrelatedLine(t *testing.T) {
+	var buf bytes.Buffer
+	lg := newMigrationLogger(&buf)
+	lg.now = fixedClock()
+
+	lg.logf("migrate gen-0001 #1", "submitting claim tx %s", "ABC123")
+
+	line := strings.TrimSpace(buf.String())
+	for _, want := range []string{"2026-06-16T18:25:04Z", "[migrate gen-0001 #1]", "submitting claim tx ABC123"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("log line missing %q:\n%s", want, line)
+		}
+	}
+}
+
+func TestMigrationLoggerConcurrentLinesAreWhole(t *testing.T) {
+	var buf bytes.Buffer
+	lg := newMigrationLogger(&buf)
+	lg.now = fixedClock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			lg.logf("worker", "line number %d with several words to widen the write", n)
+		}(i)
+	}
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 50 {
+		t.Fatalf("got %d lines, want 50 (interleaving/corruption)", len(lines))
+	}
+	for _, ln := range lines {
+		if !strings.Contains(ln, "[worker]") || !strings.Contains(ln, "line number ") {
+			t.Errorf("corrupted/interleaved line: %q", ln)
+		}
+	}
+}

--- a/devnet/tests/gen-activity/migrate_mode.go
+++ b/devnet/tests/gen-activity/migrate_mode.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"gen/tests/common"
+)
+
+// migrationPreflight rejects a migration run when the chain's migration window
+// is not open. Fatal preflight conditions stop the run before any worker starts.
+func migrationPreflight(params common.MigrationParams) error {
+	if !params.EnableMigration {
+		return fmt.Errorf("migration is disabled on this chain (params.enable_migration=false); the migration window is closed")
+	}
+	return nil
+}
+
+// runMigrateMode is the entry point for -mode=migrate. It loads the registry,
+// preflights the chain's migration params, then runs the bounded worker pool.
+// It is invoked from run() when the resolved mode is migrate.
+func runMigrateMode(cfg *Config) error {
+	cli := newChainCLI(cfg)
+	lg := newMigrationLogger(os.Stdout)
+
+	reg, err := LoadRegistry(cfg.AccountsPath)
+	if err != nil {
+		return fmt.Errorf("migrate mode requires an existing registry at %s: %w", cfg.AccountsPath, err)
+	}
+
+	// Preflight against chain params (skipped in dry-run so planning works offline).
+	maxPerBlock := 0
+	if !cfg.DryRun {
+		params, perr := cli.MigrationParams()
+		if perr != nil {
+			return fmt.Errorf("query migration params: %w", perr)
+		}
+		if err := migrationPreflight(params); err != nil {
+			return err
+		}
+		maxPerBlock = params.MaxMigrationsPerBlock
+		lg.logf("coordinator", "chain migration params: enabled=%v max_per_block=%d end_time=%d",
+			params.EnableMigration, params.MaxMigrationsPerBlock, params.MigrationEndTime)
+	}
+
+	exec := &migrationExecutor{chain: cli, log: lg}
+	save := func(r *ActivityRegistry) error {
+		return r.Save(cfg.AccountsPath, time.Now().UTC().Format(time.RFC3339))
+	}
+	opts := migrationRunOpts{
+		Parallelism: cfg.Parallelism,
+		MaxPerBlock: maxPerBlock,
+		DryRun:      cfg.DryRun,
+		Now:         func() string { return time.Now().UTC().Format(time.RFC3339) },
+	}
+
+	sum, err := runMigration(reg, exec, lg, opts, save)
+	if err != nil {
+		return err
+	}
+	log.Printf("migrate mode complete: migrated=%d already=%d skipped=%d failed=%d planned=%d",
+		sum.Migrated, sum.AlreadyMigrated, sum.Skipped, sum.Failed, sum.Planned)
+	if sum.Failed > 0 {
+		return fmt.Errorf("%d account(s) failed to migrate", sum.Failed)
+	}
+	return nil
+}

--- a/devnet/tests/gen-activity/migrate_mode.go
+++ b/devnet/tests/gen-activity/migrate_mode.go
@@ -12,8 +12,16 @@ import (
 // migrationPreflight rejects a migration run when the chain's migration window
 // is not open. Fatal preflight conditions stop the run before any worker starts.
 func migrationPreflight(params common.MigrationParams) error {
+	return migrationPreflightAt(params, time.Now().Unix())
+}
+
+func migrationPreflightAt(params common.MigrationParams, nowUnix int64) error {
 	if !params.EnableMigration {
 		return fmt.Errorf("migration is disabled on this chain (params.enable_migration=false); the migration window is closed")
+	}
+	if params.MigrationEndTime > 0 && nowUnix > params.MigrationEndTime {
+		return fmt.Errorf("migration window closed at %s (migration_end_time=%d)",
+			time.Unix(params.MigrationEndTime, 0).UTC().Format(time.RFC3339), params.MigrationEndTime)
 	}
 	return nil
 }

--- a/devnet/tests/gen-activity/migrate_mode_test.go
+++ b/devnet/tests/gen-activity/migrate_mode_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"testing"
+
+	"gen/tests/common"
+)
+
+func TestMigrationPreflight(t *testing.T) {
+	t.Run("enabled passes", func(t *testing.T) {
+		if err := migrationPreflight(common.MigrationParams{EnableMigration: true, MaxMigrationsPerBlock: 50}); err != nil {
+			t.Errorf("unexpected preflight error: %v", err)
+		}
+	})
+	t.Run("disabled migration fails", func(t *testing.T) {
+		if err := migrationPreflight(common.MigrationParams{EnableMigration: false}); err == nil {
+			t.Error("expected preflight error when migration disabled")
+		}
+	})
+}

--- a/devnet/tests/gen-activity/migrate_mode_test.go
+++ b/devnet/tests/gen-activity/migrate_mode_test.go
@@ -8,13 +8,25 @@ import (
 
 func TestMigrationPreflight(t *testing.T) {
 	t.Run("enabled passes", func(t *testing.T) {
-		if err := migrationPreflight(common.MigrationParams{EnableMigration: true, MaxMigrationsPerBlock: 50}); err != nil {
+		if err := migrationPreflightAt(common.MigrationParams{EnableMigration: true, MaxMigrationsPerBlock: 50}, 1000); err != nil {
 			t.Errorf("unexpected preflight error: %v", err)
 		}
 	})
 	t.Run("disabled migration fails", func(t *testing.T) {
-		if err := migrationPreflight(common.MigrationParams{EnableMigration: false}); err == nil {
+		if err := migrationPreflightAt(common.MigrationParams{EnableMigration: false}, 1000); err == nil {
 			t.Error("expected preflight error when migration disabled")
+		}
+	})
+	t.Run("closed migration window fails", func(t *testing.T) {
+		err := migrationPreflightAt(common.MigrationParams{EnableMigration: true, MigrationEndTime: 999}, 1000)
+		if err == nil {
+			t.Error("expected preflight error when migration window is closed")
+		}
+	})
+	t.Run("open migration window passes", func(t *testing.T) {
+		err := migrationPreflightAt(common.MigrationParams{EnableMigration: true, MigrationEndTime: 1001}, 1000)
+		if err != nil {
+			t.Errorf("unexpected preflight error: %v", err)
 		}
 	})
 }

--- a/devnet/tests/gen-activity/migrate_plan.go
+++ b/devnet/tests/gen-activity/migrate_plan.go
@@ -1,0 +1,102 @@
+package main
+
+import "fmt"
+
+// Migration flow kinds: single-sig (mnemonic-derived destination, used by
+// regular/vesting/permanent-locked accounts) and multisig (four-step proof flow).
+const (
+	migrationKindSingleSig = "single-sig"
+	migrationKindMultisig  = "multisig"
+)
+
+// migrationWorkItem is one account queued for migration, carrying a stable
+// correlation id used in every log line for that item so concurrent runs stay
+// traceable.
+type migrationWorkItem struct {
+	Index         int
+	Rec           *AccountRecord
+	Kind          string
+	AccountType   string
+	CorrelationID string
+}
+
+// migrationKindOf returns the migration flow a record requires.
+func migrationKindOf(rec *AccountRecord) string {
+	if rec.Multisig != nil && len(rec.Multisig.MemberNames) > 0 {
+		return migrationKindMultisig
+	}
+	return migrationKindSingleSig
+}
+
+// migrationAccountType returns a human-readable account type for logging:
+// "regular", a vesting type (e.g. "continuous", "permanent_locked"), or
+// "multisig-K-of-N".
+func migrationAccountType(rec *AccountRecord) string {
+	if rec.Multisig != nil {
+		return fmt.Sprintf("multisig-%d-of-%d", rec.Multisig.Threshold, rec.Multisig.Signers)
+	}
+	if rec.Vesting != nil && rec.Vesting.Type != "" {
+		return rec.Vesting.Type
+	}
+	return "regular"
+}
+
+// buildMigrationQueue turns the eligible registry records into an ordered,
+// indexed work queue. Indices start at 1 and correlation ids embed the account
+// name and index for log traceability.
+func buildMigrationQueue(reg *ActivityRegistry) []migrationWorkItem {
+	cands := selectMigrationCandidates(reg)
+	items := make([]migrationWorkItem, 0, len(cands))
+	for i, rec := range cands {
+		idx := i + 1
+		items = append(items, migrationWorkItem{
+			Index:         idx,
+			Rec:           rec,
+			Kind:          migrationKindOf(rec),
+			AccountType:   migrationAccountType(rec),
+			CorrelationID: fmt.Sprintf("migrate %s #%d", rec.Name, idx),
+		})
+	}
+	return items
+}
+
+// migrationEligible reports whether a registry record should be migrated.
+//
+// A record is eligible when:
+//   - it was created with the legacy (coin-type 118) key style, and
+//   - it carries signing material: either a recorded mnemonic (single-sig,
+//     vesting, permanent-locked) or multisig member metadata, and
+//   - it has not already been migrated successfully (a prior "failed" attempt is
+//     retryable, so it stays eligible).
+//
+// The authoritative on-chain "already migrated" check happens at execution time
+// against the migration record; this is the cheap registry-level pre-filter.
+func migrationEligible(rec *AccountRecord) bool {
+	if rec == nil {
+		return false
+	}
+	if rec.KeyStyle != "" && rec.KeyStyle != "legacy" {
+		return false
+	}
+	if rec.Migration != nil {
+		switch rec.Migration.Status {
+		case MigrationStatusMigrated, MigrationStatusAlreadyMigrated:
+			return false
+		}
+	}
+	hasMnemonic := rec.Mnemonic != ""
+	isMultisig := rec.Multisig != nil && len(rec.Multisig.MemberNames) > 0
+	return hasMnemonic || isMultisig
+}
+
+// selectMigrationCandidates returns the registry records eligible for migration,
+// preserving registry order so a run is deterministic.
+func selectMigrationCandidates(reg *ActivityRegistry) []*AccountRecord {
+	var out []*AccountRecord
+	for _, rec := range reg.Accounts {
+		if migrationEligible(rec) {
+			out = append(out, rec)
+		}
+	}
+	return out
+}

--- a/devnet/tests/gen-activity/migrate_plan.go
+++ b/devnet/tests/gen-activity/migrate_plan.go
@@ -20,6 +20,34 @@ type migrationWorkItem struct {
 	CorrelationID string
 }
 
+// memberKeyMaterial is one multisig member's keyring name and (optional) seed
+// mnemonic, used by migrate mode to re-import a missing member key.
+type memberKeyMaterial struct {
+	Name     string
+	Mnemonic string
+}
+
+// multisigMembers returns the per-member key material for a multisig, preferring
+// the richer Members list (carries mnemonics) and falling back to MemberNames
+// (names only) for registries written before member mnemonics were persisted.
+func multisigMembers(ms *MultisigInfo) []memberKeyMaterial {
+	if ms == nil {
+		return nil
+	}
+	if len(ms.Members) > 0 {
+		out := make([]memberKeyMaterial, 0, len(ms.Members))
+		for _, m := range ms.Members {
+			out = append(out, memberKeyMaterial{Name: m.Name, Mnemonic: m.Mnemonic})
+		}
+		return out
+	}
+	out := make([]memberKeyMaterial, 0, len(ms.MemberNames))
+	for _, n := range ms.MemberNames {
+		out = append(out, memberKeyMaterial{Name: n})
+	}
+	return out
+}
+
 // migrationKindOf returns the migration flow a record requires.
 func migrationKindOf(rec *AccountRecord) string {
 	if rec.Multisig != nil && len(rec.Multisig.MemberNames) > 0 {

--- a/devnet/tests/gen-activity/migrate_plan_test.go
+++ b/devnet/tests/gen-activity/migrate_plan_test.go
@@ -43,6 +43,58 @@ func TestMigrationInfoRoundTrip(t *testing.T) {
 	}
 }
 
+func TestMultisigMembersRoundTrip(t *testing.T) {
+	reg := NewRegistry("lumera-devnet-1", "funder", "lumera1funder", "legacy", "t0")
+	rec := &AccountRecord{AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0001", Address: "lumera1ms", KeyStyle: "legacy"}}
+	rec.Multisig = &MultisigInfo{
+		MemberNames: []string{"gen-msig23-0001-signer-1", "gen-msig23-0001-signer-2", "gen-msig23-0001-signer-3"},
+		Members: []MultisigMember{
+			{Name: "gen-msig23-0001-signer-1", Address: "lumera1m1", Mnemonic: "seed one"},
+			{Name: "gen-msig23-0001-signer-2", Address: "lumera1m2", Mnemonic: "seed two"},
+			{Name: "gen-msig23-0001-signer-3", Address: "lumera1m3", Mnemonic: "seed three"},
+		},
+		Threshold: 2, Signers: 3,
+	}
+	reg.UpsertAccount(rec)
+
+	path := filepath.Join(t.TempDir(), "accounts.json")
+	if err := reg.Save(path, "t1"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	m := got.Accounts[0].Multisig
+	if m == nil || len(m.Members) != 3 {
+		t.Fatalf("members not persisted: %+v", m)
+	}
+	if m.Members[0].Mnemonic != "seed one" || m.Members[2].Name != "gen-msig23-0001-signer-3" {
+		t.Errorf("member material wrong after reload: %+v", m.Members)
+	}
+}
+
+func TestMultisigMembersMaterial(t *testing.T) {
+	t.Run("prefers Members with mnemonics", func(t *testing.T) {
+		ms := &MultisigInfo{
+			MemberNames: []string{"a", "b"},
+			Members:     []MultisigMember{{Name: "a", Mnemonic: "ma"}, {Name: "b", Mnemonic: "mb"}},
+			Threshold:   2, Signers: 2,
+		}
+		got := multisigMembers(ms)
+		if len(got) != 2 || got[0].Name != "a" || got[0].Mnemonic != "ma" {
+			t.Errorf("material = %+v, want names+mnemonics from Members", got)
+		}
+	})
+	t.Run("falls back to MemberNames without mnemonics", func(t *testing.T) {
+		ms := &MultisigInfo{MemberNames: []string{"a", "b", "c"}, Threshold: 2, Signers: 3}
+		got := multisigMembers(ms)
+		if len(got) != 3 || got[1].Name != "b" || got[1].Mnemonic != "" {
+			t.Errorf("material = %+v, want names from MemberNames with empty mnemonics", got)
+		}
+	})
+}
+
 func TestMigrationEligible(t *testing.T) {
 	t.Run("legacy single-sig with mnemonic is eligible", func(t *testing.T) {
 		if !migrationEligible(legacyRec("gen-0001", "lumera1a", "seed words")) {

--- a/devnet/tests/gen-activity/migrate_plan_test.go
+++ b/devnet/tests/gen-activity/migrate_plan_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"gen/tests/common"
+)
+
+func legacyRec(name, addr, mnemonic string) *AccountRecord {
+	return &AccountRecord{AccountIdentity: common.AccountIdentity{
+		Name: name, Address: addr, Mnemonic: mnemonic, KeyStyle: "legacy",
+	}}
+}
+
+func TestMigrationInfoRoundTrip(t *testing.T) {
+	reg := NewRegistry("lumera-devnet-1", "funder", "lumera1funder", "legacy", "2026-06-16T00:00:00Z")
+	rec := legacyRec("gen-0001", "lumera1a", "twelve words mnemonic")
+	rec.Migration = &MigrationInfo{
+		NewName:    "gen-0001-evm",
+		NewAddress: "lumera1new",
+		TxHash:     "ABC123",
+		Height:     64566,
+		MigratedAt: "2026-06-16T18:25:04Z",
+		Status:     MigrationStatusMigrated,
+	}
+	reg.UpsertAccount(rec)
+
+	path := filepath.Join(t.TempDir(), "accounts.json")
+	if err := reg.Save(path, "2026-06-16T01:00:00Z"); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("LoadRegistry: %v", err)
+	}
+	if len(got.Accounts) != 1 || got.Accounts[0].Migration == nil {
+		t.Fatalf("migration metadata not persisted: %+v", got.Accounts)
+	}
+	m := got.Accounts[0].Migration
+	if m.NewAddress != "lumera1new" || m.Status != MigrationStatusMigrated || m.Height != 64566 {
+		t.Errorf("migration metadata mismatch after reload: %+v", m)
+	}
+}
+
+func TestMigrationEligible(t *testing.T) {
+	t.Run("legacy single-sig with mnemonic is eligible", func(t *testing.T) {
+		if !migrationEligible(legacyRec("gen-0001", "lumera1a", "seed words")) {
+			t.Error("expected legacy single-sig with mnemonic to be eligible")
+		}
+	})
+
+	t.Run("already migrated is not eligible", func(t *testing.T) {
+		r := legacyRec("gen-0001", "lumera1a", "seed words")
+		r.Migration = &MigrationInfo{Status: MigrationStatusMigrated, NewAddress: "lumera1new"}
+		if migrationEligible(r) {
+			t.Error("expected already-migrated record to be ineligible")
+		}
+	})
+
+	t.Run("already_migrated status is not eligible", func(t *testing.T) {
+		r := legacyRec("gen-0001", "lumera1a", "seed words")
+		r.Migration = &MigrationInfo{Status: MigrationStatusAlreadyMigrated, NewAddress: "lumera1new"}
+		if migrationEligible(r) {
+			t.Error("expected already_migrated record to be ineligible")
+		}
+	})
+
+	t.Run("previously failed record is still eligible (retryable)", func(t *testing.T) {
+		r := legacyRec("gen-0001", "lumera1a", "seed words")
+		r.Migration = &MigrationInfo{Status: MigrationStatusFailed, Error: "boom"}
+		if !migrationEligible(r) {
+			t.Error("expected failed record to be retryable/eligible")
+		}
+	})
+
+	t.Run("no mnemonic and not multisig is not eligible", func(t *testing.T) {
+		r := &AccountRecord{AccountIdentity: common.AccountIdentity{Name: "x", Address: "lumera1a", KeyStyle: "legacy"}}
+		if migrationEligible(r) {
+			t.Error("expected record with no signing material to be ineligible")
+		}
+	})
+
+	t.Run("multisig without top-level mnemonic is eligible", func(t *testing.T) {
+		r := &AccountRecord{AccountIdentity: common.AccountIdentity{Name: "ms", Address: "lumera1ms", KeyStyle: "legacy"}}
+		r.Multisig = &MultisigInfo{MemberNames: []string{"ms-signer-1", "ms-signer-2", "ms-signer-3"}, Threshold: 2, Signers: 3}
+		if !migrationEligible(r) {
+			t.Error("expected legacy multisig to be eligible")
+		}
+	})
+
+	t.Run("non-legacy key style is not eligible", func(t *testing.T) {
+		r := legacyRec("gen-0001", "lumera1a", "seed words")
+		r.KeyStyle = "evm"
+		if migrationEligible(r) {
+			t.Error("expected EVM-style record to be ineligible")
+		}
+	})
+}
+
+func TestSelectMigrationCandidates(t *testing.T) {
+	reg := NewRegistry("lumera-devnet-1", "funder", "lumera1funder", "legacy", "2026-06-16T00:00:00Z")
+	reg.UpsertAccount(legacyRec("gen-0001", "lumera1a", "seed")) // eligible
+	migrated := legacyRec("gen-0002", "lumera1b", "seed")        // not eligible (migrated)
+	migrated.Migration = &MigrationInfo{Status: MigrationStatusMigrated}
+	reg.UpsertAccount(migrated)
+	reg.UpsertAccount(legacyRec("gen-0003", "lumera1c", "seed")) // eligible
+	evm := legacyRec("gen-0004", "lumera1d", "seed")             // not eligible (evm)
+	evm.KeyStyle = "evm"
+	reg.UpsertAccount(evm)
+
+	cands := selectMigrationCandidates(reg)
+	if len(cands) != 2 {
+		t.Fatalf("candidates = %d, want 2", len(cands))
+	}
+	if cands[0].Name != "gen-0001" || cands[1].Name != "gen-0003" {
+		t.Errorf("candidate order/identity wrong: %s, %s", cands[0].Name, cands[1].Name)
+	}
+}

--- a/devnet/tests/gen-activity/migrate_queue_test.go
+++ b/devnet/tests/gen-activity/migrate_queue_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"gen/tests/common"
+)
+
+func TestMigrationKindOf(t *testing.T) {
+	single := legacyRec("gen-0001", "lumera1a", "seed")
+	if got := migrationKindOf(single); got != migrationKindSingleSig {
+		t.Errorf("single-sig kind = %q, want %q", got, migrationKindSingleSig)
+	}
+
+	ms := &AccountRecord{AccountIdentity: common.AccountIdentity{Name: "ms", Address: "lumera1ms", KeyStyle: "legacy"}}
+	ms.Multisig = &MultisigInfo{MemberNames: []string{"a", "b", "c"}, Threshold: 2, Signers: 3}
+	if got := migrationKindOf(ms); got != migrationKindMultisig {
+		t.Errorf("multisig kind = %q, want %q", got, migrationKindMultisig)
+	}
+}
+
+func TestMigrationAccountType(t *testing.T) {
+	reg := legacyRec("gen-0001", "lumera1a", "seed")
+	if got := migrationAccountType(reg); got != "regular" {
+		t.Errorf("account type = %q, want regular", got)
+	}
+
+	vest := legacyRec("gen-0002", "lumera1b", "seed")
+	vest.Vesting = &VestingInfo{Type: "continuous", LockedAmount: "100ulume"}
+	if got := migrationAccountType(vest); got != "continuous" {
+		t.Errorf("vesting account type = %q, want continuous", got)
+	}
+
+	ms := &AccountRecord{AccountIdentity: common.AccountIdentity{Name: "ms", KeyStyle: "legacy"}}
+	ms.Multisig = &MultisigInfo{MemberNames: []string{"a", "b", "c"}, Threshold: 2, Signers: 3}
+	if got := migrationAccountType(ms); got != "multisig-2-of-3" {
+		t.Errorf("multisig account type = %q, want multisig-2-of-3", got)
+	}
+}
+
+func TestBuildMigrationQueue(t *testing.T) {
+	reg := NewRegistry("lumera-devnet-1", "funder", "lumera1funder", "legacy", "2026-06-16T00:00:00Z")
+	reg.UpsertAccount(legacyRec("gen-0001", "lumera1a", "seed"))
+	ms := &AccountRecord{AccountIdentity: common.AccountIdentity{Name: "gen-msig-0001", Address: "lumera1ms", Mnemonic: "", KeyStyle: "legacy"}}
+	ms.Multisig = &MultisigInfo{MemberNames: []string{"a", "b", "c"}, Threshold: 2, Signers: 3}
+	reg.UpsertAccount(ms)
+
+	q := buildMigrationQueue(reg)
+	if len(q) != 2 {
+		t.Fatalf("queue length = %d, want 2", len(q))
+	}
+	if q[0].Index != 1 || q[1].Index != 2 {
+		t.Errorf("indices = %d,%d, want 1,2", q[0].Index, q[1].Index)
+	}
+	if q[0].CorrelationID != "migrate gen-0001 #1" {
+		t.Errorf("correlation id = %q, want 'migrate gen-0001 #1'", q[0].CorrelationID)
+	}
+	if q[0].Kind != migrationKindSingleSig || q[1].Kind != migrationKindMultisig {
+		t.Errorf("kinds = %q,%q", q[0].Kind, q[1].Kind)
+	}
+}

--- a/devnet/tests/gen-activity/migrate_run.go
+++ b/devnet/tests/gen-activity/migrate_run.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// migrationRunOpts configures a migration run.
+type migrationRunOpts struct {
+	Parallelism int
+	MaxPerBlock int // chain's max_migrations_per_block; 0 means unthrottled
+	DryRun      bool
+	// Now returns the timestamp stamped onto applied MigrationInfo records.
+	Now func() string
+}
+
+// migrationOutcomeCounts is the run summary: per-status tallies plus the list of
+// failed item descriptions for triage.
+type migrationOutcomeCounts struct {
+	Migrated        int
+	AlreadyMigrated int
+	Skipped         int
+	Failed          int
+	Planned         int
+	Failures        []string
+}
+
+// effectiveConcurrency caps worker parallelism by the chain's per-block migration
+// limit so a burst never exceeds what a block can absorb. A non-positive
+// parallelism floors to 1; a non-positive cap means "no per-block limit".
+func effectiveConcurrency(parallelism, maxPerBlock int) int {
+	n := parallelism
+	if n < 1 {
+		n = 1
+	}
+	if maxPerBlock > 0 && maxPerBlock < n {
+		n = maxPerBlock
+	}
+	return n
+}
+
+// applyMigrationResult writes a result's outcome onto the registry record and
+// reports whether it changed anything. Dry-run (Planned) results never mutate
+// the registry.
+func applyMigrationResult(rec *AccountRecord, res migrationResult, now string) bool {
+	if res.Planned {
+		return false
+	}
+	info := &MigrationInfo{Status: res.Status, MigratedAt: now}
+	switch res.Status {
+	case MigrationStatusMigrated:
+		info.NewName = res.NewName
+		info.NewAddress = res.NewAddress
+		info.TxHash = res.TxHash
+		info.Height = res.Height
+	case MigrationStatusAlreadyMigrated:
+		info.NewAddress = res.NewAddress
+		info.Height = res.Height
+	case MigrationStatusSkipped:
+		info.Error = res.Reason
+	case MigrationStatusFailed:
+		if res.Err != nil {
+			info.Error = res.Err.Error()
+		}
+	}
+	rec.Migration = info
+	return true
+}
+
+// summarizeMigration tallies results by status for the run summary.
+func summarizeMigration(results []migrationResult) migrationOutcomeCounts {
+	var c migrationOutcomeCounts
+	for _, r := range results {
+		switch {
+		case r.Planned:
+			c.Planned++
+		case r.Status == MigrationStatusMigrated:
+			c.Migrated++
+		case r.Status == MigrationStatusAlreadyMigrated:
+			c.AlreadyMigrated++
+		case r.Status == MigrationStatusSkipped:
+			c.Skipped++
+		case r.Status == MigrationStatusFailed:
+			c.Failed++
+			reason := "unknown error"
+			if r.Err != nil {
+				reason = r.Err.Error()
+			}
+			c.Failures = append(c.Failures, fmt.Sprintf("%s: %s", r.Item.CorrelationID, reason))
+		}
+	}
+	return c
+}
+
+// runMigration executes the migration work queue with a bounded worker pool and
+// a single coordinator goroutine that applies results to the registry and saves
+// it after each change. Workers never touch the registry directly. The per-block
+// migration cap bounds in-flight submissions (each submission waits for
+// inclusion before releasing its slot, so a block is never over-filled).
+func runMigration(reg *ActivityRegistry, exec *migrationExecutor, lg *migrationLogger, opts migrationRunOpts, save func(*ActivityRegistry) error) (migrationOutcomeCounts, error) {
+	queue := buildMigrationQueue(reg)
+	total := len(queue)
+	if total == 0 {
+		lg.logf("coordinator", "no eligible accounts to migrate")
+		return migrationOutcomeCounts{}, nil
+	}
+
+	concurrency := effectiveConcurrency(opts.Parallelism, opts.MaxPerBlock)
+	lg.logf("coordinator", "starting migration: total=%d concurrency=%d max_per_block=%d dry_run=%v",
+		total, concurrency, opts.MaxPerBlock, opts.DryRun)
+
+	now := opts.Now
+	if now == nil {
+		now = func() string { return "" }
+	}
+
+	results := make(chan migrationResult, total)
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for _, item := range queue {
+		wg.Add(1)
+		go func(it migrationWorkItem) {
+			defer wg.Done()
+			sem <- struct{}{}        // acquire a throttle slot
+			defer func() { <-sem }() // release after inclusion (migrateOne waits)
+			lg.logf(it.CorrelationID, "worker acquired slot (in-flight cap %d)", concurrency)
+			results <- exec.migrateOne(it, opts.DryRun)
+		}(item)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// Single coordinator: apply each result to the registry and persist.
+	all := make([]migrationResult, 0, total)
+	done := 0
+	for res := range results {
+		all = append(all, res)
+		done++
+		if applyMigrationResult(res.Item.Rec, res, now()) {
+			if err := save(reg); err != nil {
+				lg.logf("coordinator", "WARN: registry save failed after %s: %v", res.Item.CorrelationID, err)
+			}
+		}
+		lg.logf("coordinator", "progress %d/%d applied: %s status=%s", done, total, res.Item.CorrelationID, resultStatusLabel(res))
+	}
+
+	sum := summarizeMigration(all)
+	lg.logf("coordinator", "summary: migrated=%d already=%d skipped=%d failed=%d planned=%d",
+		sum.Migrated, sum.AlreadyMigrated, sum.Skipped, sum.Failed, sum.Planned)
+	for _, f := range sum.Failures {
+		lg.logf("coordinator", "FAILED ITEM: %s", f)
+	}
+	return sum, nil
+}
+
+func resultStatusLabel(res migrationResult) string {
+	if res.Planned {
+		return "planned"
+	}
+	return res.Status
+}

--- a/devnet/tests/gen-activity/migrate_run.go
+++ b/devnet/tests/gen-activity/migrate_run.go
@@ -137,12 +137,16 @@ func runMigration(reg *ActivityRegistry, exec *migrationExecutor, lg *migrationL
 	// Single coordinator: apply each result to the registry and persist.
 	all := make([]migrationResult, 0, total)
 	done := 0
+	var saveErr error
 	for res := range results {
 		all = append(all, res)
 		done++
 		if applyMigrationResult(res.Item.Rec, res, now()) {
 			if err := save(reg); err != nil {
 				lg.logf("coordinator", "WARN: registry save failed after %s: %v", res.Item.CorrelationID, err)
+				if saveErr == nil {
+					saveErr = err
+				}
 			}
 		}
 		lg.logf("coordinator", "progress %d/%d applied: %s status=%s", done, total, res.Item.CorrelationID, resultStatusLabel(res))
@@ -153,6 +157,9 @@ func runMigration(reg *ActivityRegistry, exec *migrationExecutor, lg *migrationL
 		sum.Migrated, sum.AlreadyMigrated, sum.Skipped, sum.Failed, sum.Planned)
 	for _, f := range sum.Failures {
 		lg.logf("coordinator", "FAILED ITEM: %s", f)
+	}
+	if saveErr != nil {
+		return sum, fmt.Errorf("save migration registry: %w", saveErr)
 	}
 	return sum, nil
 }

--- a/devnet/tests/gen-activity/migrate_run_test.go
+++ b/devnet/tests/gen-activity/migrate_run_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -97,6 +98,36 @@ func TestRunMigrationProcessesAllAndAppliesToRegistry(t *testing.T) {
 	}
 	if saves == 0 {
 		t.Error("expected registry to be saved at least once")
+	}
+}
+
+func TestRunMigrationReturnsSaveError(t *testing.T) {
+	reg := NewRegistry("lumera-devnet-1", "funder", "lumera1funder", "legacy", "t0")
+	reg.UpsertAccount(legacyRec("gen-0001", "lumera1legacy1", "seed1"))
+
+	chain := &fakeMigrationChain{
+		records:    map[string]common.MigrationRecord{},
+		estimate:   common.MigrationEstimate{WouldSucceed: true},
+		keys:       map[string]bool{"gen-0001": true},
+		claimHash:  "TX",
+		importAddr: map[string]string{},
+	}
+	var buf bytes.Buffer
+	lg := newMigrationLogger(&buf)
+	lg.now = fixedClock()
+	exec := &migrationExecutor{chain: chain, log: lg}
+
+	sum, err := runMigration(reg, exec, lg, migrationRunOpts{Parallelism: 1, MaxPerBlock: 50, Now: func() string { return "t1" }}, func(*ActivityRegistry) error {
+		return errBoom()
+	})
+	if err == nil {
+		t.Fatal("expected registry save error")
+	}
+	if sum.Migrated != 1 {
+		t.Errorf("Migrated = %d, want 1 (summary: %+v)", sum.Migrated, sum)
+	}
+	if got := buf.String(); !strings.Contains(got, "WARN: registry save failed") {
+		t.Errorf("log output missing save warning:\n%s", got)
 	}
 }
 

--- a/devnet/tests/gen-activity/migrate_run_test.go
+++ b/devnet/tests/gen-activity/migrate_run_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+
+	"gen/tests/common"
+)
+
+func errBoom() error { return errors.New("boom") }
+
+func TestEffectiveConcurrency(t *testing.T) {
+	cases := []struct {
+		parallelism, maxPerBlock, want int
+	}{
+		{10, 50, 10}, // parallelism is the binding limit
+		{50, 10, 10}, // per-block cap is the binding limit
+		{5, 0, 5},    // no cap configured -> parallelism
+		{0, 10, 1},   // floor of 1
+	}
+	for _, tc := range cases {
+		if got := effectiveConcurrency(tc.parallelism, tc.maxPerBlock); got != tc.want {
+			t.Errorf("effectiveConcurrency(%d,%d) = %d, want %d", tc.parallelism, tc.maxPerBlock, got, tc.want)
+		}
+	}
+}
+
+func TestApplyMigrationResult(t *testing.T) {
+	t.Run("migrated sets full migration info", func(t *testing.T) {
+		rec := legacyRec("gen-0001", "lumera1a", "seed")
+		res := migrationResult{Status: MigrationStatusMigrated, NewName: "gen-0001-evm", NewAddress: "lumera1new", TxHash: "TX", Height: 100}
+		if !applyMigrationResult(rec, res, "2026-06-16T00:00:00Z") {
+			t.Fatal("expected registry change")
+		}
+		if rec.Migration == nil || rec.Migration.Status != MigrationStatusMigrated ||
+			rec.Migration.NewAddress != "lumera1new" || rec.Migration.TxHash != "TX" ||
+			rec.Migration.Height != 100 || rec.Migration.MigratedAt != "2026-06-16T00:00:00Z" {
+			t.Errorf("migration info not set correctly: %+v", rec.Migration)
+		}
+	})
+
+	t.Run("failed records error and status", func(t *testing.T) {
+		rec := legacyRec("gen-0001", "lumera1a", "seed")
+		res := migrationResult{Status: MigrationStatusFailed, Err: errBoom()}
+		applyMigrationResult(rec, res, "t")
+		if rec.Migration == nil || rec.Migration.Status != MigrationStatusFailed || rec.Migration.Error == "" {
+			t.Errorf("failed info not set: %+v", rec.Migration)
+		}
+	})
+
+	t.Run("planned (dry-run) does not change the registry", func(t *testing.T) {
+		rec := legacyRec("gen-0001", "lumera1a", "seed")
+		res := migrationResult{Planned: true}
+		if applyMigrationResult(rec, res, "t") {
+			t.Error("dry-run result must not change the registry")
+		}
+		if rec.Migration != nil {
+			t.Error("dry-run must not set migration info")
+		}
+	})
+}
+
+func TestRunMigrationProcessesAllAndAppliesToRegistry(t *testing.T) {
+	reg := NewRegistry("lumera-devnet-1", "funder", "lumera1funder", "legacy", "t0")
+	reg.UpsertAccount(legacyRec("gen-0001", "lumera1legacy1", "seed1"))
+	reg.UpsertAccount(legacyRec("gen-0002", "lumera1legacy2", "seed2"))
+
+	chain := &fakeMigrationChain{
+		records:    map[string]common.MigrationRecord{},
+		estimate:   common.MigrationEstimate{WouldSucceed: true},
+		keys:       map[string]bool{"gen-0001": true, "gen-0002": true},
+		claimHash:  "TX",
+		importAddr: map[string]string{},
+	}
+	var buf bytes.Buffer
+	lg := newMigrationLogger(&buf)
+	lg.now = fixedClock()
+	exec := &migrationExecutor{chain: chain, log: lg}
+
+	var saves int
+	var mu sync.Mutex
+	save := func(*ActivityRegistry) error { mu.Lock(); saves++; mu.Unlock(); return nil }
+
+	sum, err := runMigration(reg, exec, lg, migrationRunOpts{Parallelism: 2, MaxPerBlock: 50, Now: func() string { return "t1" }}, save)
+	if err != nil {
+		t.Fatalf("runMigration: %v", err)
+	}
+	if sum.Migrated != 2 {
+		t.Errorf("Migrated = %d, want 2 (summary: %+v)", sum.Migrated, sum)
+	}
+	for _, rec := range reg.Accounts {
+		if rec.Migration == nil || rec.Migration.Status != MigrationStatusMigrated {
+			t.Errorf("account %s not marked migrated: %+v", rec.Name, rec.Migration)
+		}
+	}
+	if saves == 0 {
+		t.Error("expected registry to be saved at least once")
+	}
+}
+
+func TestRunMigrationDryRunDoesNotMutate(t *testing.T) {
+	reg := NewRegistry("lumera-devnet-1", "funder", "lumera1funder", "legacy", "t0")
+	reg.UpsertAccount(legacyRec("gen-0001", "lumera1legacy1", "seed1"))
+
+	chain := &fakeMigrationChain{
+		records:  map[string]common.MigrationRecord{},
+		estimate: common.MigrationEstimate{WouldSucceed: true},
+		keys:     map[string]bool{"gen-0001": true},
+	}
+	var buf bytes.Buffer
+	lg := newMigrationLogger(&buf)
+	lg.now = fixedClock()
+	exec := &migrationExecutor{chain: chain, log: lg}
+
+	saves := 0
+	sum, err := runMigration(reg, exec, lg, migrationRunOpts{Parallelism: 2, MaxPerBlock: 50, DryRun: true, Now: func() string { return "t1" }}, func(*ActivityRegistry) error { saves++; return nil })
+	if err != nil {
+		t.Fatalf("runMigration: %v", err)
+	}
+	if sum.Planned != 1 {
+		t.Errorf("Planned = %d, want 1", sum.Planned)
+	}
+	if reg.Accounts[0].Migration != nil {
+		t.Error("dry-run must not mutate registry")
+	}
+	if chain.claimCalls != 0 {
+		t.Errorf("claimCalls = %d, want 0 in dry-run", chain.claimCalls)
+	}
+	if saves != 0 {
+		t.Errorf("dry-run must not save registry, saves = %d", saves)
+	}
+}

--- a/devnet/tests/gen-activity/mode_test.go
+++ b/devnet/tests/gen-activity/mode_test.go
@@ -1,0 +1,127 @@
+package main
+
+import "testing"
+
+func TestResolveMode(t *testing.T) {
+	t.Run("nothing set defaults to fresh", func(t *testing.T) {
+		c := Config{}
+		got, err := c.resolveMode()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != ModeFresh {
+			t.Errorf("resolveMode() = %q, want %q", got, ModeFresh)
+		}
+	})
+
+	t.Run("add-accounts bool implies add-accounts mode", func(t *testing.T) {
+		c := Config{AddAccounts: true}
+		got, err := c.resolveMode()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != ModeAddAccounts {
+			t.Errorf("resolveMode() = %q, want %q", got, ModeAddAccounts)
+		}
+	})
+
+	t.Run("activity-existing bool implies activity-existing mode", func(t *testing.T) {
+		c := Config{ActivityExisting: true}
+		got, err := c.resolveMode()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != ModeActivityExisting {
+			t.Errorf("resolveMode() = %q, want %q", got, ModeActivityExisting)
+		}
+	})
+
+	t.Run("explicit migrate mode resolves to migrate", func(t *testing.T) {
+		c := Config{Mode: ModeMigrate}
+		got, err := c.resolveMode()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != ModeMigrate {
+			t.Errorf("resolveMode() = %q, want %q", got, ModeMigrate)
+		}
+	})
+
+	t.Run("explicit mode matching the bool is not a conflict", func(t *testing.T) {
+		c := Config{Mode: ModeAddAccounts, AddAccounts: true}
+		got, err := c.resolveMode()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != ModeAddAccounts {
+			t.Errorf("resolveMode() = %q, want %q", got, ModeAddAccounts)
+		}
+	})
+
+	t.Run("migrate mode conflicts with add-accounts bool", func(t *testing.T) {
+		c := Config{Mode: ModeMigrate, AddAccounts: true}
+		if _, err := c.resolveMode(); err == nil {
+			t.Error("expected conflict error for migrate mode + add-accounts bool")
+		}
+	})
+
+	t.Run("both legacy bools are mutually exclusive", func(t *testing.T) {
+		c := Config{AddAccounts: true, ActivityExisting: true}
+		if _, err := c.resolveMode(); err == nil {
+			t.Error("expected error when both add-accounts and activity-existing set")
+		}
+	})
+
+	t.Run("unknown mode string fails", func(t *testing.T) {
+		c := Config{Mode: "bogus"}
+		if _, err := c.resolveMode(); err == nil {
+			t.Error("expected error for unknown mode")
+		}
+	})
+}
+
+func TestConfigValidateMigrateMode(t *testing.T) {
+	migrateConfig := func() Config {
+		return Config{
+			Bin:          "lumerad",
+			ChainID:      "lumera-devnet-1",
+			AccountsPath: "accounts.json",
+			Mode:         ModeMigrate,
+			Parallelism:  5,
+		}
+	}
+
+	t.Run("migrate mode does not require funding key or generation fields", func(t *testing.T) {
+		c := migrateConfig()
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error in migrate mode: %v", err)
+		}
+		if c.resolvedMode != ModeMigrate {
+			t.Errorf("resolvedMode = %q, want %q", c.resolvedMode, ModeMigrate)
+		}
+	})
+
+	t.Run("migrate mode still requires accounts path", func(t *testing.T) {
+		c := migrateConfig()
+		c.AccountsPath = ""
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for missing accounts path in migrate mode")
+		}
+	})
+
+	t.Run("migrate mode still requires chain-id", func(t *testing.T) {
+		c := migrateConfig()
+		c.ChainID = ""
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for missing chain-id in migrate mode")
+		}
+	})
+
+	t.Run("migrate mode still requires parallelism >= 1", func(t *testing.T) {
+		c := migrateConfig()
+		c.Parallelism = 0
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for parallelism < 1 in migrate mode")
+		}
+	})
+}

--- a/devnet/tests/gen-activity/mode_wizard_test.go
+++ b/devnet/tests/gen-activity/mode_wizard_test.go
@@ -1,0 +1,60 @@
+package main
+
+import "testing"
+
+func hasSetting(items []string, key string) bool {
+	for _, it := range items {
+		if menuKeyFromItem(it) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func TestVisibleSettingsMigrateModeHidesGenerationFields(t *testing.T) {
+	c := &Config{Mode: ModeMigrate}
+	items := menuItems(c)
+
+	// Migrate mode keeps only registry/connection/execution-relevant knobs.
+	for _, want := range []string{settingMode, settingAccountsPath, settingParallelism, settingDryRun} {
+		if !hasSetting(items, want) {
+			t.Errorf("migrate menu missing expected setting %q", want)
+		}
+	}
+	// Generation/funding settings are irrelevant in migrate mode and must be hidden.
+	for _, hidden := range []string{
+		settingFundingKey, settingNumAccounts, settingNumMultisig23, settingNumMultisig35,
+		settingActions, settingFundingBatch, settingMaxAmount, settingVestingPercent, settingNumPermLocked,
+	} {
+		if hasSetting(items, hidden) {
+			t.Errorf("migrate menu should hide setting %q", hidden)
+		}
+	}
+}
+
+func TestVisibleSettingsFreshModeShowsGenerationFields(t *testing.T) {
+	c := &Config{} // fresh
+	items := menuItems(c)
+	for _, want := range []string{settingFundingKey, settingNumAccounts, settingMaxAmount, settingVestingPercent} {
+		if !hasSetting(items, want) {
+			t.Errorf("fresh menu missing expected setting %q", want)
+		}
+	}
+}
+
+func TestEditSettingModeMigrate(t *testing.T) {
+	c := &Config{}
+	p := &fakePrompter{selectQueue: []string{"migrate"}}
+	if err := editSetting(c, settingMode, p); err != nil {
+		t.Fatalf("edit mode migrate: %v", err)
+	}
+	if c.Mode != ModeMigrate {
+		t.Errorf("Mode = %q, want %q", c.Mode, ModeMigrate)
+	}
+	if c.AddAccounts || c.ActivityExisting {
+		t.Errorf("legacy bools must be cleared when selecting migrate: add=%v activity=%v", c.AddAccounts, c.ActivityExisting)
+	}
+	if modeLabel(c) != ModeMigrate {
+		t.Errorf("modeLabel = %q, want %q", modeLabel(c), ModeMigrate)
+	}
+}

--- a/devnet/tests/gen-activity/multisig.go
+++ b/devnet/tests/gen-activity/multisig.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	"gen/tests/common"
@@ -40,8 +41,6 @@ func memberNames(composite string, signers int) []string {
 // multisig accounts, returning new AccountRecords (with Multisig info set). It is
 // rerun-safe: existing keys/composites are reused. Member keys use the detected
 // key style; the composite is key-type agnostic.
-//
-//nolint:unused // wired into run() in a later task
 func generateMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accountPrefix string, specs []multisigSpec, keyStyle common.KeyStyle) []*AccountRecord {
 	ms := common.NewMultisig(cli)
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -75,8 +74,6 @@ func generateMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accou
 }
 
 // ensureMembers creates any missing member keys with the detected key style.
-//
-//nolint:unused // wired into run() in a later task
 func ensureMembers(cli *common.ChainCLI, names []string, keyStyle common.KeyStyle) error {
 	for _, name := range names {
 		if cli.HasKey(name) {
@@ -87,4 +84,130 @@ func ensureMembers(cli *common.ChainCLI, names []string, keyStyle common.KeyStyl
 		}
 	}
 	return nil
+}
+
+// multisigExerciser performs one multisign tx for a multisig account. It is an
+// interface so the recording logic is testable without a live chain.
+type multisigExerciser interface {
+	// MultisigBankSend builds, signs (K members), and broadcasts a bank send
+	// from the multisig account to `to`, returning the tx hash.
+	MultisigBankSend(rec *AccountRecord, to, amount string) (string, error)
+}
+
+// exerciseMultisig runs one multisign bank-send for the account and records it.
+func exerciseMultisig(ex multisigExerciser, rec *AccountRecord, peer, amount string) error {
+	if rec.Multisig == nil {
+		return fmt.Errorf("account %s is not a multisig account", rec.Name)
+	}
+	txHash, err := ex.MultisigBankSend(rec, peer, amount)
+	if err != nil {
+		return err
+	}
+	rec.AddBankSend(common.BankSendActivity{To: peer, Amount: amount, TxHash: txHash})
+	return nil
+}
+
+// cliMultisigExerciser is the production exerciser backed by common.Multisig.
+type cliMultisigExerciser struct {
+	cli *common.ChainCLI
+	ms  *common.Multisig
+}
+
+func newCLIMultisigExerciser(cli *common.ChainCLI) *cliMultisigExerciser {
+	return &cliMultisigExerciser{cli: cli, ms: common.NewMultisig(cli)}
+}
+
+func (e *cliMultisigExerciser) MultisigBankSend(rec *AccountRecord, to, amount string) (string, error) {
+	accNum, seq, err := e.cli.AccountNumberAndSequence(rec.Address)
+	if err != nil {
+		return "", fmt.Errorf("query account number/sequence for %s: %w", rec.Address, err)
+	}
+	unsigned, err := os.CreateTemp("", "msig-unsigned-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create temp unsigned file: %w", err)
+	}
+	_ = unsigned.Close()
+	defer func() { _ = os.Remove(unsigned.Name()) }()
+
+	args := e.ms.GenBankSendArgs(rec.Name, rec.Address, to, amount, accNum, seq)
+	if err := e.ms.BuildUnsignedToFile(unsigned.Name(), args); err != nil {
+		return "", err
+	}
+	return e.ms.SignAndBroadcastFile(unsigned.Name(), rec.Name, rec.Address,
+		rec.Multisig.MemberNames, rec.Multisig.Threshold, accNum, seq)
+}
+
+// exerciseMultisigAccounts registers each funded multisig composite's pubkey
+// on-chain (via the shared ceremony's self-send) and runs one multisign
+// bank-send to a regular peer address. Failures are logged, never fatal.
+func exerciseMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, newMultisig []*AccountRecord, cfg *Config) {
+	targets := newMultisig
+	if cfg.ActivityExisting {
+		targets = nil
+		for _, rec := range reg.Accounts {
+			if rec.Multisig != nil && rec.Funded {
+				targets = append(targets, rec)
+			}
+		}
+	}
+	if len(targets) == 0 {
+		return
+	}
+
+	peer := firstRegularPeer(reg)
+	if peer == "" {
+		log.Printf("  no regular peer account to receive multisig sends; skipping multisig exercise")
+		return
+	}
+
+	ms := common.NewMultisig(cli)
+	ex := newCLIMultisigExerciser(cli)
+	amount := common.Coin{Amount: 1, Denom: common.ChainDenom}.String()
+
+	for _, rec := range targets {
+		if !rec.Funded {
+			continue
+		}
+		if err := registerMultisigPubkey(cli, ms, rec); err != nil {
+			log.Printf("  WARN: register pubkey for %s: %v", rec.Name, err)
+			continue
+		}
+		if err := exerciseMultisig(ex, rec, peer, amount); err != nil {
+			log.Printf("  WARN: exercise multisig %s: %v", rec.Name, err)
+		}
+	}
+}
+
+// registerMultisigPubkey publishes a multisig composite's pubkey on-chain via a
+// 1-ulume self-send (required before it can be queried for account number).
+func registerMultisigPubkey(cli *common.ChainCLI, ms *common.Multisig, rec *AccountRecord) error {
+	accNum, seq, err := cli.AccountNumberAndSequence(rec.Address)
+	if err != nil {
+		return fmt.Errorf("query account number/sequence for %s: %w", rec.Address, err)
+	}
+	unsigned, err := os.CreateTemp("", "msig-selfsend-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp unsigned file: %w", err)
+	}
+	_ = unsigned.Close()
+	defer func() { _ = os.Remove(unsigned.Name()) }()
+
+	args := ms.GenBankSendArgs(rec.Name, rec.Address, rec.Address, "1"+common.ChainDenom, accNum, seq)
+	if err := ms.BuildUnsignedToFile(unsigned.Name(), args); err != nil {
+		return err
+	}
+	_, err = ms.SignAndBroadcastFile(unsigned.Name(), rec.Name, rec.Address,
+		rec.Multisig.MemberNames, rec.Multisig.Threshold, accNum, seq)
+	return err
+}
+
+// firstRegularPeer returns the address of the first funded non-multisig account
+// to serve as a recipient for multisig sends.
+func firstRegularPeer(reg *ActivityRegistry) string {
+	for _, rec := range reg.Accounts {
+		if rec.Multisig == nil && rec.Funded && rec.Address != "" {
+			return rec.Address
+		}
+	}
+	return ""
 }

--- a/devnet/tests/gen-activity/multisig.go
+++ b/devnet/tests/gen-activity/multisig.go
@@ -51,7 +51,8 @@ func generateMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accou
 		composite := names[0]
 		members := memberNames(composite, spec.Signers)
 
-		if err := ensureMembers(cli, members, keyStyle); err != nil {
+		memberKeys, err := ensureMembers(cli, members, keyStyle)
+		if err != nil {
 			log.Printf("  WARN: multisig %s members: %v", composite, err)
 			continue
 		}
@@ -62,7 +63,7 @@ func generateMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accou
 		}
 		rec := &AccountRecord{
 			AccountIdentity: common.AccountIdentity{Name: composite, Address: addr, KeyStyle: keyStyle.Name()},
-			Multisig:        &MultisigInfo{MemberNames: members, Threshold: spec.Threshold, Signers: spec.Signers},
+			Multisig:        &MultisigInfo{MemberNames: members, Members: memberKeys, Threshold: spec.Threshold, Signers: spec.Signers},
 			CreatedAt:       now,
 			UpdatedAt:       now,
 		}
@@ -73,17 +74,28 @@ func generateMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accou
 	return recs
 }
 
-// ensureMembers creates any missing member keys with the detected key style.
-func ensureMembers(cli *common.ChainCLI, names []string, keyStyle common.KeyStyle) error {
+// ensureMembers creates any missing member keys with the detected key style and
+// returns the member key material. Newly created keys carry their mnemonic (so
+// migrate mode can re-import them into a fresh keyring); reused keys carry only
+// their name+address because the seed is no longer available.
+func ensureMembers(cli *common.ChainCLI, names []string, keyStyle common.KeyStyle) ([]MultisigMember, error) {
+	members := make([]MultisigMember, 0, len(names))
 	for _, name := range names {
 		if cli.HasKey(name) {
+			addr, err := cli.ShowAddress(name)
+			if err != nil {
+				return nil, fmt.Errorf("resolve existing member key %s: %w", name, err)
+			}
+			members = append(members, MultisigMember{Name: name, Address: addr})
 			continue
 		}
-		if _, err := cli.AddKeyWithStyle(name, keyStyle); err != nil {
-			return fmt.Errorf("add member key %s: %w", name, err)
+		gk, err := cli.AddKeyWithStyle(name, keyStyle)
+		if err != nil {
+			return nil, fmt.Errorf("add member key %s: %w", name, err)
 		}
+		members = append(members, MultisigMember{Name: name, Address: gk.Address, Mnemonic: gk.Mnemonic})
 	}
-	return nil
+	return members, nil
 }
 
 // multisigExerciser performs one multisign tx for a multisig account. It is an

--- a/devnet/tests/gen-activity/multisig.go
+++ b/devnet/tests/gen-activity/multisig.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"gen/tests/common"
+)
+
+// multisigSpec describes one multisig account to generate.
+type multisigSpec struct {
+	Prefix    string // name infix, e.g. "msig23"
+	Threshold int    // K
+	Signers   int    // N
+}
+
+// multisigPlan expands the 2-of-3 and 3-of-5 counts into a flat list of specs.
+func multisigPlan(num23, num35 int) []multisigSpec {
+	var plan []multisigSpec
+	for range num23 {
+		plan = append(plan, multisigSpec{Prefix: "msig23", Threshold: 2, Signers: 3})
+	}
+	for range num35 {
+		plan = append(plan, multisigSpec{Prefix: "msig35", Threshold: 3, Signers: 5})
+	}
+	return plan
+}
+
+// memberNames returns deterministic member key names for a composite.
+func memberNames(composite string, signers int) []string {
+	names := make([]string, signers)
+	for i := range signers {
+		names[i] = fmt.Sprintf("%s-signer-%d", composite, i+1)
+	}
+	return names
+}
+
+// generateMultisigAccounts creates member keys + composite keys for the planned
+// multisig accounts, returning new AccountRecords (with Multisig info set). It is
+// rerun-safe: existing keys/composites are reused. Member keys use the detected
+// key style; the composite is key-type agnostic.
+//
+//nolint:unused // wired into run() in a later task
+func generateMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accountPrefix string, specs []multisigSpec, keyStyle common.KeyStyle) []*AccountRecord {
+	ms := common.NewMultisig(cli)
+	now := time.Now().UTC().Format(time.RFC3339)
+	var recs []*AccountRecord
+
+	for _, spec := range specs {
+		names := reg.AllocateNames(accountPrefix+"-"+spec.Prefix, 1)
+		composite := names[0]
+		members := memberNames(composite, spec.Signers)
+
+		if err := ensureMembers(cli, members, keyStyle); err != nil {
+			log.Printf("  WARN: multisig %s members: %v", composite, err)
+			continue
+		}
+		addr, err := ms.CreateMultisigKey(composite, members, spec.Threshold)
+		if err != nil {
+			log.Printf("  WARN: create multisig %s: %v", composite, err)
+			continue
+		}
+		rec := &AccountRecord{
+			AccountIdentity: common.AccountIdentity{Name: composite, Address: addr, KeyStyle: keyStyle.Name()},
+			Multisig:        &MultisigInfo{MemberNames: members, Threshold: spec.Threshold, Signers: spec.Signers},
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		reg.UpsertAccount(rec)
+		recs = append(recs, rec)
+		log.Printf("  created %d-of-%d multisig %s (%s)", spec.Threshold, spec.Signers, composite, addr)
+	}
+	return recs
+}
+
+// ensureMembers creates any missing member keys with the detected key style.
+//
+//nolint:unused // wired into run() in a later task
+func ensureMembers(cli *common.ChainCLI, names []string, keyStyle common.KeyStyle) error {
+	for _, name := range names {
+		if cli.HasKey(name) {
+			continue
+		}
+		if _, err := cli.AddKeyWithStyle(name, keyStyle); err != nil {
+			return fmt.Errorf("add member key %s: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/devnet/tests/gen-activity/multisig_test.go
+++ b/devnet/tests/gen-activity/multisig_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	"gen/tests/common"
 )
 
 func TestMultisigPlanFromCounts(t *testing.T) {
@@ -32,4 +34,52 @@ func TestMemberNamesForComposite(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("memberNames = %v, want %v", got, want)
 	}
+}
+
+func TestActivityTargetsExcludesMultisig(t *testing.T) {
+	reg := NewRegistry("c", "f", "", "legacy", "t")
+	reg.Accounts = []*AccountRecord{
+		{AccountIdentity: common.AccountIdentity{Name: "reg", Address: "lumera1reg"}, Funded: true},
+		{AccountIdentity: common.AccountIdentity{Name: "msig", Address: "lumera1msig"}, Funded: true,
+			Multisig: &MultisigInfo{Threshold: 2, Signers: 3}},
+	}
+	// includeExisting must skip the funded multisig composite (single-sig mix).
+	got := activityTargets(reg, nil, true)
+	if len(got) != 1 || got[0].Name != "reg" {
+		t.Errorf("activityTargets(includeExisting) = %+v, want only the regular account", got)
+	}
+}
+
+func TestExerciseMultisigRecordsBankSend(t *testing.T) {
+	rec := &AccountRecord{
+		AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0001", Address: "lumera1msig"},
+		Multisig:        &MultisigInfo{MemberNames: []string{"m1", "m2", "m3"}, Threshold: 2, Signers: 3},
+		Funded:          true,
+	}
+	fake := &fakeMultisigExerciser{txHash: "DEAD01"}
+
+	err := exerciseMultisig(fake, rec, "lumera1peer", "5ulume")
+	if err != nil {
+		t.Fatalf("exerciseMultisig: %v", err)
+	}
+	if len(rec.BankSends) != 1 || rec.BankSends[0].To != "lumera1peer" {
+		t.Fatalf("expected one recorded bank send to peer, got %+v", rec.BankSends)
+	}
+	if rec.BankSends[0].TxHash != "DEAD01" {
+		t.Errorf("recorded tx hash = %q, want DEAD01", rec.BankSends[0].TxHash)
+	}
+	if !fake.called {
+		t.Error("multisig exerciser was not invoked")
+	}
+}
+
+// fakeMultisigExerciser satisfies multisigExerciser for the test.
+type fakeMultisigExerciser struct {
+	called bool
+	txHash string
+}
+
+func (f *fakeMultisigExerciser) MultisigBankSend(rec *AccountRecord, to, amount string) (string, error) {
+	f.called = true
+	return f.txHash, nil
 }

--- a/devnet/tests/gen-activity/multisig_test.go
+++ b/devnet/tests/gen-activity/multisig_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMultisigPlanFromCounts(t *testing.T) {
+	plan := multisigPlan(2, 1)
+	want := []multisigSpec{
+		{Prefix: "msig23", Threshold: 2, Signers: 3},
+		{Prefix: "msig23", Threshold: 2, Signers: 3},
+		{Prefix: "msig35", Threshold: 3, Signers: 5},
+	}
+	if !reflect.DeepEqual(plan, want) {
+		t.Errorf("multisigPlan(2,1) = %+v, want %+v", plan, want)
+	}
+}
+
+func TestMultisigPlanZeroIsEmpty(t *testing.T) {
+	if plan := multisigPlan(0, 0); len(plan) != 0 {
+		t.Errorf("multisigPlan(0,0) = %+v, want empty", plan)
+	}
+}
+
+func TestMemberNamesForComposite(t *testing.T) {
+	got := memberNames("gen-msig35-0007", 5)
+	want := []string{
+		"gen-msig35-0007-signer-1", "gen-msig35-0007-signer-2", "gen-msig35-0007-signer-3",
+		"gen-msig35-0007-signer-4", "gen-msig35-0007-signer-5",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("memberNames = %v, want %v", got, want)
+	}
+}

--- a/devnet/tests/gen-activity/registry.go
+++ b/devnet/tests/gen-activity/registry.go
@@ -21,6 +21,27 @@ type MultisigInfo struct {
 	Signers     int      `json:"signers"`
 }
 
+// Migration outcome statuses recorded in MigrationInfo.Status.
+const (
+	MigrationStatusMigrated        = "migrated"
+	MigrationStatusAlreadyMigrated = "already_migrated"
+	MigrationStatusSkipped         = "skipped"
+	MigrationStatusFailed          = "failed"
+)
+
+// MigrationInfo records the result of migrating an account to its EVM-compatible
+// counterpart. It is populated by migrate mode and is absent on records that
+// have never been through migration.
+type MigrationInfo struct {
+	NewName    string `json:"new_name,omitempty"`
+	NewAddress string `json:"new_address,omitempty"`
+	TxHash     string `json:"tx_hash,omitempty"`
+	Height     int64  `json:"height,omitempty"`
+	MigratedAt string `json:"migrated_at,omitempty"`
+	Status     string `json:"status,omitempty"` // migrated, already_migrated, skipped, failed
+	Error      string `json:"error,omitempty"`
+}
+
 // VestingInfo describes a vesting or permanent-locked account. Type is one of
 // the common.VestingType values ("continuous", "delayed", "permanent_locked").
 // EndTime is the unix unlock time (0 for permanent_locked).
@@ -36,12 +57,13 @@ type AccountRecord struct {
 	common.AccountIdentity
 	common.ActivityLog
 
-	HasBalance bool          `json:"has_balance,omitempty"`
-	Funded     bool          `json:"funded,omitempty"`
-	CreatedAt  string        `json:"created_at,omitempty"`
-	UpdatedAt  string        `json:"updated_at,omitempty"`
-	Multisig   *MultisigInfo `json:"multisig,omitempty"`
-	Vesting    *VestingInfo  `json:"vesting,omitempty"`
+	HasBalance bool           `json:"has_balance,omitempty"`
+	Funded     bool           `json:"funded,omitempty"`
+	CreatedAt  string         `json:"created_at,omitempty"`
+	UpdatedAt  string         `json:"updated_at,omitempty"`
+	Multisig   *MultisigInfo  `json:"multisig,omitempty"`
+	Vesting    *VestingInfo   `json:"vesting,omitempty"`
+	Migration  *MigrationInfo `json:"migration,omitempty"`
 }
 
 // ActivityRegistry is the gen-activity-owned top-level registry envelope. It is

--- a/devnet/tests/gen-activity/registry.go
+++ b/devnet/tests/gen-activity/registry.go
@@ -8,8 +8,18 @@ import (
 	"gen/tests/common"
 )
 
-// schemaVersion identifies the gen-activity registry layout.
-const schemaVersion = 1
+// schemaVersion identifies the gen-activity registry layout. v2 adds multisig
+// account records (AccountRecord.Multisig). v1 files are not supported and must
+// be regenerated.
+const schemaVersion = 2
+
+// MultisigInfo describes a generated K-of-N multisig account: its member key
+// names, signing threshold (K), and total signer count (N).
+type MultisigInfo struct {
+	MemberNames []string `json:"member_names"`
+	Threshold   int      `json:"threshold"`
+	Signers     int      `json:"signers"`
+}
 
 // AccountRecord is a gen-activity account: the shared identity and activity log
 // plus funding/timestamp metadata owned by this tool.
@@ -17,10 +27,11 @@ type AccountRecord struct {
 	common.AccountIdentity
 	common.ActivityLog
 
-	HasBalance bool   `json:"has_balance,omitempty"`
-	Funded     bool   `json:"funded,omitempty"`
-	CreatedAt  string `json:"created_at,omitempty"`
-	UpdatedAt  string `json:"updated_at,omitempty"`
+	HasBalance bool          `json:"has_balance,omitempty"`
+	Funded     bool          `json:"funded,omitempty"`
+	CreatedAt  string        `json:"created_at,omitempty"`
+	UpdatedAt  string        `json:"updated_at,omitempty"`
+	Multisig   *MultisigInfo `json:"multisig,omitempty"`
 }
 
 // ActivityRegistry is the gen-activity-owned top-level registry envelope. It is

--- a/devnet/tests/gen-activity/registry.go
+++ b/devnet/tests/gen-activity/registry.go
@@ -21,6 +21,15 @@ type MultisigInfo struct {
 	Signers     int      `json:"signers"`
 }
 
+// VestingInfo describes a vesting or permanent-locked account. Type is one of
+// the common.VestingType values ("continuous", "delayed", "permanent_locked").
+// EndTime is the unix unlock time (0 for permanent_locked).
+type VestingInfo struct {
+	Type         string `json:"type"`
+	EndTime      int64  `json:"end_time,omitempty"`
+	LockedAmount string `json:"locked_amount"`
+}
+
 // AccountRecord is a gen-activity account: the shared identity and activity log
 // plus funding/timestamp metadata owned by this tool.
 type AccountRecord struct {
@@ -32,6 +41,7 @@ type AccountRecord struct {
 	CreatedAt  string        `json:"created_at,omitempty"`
 	UpdatedAt  string        `json:"updated_at,omitempty"`
 	Multisig   *MultisigInfo `json:"multisig,omitempty"`
+	Vesting    *VestingInfo  `json:"vesting,omitempty"`
 }
 
 // ActivityRegistry is the gen-activity-owned top-level registry envelope. It is

--- a/devnet/tests/gen-activity/registry.go
+++ b/devnet/tests/gen-activity/registry.go
@@ -13,12 +13,25 @@ import (
 // be regenerated.
 const schemaVersion = 2
 
+// MultisigMember is one member sub-key of a generated multisig, including the
+// mnemonic so migrate mode can re-import the key into a fresh keyring. Empty
+// Mnemonic means the key was reused (pre-existing) at generation time and its
+// seed is unknown.
+type MultisigMember struct {
+	Name     string `json:"name"`
+	Address  string `json:"address,omitempty"`
+	Mnemonic string `json:"mnemonic,omitempty"`
+}
+
 // MultisigInfo describes a generated K-of-N multisig account: its member key
-// names, signing threshold (K), and total signer count (N).
+// names, signing threshold (K), and total signer count (N). Members carries the
+// per-member key material (with mnemonics) when available; MemberNames is always
+// populated and kept for backward compatibility with older registries.
 type MultisigInfo struct {
-	MemberNames []string `json:"member_names"`
-	Threshold   int      `json:"threshold"`
-	Signers     int      `json:"signers"`
+	MemberNames []string         `json:"member_names"`
+	Members     []MultisigMember `json:"members,omitempty"`
+	Threshold   int              `json:"threshold"`
+	Signers     int              `json:"signers"`
 }
 
 // Migration outcome statuses recorded in MigrationInfo.Status.

--- a/devnet/tests/gen-activity/registry_test.go
+++ b/devnet/tests/gen-activity/registry_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"gen/tests/common"
@@ -76,7 +77,7 @@ func TestLoadRegistryRejectsWrongSchemaVersion(t *testing.T) {
 		t.Error("expected error loading registry without schema_version, got nil")
 	}
 
-	data = []byte(`{"schema_version":2,"chain_id":"lumera-devnet-1","accounts":[]}`)
+	data = []byte(`{"schema_version":3,"chain_id":"lumera-devnet-1","accounts":[]}`)
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("seed file: %v", err)
 	}
@@ -114,5 +115,56 @@ func TestAllocateNames(t *testing.T) {
 		if more[i] != wantMore[i] {
 			t.Fatalf("more = %v, want %v", more, wantMore)
 		}
+	}
+}
+
+func TestRegistrySchemaIsV2(t *testing.T) {
+	if schemaVersion != 2 {
+		t.Fatalf("schemaVersion = %d, want 2", schemaVersion)
+	}
+	reg := NewRegistry("lumera-devnet-1", "faucet", "", "legacy", "2026-06-12T00:00:00Z")
+	if reg.SchemaVersion != 2 {
+		t.Errorf("NewRegistry schema = %d, want 2", reg.SchemaVersion)
+	}
+}
+
+func TestMultisigRecordRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "accounts.json")
+	reg := NewRegistry("lumera-devnet-1", "faucet", "", "legacy", "2026-06-12T00:00:00Z")
+	reg.UpsertAccount(&AccountRecord{
+		AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0001", Address: "lumera1msig"},
+		Multisig: &MultisigInfo{
+			MemberNames: []string{"gen-msig23-0001-signer-1", "gen-msig23-0001-signer-2", "gen-msig23-0001-signer-3"},
+			Threshold:   2,
+			Signers:     3,
+		},
+	})
+	if err := reg.Save(path, "2026-06-12T00:00:00Z"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(got.Accounts) != 1 || got.Accounts[0].Multisig == nil {
+		t.Fatalf("multisig info not persisted: %+v", got.Accounts)
+	}
+	if got.Accounts[0].Multisig.Threshold != 2 || got.Accounts[0].Multisig.Signers != 3 {
+		t.Errorf("multisig threshold/signers = %d/%d, want 2/3",
+			got.Accounts[0].Multisig.Threshold, got.Accounts[0].Multisig.Signers)
+	}
+}
+
+func TestAllocateNamesPerKindContinuesIndex(t *testing.T) {
+	reg := NewRegistry("c", "f", "", "legacy", "t")
+	reg.Accounts = []*AccountRecord{
+		{AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0001"}},
+		{AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0002"}},
+	}
+	names := reg.AllocateNames("gen-msig23", 2)
+	want := []string{"gen-msig23-0003", "gen-msig23-0004"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("AllocateNames = %v, want %v", names, want)
 	}
 }

--- a/devnet/tests/gen-activity/registry_test.go
+++ b/devnet/tests/gen-activity/registry_test.go
@@ -156,6 +156,30 @@ func TestMultisigRecordRoundTrip(t *testing.T) {
 	}
 }
 
+func TestVestingRecordRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "accounts.json")
+	reg := NewRegistry("lumera-devnet-1", "faucet", "", "legacy", "2026-06-12T00:00:00Z")
+	reg.UpsertAccount(&AccountRecord{
+		AccountIdentity: common.AccountIdentity{Name: "gen-0003", Address: "lumera1vest"},
+		Vesting:         &VestingInfo{Type: "continuous", EndTime: 1800000000, LockedAmount: "5000000ulume"},
+		Funded:          true,
+	})
+	if err := reg.Save(path, "2026-06-12T00:00:00Z"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.Accounts[0].Vesting == nil || got.Accounts[0].Vesting.Type != "continuous" {
+		t.Fatalf("vesting info not persisted: %+v", got.Accounts[0].Vesting)
+	}
+	if got.Accounts[0].Vesting.EndTime != 1800000000 {
+		t.Errorf("vesting end-time = %d, want 1800000000", got.Accounts[0].Vesting.EndTime)
+	}
+}
+
 func TestAllocateNamesPerKindContinuesIndex(t *testing.T) {
 	reg := NewRegistry("c", "f", "", "legacy", "t")
 	reg.Accounts = []*AccountRecord{

--- a/devnet/tests/gen-activity/vesting.go
+++ b/devnet/tests/gen-activity/vesting.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"math/rand"
+
+	"gen/tests/common"
+)
+
+// vestingWindow bounds the random vesting end time: now + [1h, 30 days].
+const (
+	vestingMinSeconds int64 = 3600
+	vestingMaxSeconds int64 = 30 * 24 * 3600
+)
+
+// planVesting randomly designates floor(len*percent/100) of recs as vesting
+// accounts, assigning each a continuous or delayed type and a random end time in
+// the vesting window. rng and nowUnix are injected for deterministic tests.
+// Returns the selected records (whose .Vesting was set in place).
+func planVesting(recs []*AccountRecord, percent int, lockedAmount string, rng *rand.Rand, nowUnix int64) []*AccountRecord {
+	if percent <= 0 || len(recs) == 0 {
+		return nil
+	}
+	count := len(recs) * percent / 100
+	if count == 0 {
+		return nil
+	}
+	// Random subset via partial permutation of indices.
+	idx := rng.Perm(len(recs))[:count]
+	selected := make([]*AccountRecord, 0, count)
+	for _, i := range idx {
+		rec := recs[i]
+		typ := common.VestingContinuous
+		if rng.Intn(2) == 0 {
+			typ = common.VestingDelayed
+		}
+		endTime := nowUnix + vestingMinSeconds + rng.Int63n(vestingMaxSeconds-vestingMinSeconds+1)
+		rec.Vesting = &VestingInfo{
+			Type:         string(typ),
+			EndTime:      endTime,
+			LockedAmount: lockedAmount,
+		}
+		selected = append(selected, rec)
+	}
+	return selected
+}
+
+// newPermanentLockedInfo builds the VestingInfo for a dedicated PermanentLocked
+// account (no end time).
+func newPermanentLockedInfo(lockedAmount string) *VestingInfo {
+	return &VestingInfo{
+		Type:         string(common.VestingPermanentLocked),
+		LockedAmount: lockedAmount,
+	}
+}
+
+// generatePermanentLockedAccounts creates `count` fresh keys named
+// "<prefix>-plock-NNNN", tags each with a permanent-locked VestingInfo, upserts
+// them into the registry, and returns the new records. Keys are created with the
+// detected key style; the accounts are NOT yet on-chain (the funding phase
+// creates them via create-permanent-locked-account). Rerun-safe.
+//
+//nolint:unused // wired into run() in a later task
+func generatePermanentLockedAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accountPrefix string, count int, keyStyle common.KeyStyle, lockedAmount, now string) []*AccountRecord {
+	if count <= 0 {
+		return nil
+	}
+	names := reg.AllocateNames(accountPrefix+"-plock", count)
+	var recs []*AccountRecord
+	for _, name := range names {
+		var addr string
+		if cli.HasKey(name) {
+			a, err := cli.ShowAddress(name)
+			if err != nil {
+				continue
+			}
+			addr = a
+		} else {
+			gk, err := cli.AddKeyWithStyle(name, keyStyle)
+			if err != nil {
+				continue
+			}
+			addr = gk.Address
+		}
+		rec := &AccountRecord{
+			AccountIdentity: common.AccountIdentity{Name: name, Address: addr, KeyStyle: keyStyle.Name()},
+			Vesting:         newPermanentLockedInfo(lockedAmount),
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		reg.UpsertAccount(rec)
+		recs = append(recs, rec)
+	}
+	return recs
+}

--- a/devnet/tests/gen-activity/vesting.go
+++ b/devnet/tests/gen-activity/vesting.go
@@ -119,6 +119,24 @@ func createVestingOnChain(cli *common.ChainCLI, funderKey string, rec *AccountRe
 	}
 }
 
+// permanentLockedRecord builds a permanent-locked AccountRecord from a generated
+// key, preserving the mnemonic and pubkey so migrate mode can later derive the
+// EVM destination / re-import the key (regular accounts keep these too).
+func permanentLockedRecord(gk common.GeneratedKey, keyStyle common.KeyStyle, lockedAmount, now string) *AccountRecord {
+	return &AccountRecord{
+		AccountIdentity: common.AccountIdentity{
+			Name:      gk.Name,
+			Address:   gk.Address,
+			Mnemonic:  gk.Mnemonic,
+			PubKeyB64: gk.PubKey,
+			KeyStyle:  keyStyle.Name(),
+		},
+		Vesting:   newPermanentLockedInfo(lockedAmount),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+}
+
 // generatePermanentLockedAccounts creates `count` fresh keys named
 // "<prefix>-plock-NNNN", tags each with a permanent-locked VestingInfo, upserts
 // them into the registry, and returns the new records. Keys are created with the
@@ -131,26 +149,22 @@ func generatePermanentLockedAccounts(cli *common.ChainCLI, reg *ActivityRegistry
 	names := reg.AllocateNames(accountPrefix+"-plock", count)
 	var recs []*AccountRecord
 	for _, name := range names {
-		var addr string
+		var gk common.GeneratedKey
 		if cli.HasKey(name) {
-			a, err := cli.ShowAddress(name)
+			// Reused key: address only; its mnemonic is no longer available.
+			addr, err := cli.ShowAddress(name)
 			if err != nil {
 				continue
 			}
-			addr = a
+			gk = common.GeneratedKey{Name: name, Address: addr}
 		} else {
-			gk, err := cli.AddKeyWithStyle(name, keyStyle)
+			created, err := cli.AddKeyWithStyle(name, keyStyle)
 			if err != nil {
 				continue
 			}
-			addr = gk.Address
+			gk = created
 		}
-		rec := &AccountRecord{
-			AccountIdentity: common.AccountIdentity{Name: name, Address: addr, KeyStyle: keyStyle.Name()},
-			Vesting:         newPermanentLockedInfo(lockedAmount),
-			CreatedAt:       now,
-			UpdatedAt:       now,
-		}
+		rec := permanentLockedRecord(gk, keyStyle, lockedAmount, now)
 		reg.UpsertAccount(rec)
 		recs = append(recs, rec)
 	}

--- a/devnet/tests/gen-activity/vesting.go
+++ b/devnet/tests/gen-activity/vesting.go
@@ -77,8 +77,6 @@ func splitFundingTargets(reg *ActivityRegistry) (bank, vesting []*AccountRecord)
 // appropriate create-* tx (funding the locked amount), then tops it up with a
 // small liquid amount so it can pay gas. Marks Funded on success. Failures are
 // logged and skipped (never fatal). Returns the count funded.
-//
-//nolint:unused // wired into run() in a later task
 func fundVestingAccounts(cli *common.ChainCLI, funderKey, funderAddr string, targets []*AccountRecord, liquidTopUp string) int {
 	funded := 0
 	for _, rec := range targets {
@@ -105,8 +103,6 @@ func fundVestingAccounts(cli *common.ChainCLI, funderKey, funderAddr string, tar
 
 // createVestingOnChain dispatches the correct create-* tx for the account's
 // vesting type.
-//
-//nolint:unused // called by fundVestingAccounts (itself wired into run() later)
 func createVestingOnChain(cli *common.ChainCLI, funderKey string, rec *AccountRecord) error {
 	switch rec.Vesting.Type {
 	case string(common.VestingContinuous):
@@ -128,8 +124,6 @@ func createVestingOnChain(cli *common.ChainCLI, funderKey string, rec *AccountRe
 // them into the registry, and returns the new records. Keys are created with the
 // detected key style; the accounts are NOT yet on-chain (the funding phase
 // creates them via create-permanent-locked-account). Rerun-safe.
-//
-//nolint:unused // wired into run() in a later task
 func generatePermanentLockedAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accountPrefix string, count int, keyStyle common.KeyStyle, lockedAmount, now string) []*AccountRecord {
 	if count <= 0 {
 		return nil

--- a/devnet/tests/gen-activity/vesting.go
+++ b/devnet/tests/gen-activity/vesting.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
+	"log"
 	"math/rand"
+	"time"
 
 	"gen/tests/common"
 )
@@ -50,6 +53,73 @@ func newPermanentLockedInfo(lockedAmount string) *VestingInfo {
 	return &VestingInfo{
 		Type:         string(common.VestingPermanentLocked),
 		LockedAmount: lockedAmount,
+	}
+}
+
+// splitFundingTargets divides unfunded accounts into those funded by the normal
+// batched bank-send (regular + multisig composites) and those funded by a
+// vesting create tx (any account carrying VestingInfo).
+func splitFundingTargets(reg *ActivityRegistry) (bank, vesting []*AccountRecord) {
+	for _, rec := range reg.Accounts {
+		if rec.Funded {
+			continue
+		}
+		if rec.Vesting != nil {
+			vesting = append(vesting, rec)
+		} else {
+			bank = append(bank, rec)
+		}
+	}
+	return bank, vesting
+}
+
+// fundVestingAccounts creates each vesting/locked account on-chain via the
+// appropriate create-* tx (funding the locked amount), then tops it up with a
+// small liquid amount so it can pay gas. Marks Funded on success. Failures are
+// logged and skipped (never fatal). Returns the count funded.
+//
+//nolint:unused // wired into run() in a later task
+func fundVestingAccounts(cli *common.ChainCLI, funderKey, funderAddr string, targets []*AccountRecord, liquidTopUp string) int {
+	funded := 0
+	for _, rec := range targets {
+		if rec.Vesting == nil {
+			continue
+		}
+		if err := createVestingOnChain(cli, funderKey, rec); err != nil {
+			log.Printf("  WARN: create vesting account %s: %v", rec.Name, err)
+			continue
+		}
+		// Liquid top-up so the locked account can pay fees / make small sends.
+		if _, err := cli.SubmitTx("tx", "bank", "send", funderAddr, rec.Address, liquidTopUp, "--from", funderKey); err != nil {
+			log.Printf("  WARN: top up vesting account %s: %v", rec.Name, err)
+			// Account exists and is locked; mark funded so it is recorded, but it
+			// may be unable to pay gas. Still counts as created.
+		}
+		rec.Funded = true
+		rec.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		funded++
+		log.Printf("  funded %s vesting account %s (%s)", rec.Vesting.Type, rec.Name, rec.Address)
+	}
+	return funded
+}
+
+// createVestingOnChain dispatches the correct create-* tx for the account's
+// vesting type.
+//
+//nolint:unused // called by fundVestingAccounts (itself wired into run() later)
+func createVestingOnChain(cli *common.ChainCLI, funderKey string, rec *AccountRecord) error {
+	switch rec.Vesting.Type {
+	case string(common.VestingContinuous):
+		_, err := cli.CreateVestingAccount(funderKey, rec.Address, rec.Vesting.LockedAmount, rec.Vesting.EndTime, false)
+		return err
+	case string(common.VestingDelayed):
+		_, err := cli.CreateVestingAccount(funderKey, rec.Address, rec.Vesting.LockedAmount, rec.Vesting.EndTime, true)
+		return err
+	case string(common.VestingPermanentLocked):
+		_, err := cli.CreatePermanentLockedAccount(funderKey, rec.Address, rec.Vesting.LockedAmount)
+		return err
+	default:
+		return fmt.Errorf("unknown vesting type %q for %s", rec.Vesting.Type, rec.Name)
 	}
 }
 

--- a/devnet/tests/gen-activity/vesting_test.go
+++ b/devnet/tests/gen-activity/vesting_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+
+	"gen/tests/common"
+)
+
+func vestingRecs(n int) []*AccountRecord {
+	recs := make([]*AccountRecord, n)
+	for i := range recs {
+		recs[i] = &AccountRecord{AccountIdentity: common.AccountIdentity{
+			Name: "gen-acct", Address: "lumera1a",
+		}}
+	}
+	return recs
+}
+
+func TestPlanVestingSelectsPercentage(t *testing.T) {
+	recs := vestingRecs(10)
+	rng := rand.New(rand.NewSource(1))
+	selected := planVesting(recs, 30, "1000000ulume", rng, 1_700_000_000)
+	if len(selected) != 3 { // floor(10 * 30 / 100)
+		t.Fatalf("selected %d accounts, want 3", len(selected))
+	}
+	for _, rec := range selected {
+		if rec.Vesting == nil {
+			t.Fatalf("selected account %s has no Vesting info", rec.Name)
+		}
+		if rec.Vesting.Type != string(common.VestingContinuous) && rec.Vesting.Type != string(common.VestingDelayed) {
+			t.Errorf("vesting type = %q, want continuous or delayed", rec.Vesting.Type)
+		}
+		if rec.Vesting.EndTime <= 1_700_000_000 {
+			t.Errorf("end-time %d must be after now", rec.Vesting.EndTime)
+		}
+		if rec.Vesting.LockedAmount != "1000000ulume" {
+			t.Errorf("locked amount = %q, want 1000000ulume", rec.Vesting.LockedAmount)
+		}
+	}
+}
+
+func TestPlanVestingZeroPercentSelectsNone(t *testing.T) {
+	recs := vestingRecs(10)
+	rng := rand.New(rand.NewSource(1))
+	if selected := planVesting(recs, 0, "1000000ulume", rng, 1_700_000_000); len(selected) != 0 {
+		t.Errorf("0%% selected %d accounts, want 0", len(selected))
+	}
+}
+
+func TestNewPermanentLockedInfo(t *testing.T) {
+	info := newPermanentLockedInfo("5000000ulume")
+	if info.Type != string(common.VestingPermanentLocked) {
+		t.Errorf("type = %q, want permanent_locked", info.Type)
+	}
+	if info.EndTime != 0 {
+		t.Errorf("permanent-locked end-time = %d, want 0", info.EndTime)
+	}
+	if info.LockedAmount != "5000000ulume" {
+		t.Errorf("locked amount = %q, want 5000000ulume", info.LockedAmount)
+	}
+}

--- a/devnet/tests/gen-activity/vesting_test.go
+++ b/devnet/tests/gen-activity/vesting_test.go
@@ -60,3 +60,31 @@ func TestNewPermanentLockedInfo(t *testing.T) {
 		t.Errorf("locked amount = %q, want 5000000ulume", info.LockedAmount)
 	}
 }
+
+func TestSplitFundingTargets(t *testing.T) {
+	reg := NewRegistry("c", "f", "", "legacy", "t")
+	reg.Accounts = []*AccountRecord{
+		{AccountIdentity: common.AccountIdentity{Name: "regular"}},                                                // bank
+		{AccountIdentity: common.AccountIdentity{Name: "msig"}, Multisig: &MultisigInfo{Threshold: 2}},            // bank (composite funded from funder)
+		{AccountIdentity: common.AccountIdentity{Name: "vest"}, Vesting: &VestingInfo{Type: "continuous"}},        // vesting
+		{AccountIdentity: common.AccountIdentity{Name: "plock"}, Vesting: &VestingInfo{Type: "permanent_locked"}}, // vesting
+		{AccountIdentity: common.AccountIdentity{Name: "already"}, Funded: true},                                  // skipped
+	}
+	bank, vesting := splitFundingTargets(reg)
+
+	names := func(recs []*AccountRecord) []string {
+		var out []string
+		for _, r := range recs {
+			out = append(out, r.Name)
+		}
+		return out
+	}
+	gotBank := names(bank)
+	if len(gotBank) != 2 || gotBank[0] != "regular" || gotBank[1] != "msig" {
+		t.Errorf("bank targets = %v, want [regular msig]", gotBank)
+	}
+	gotVest := names(vesting)
+	if len(gotVest) != 2 || gotVest[0] != "vest" || gotVest[1] != "plock" {
+		t.Errorf("vesting targets = %v, want [vest plock]", gotVest)
+	}
+}

--- a/devnet/tests/gen-activity/vesting_test.go
+++ b/devnet/tests/gen-activity/vesting_test.go
@@ -17,6 +17,26 @@ func vestingRecs(n int) []*AccountRecord {
 	return recs
 }
 
+func TestPermanentLockedRecordPreservesKeyMaterial(t *testing.T) {
+	gk := common.GeneratedKey{Name: "gen-plock-0001", Address: "lumera1plock", Mnemonic: "twelve word seed phrase", PubKey: "base64pubkey"}
+	rec := permanentLockedRecord(gk, common.KeyStyleLegacy, "1000ulume", "2026-06-16T00:00:00Z")
+
+	// Migration relies on the mnemonic being recorded (so the key can be
+	// re-imported / its EVM destination derived). Regression: it was dropped.
+	if rec.Mnemonic != "twelve word seed phrase" {
+		t.Errorf("Mnemonic = %q, want it preserved from the generated key", rec.Mnemonic)
+	}
+	if rec.PubKeyB64 != "base64pubkey" {
+		t.Errorf("PubKeyB64 = %q, want it preserved", rec.PubKeyB64)
+	}
+	if rec.Address != "lumera1plock" || rec.KeyStyle != "legacy" {
+		t.Errorf("identity not set correctly: %+v", rec.AccountIdentity)
+	}
+	if rec.Vesting == nil || rec.Vesting.Type != string(common.VestingPermanentLocked) || rec.Vesting.LockedAmount != "1000ulume" {
+		t.Errorf("vesting info wrong: %+v", rec.Vesting)
+	}
+}
+
 func TestPlanVestingSelectsPercentage(t *testing.T) {
 	recs := vestingRecs(10)
 	rng := rand.New(rand.NewSource(1))

--- a/devnet/tests/gen-activity/wizard.go
+++ b/devnet/tests/gen-activity/wizard.go
@@ -191,6 +191,13 @@ func editSetting(c *Config, key string, p prompter) error {
 	return nil
 }
 
+// chainSummary renders the selected chain's connection settings followed by a
+// divider, shown once after chain selection and before the settings menu.
+func chainSummary(cfg *Config) string {
+	return fmt.Sprintf("\nChain: %s\n  chain-id: %s\n  rpc:      %s\n  grpc:     %s\n----------\n",
+		cfg.Chain, cfg.ChainID, cfg.RPC, cfg.GRPC)
+}
+
 // runWizard drives the interactive flow: optionally pick a chain (re-seeding cfg
 // from that chain's config section), then loop the settings menu until the user
 // chooses Run (validate + invoke runner) or Quit (return without running).
@@ -215,6 +222,7 @@ func runWizard(cfg *Config, fc *FileConfig, p prompter, runner func(*Config) err
 		if err := applyLayer(cfg, fc.Chains[chosen], nil); err != nil {
 			return err
 		}
+		fmt.Print(chainSummary(cfg))
 	} else {
 		// Manual entry when there is no config file / no chains defined.
 		if err := promptManualChain(cfg, p); err != nil {
@@ -273,7 +281,7 @@ func newSurveyPrompter() prompter { return surveyPrompter{} }
 
 func (surveyPrompter) SelectOne(label string, options []string, def string) (string, error) {
 	answer := def
-	prompt := &survey.Select{Message: label, Options: options, Default: def}
+	prompt := &survey.Select{Message: label, Options: options, Default: def, PageSize: 20}
 	if err := survey.AskOne(prompt, &answer); err != nil {
 		return "", err
 	}

--- a/devnet/tests/gen-activity/wizard.go
+++ b/devnet/tests/gen-activity/wizard.go
@@ -92,24 +92,56 @@ func settingValue(c *Config, key string) string {
 	}
 }
 
-// modeLabel renders the current run mode derived from the AddAccounts /
-// ActivityExisting flags.
+// modeLabel renders the current run mode, preferring the explicit Mode field and
+// falling back to the legacy AddAccounts / ActivityExisting flags.
 func modeLabel(c *Config) string {
+	if mode, err := c.resolveMode(); err == nil {
+		return mode
+	}
+	// Contradictory flags: fall back to a best-effort label.
 	switch {
 	case c.AddAccounts:
-		return "add-accounts"
+		return ModeAddAccounts
 	case c.ActivityExisting:
-		return "activity-existing"
+		return ModeActivityExisting
 	default:
-		return "fresh"
+		return ModeFresh
 	}
+}
+
+// migrateVisibleSettings is the subset of editable settings relevant in migrate
+// mode: registry/connection/execution knobs only. Generation and funding
+// settings are hidden because migrate mode neither funds nor creates accounts.
+var migrateVisibleSettings = map[string]bool{
+	settingMode:         true,
+	settingAccountsPath: true,
+	settingParallelism:  true,
+	settingDryRun:       true,
+}
+
+// visibleSettings returns the editable settings shown for the config's resolved
+// mode. Non-migrate modes show the full list; migrate mode shows only the
+// migration-relevant subset.
+func visibleSettings(c *Config) []string {
+	mode, err := c.resolveMode()
+	if err != nil || mode != ModeMigrate {
+		return editableSettings
+	}
+	visible := make([]string, 0, len(migrateVisibleSettings))
+	for _, key := range editableSettings {
+		if migrateVisibleSettings[key] {
+			visible = append(visible, key)
+		}
+	}
+	return visible
 }
 
 // menuItems renders the settings menu: one entry per editable setting (with its
 // current value) followed by the Run and Quit sentinels.
 func menuItems(c *Config) []string {
-	items := make([]string, 0, len(editableSettings)+2)
-	for _, key := range editableSettings {
+	keys := visibleSettings(c)
+	items := make([]string, 0, len(keys)+2)
+	for _, key := range keys {
 		items = append(items, fmt.Sprintf("%-24s %s", key, settingValue(c, key)))
 	}
 	items = append(items, menuRun, menuQuit)
@@ -141,12 +173,15 @@ func editSetting(c *Config, key string, p prompter) error {
 		}
 		c.FundingKey = v
 	case settingMode:
-		v, err := p.SelectOne("Run mode", []string{"fresh", "add-accounts", "activity-existing"}, modeLabel(c))
+		v, err := p.SelectOne("Run mode", []string{ModeFresh, ModeAddAccounts, ModeActivityExisting, ModeMigrate}, modeLabel(c))
 		if err != nil {
 			return err
 		}
-		c.AddAccounts = v == "add-accounts"
-		c.ActivityExisting = v == "activity-existing"
+		// Mode is now first-class; clear the legacy booleans so they can't
+		// contradict it during resolveMode.
+		c.Mode = v
+		c.AddAccounts = false
+		c.ActivityExisting = false
 	case settingAccountsPath:
 		v, err := p.Input(key, "Accounts registry path", c.AccountsPath)
 		if err != nil {

--- a/devnet/tests/gen-activity/wizard.go
+++ b/devnet/tests/gen-activity/wizard.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/AlecAivazis/survey/v2"
 )
 
 // prompter abstracts the interactive prompts so the wizard's control flow is
@@ -162,19 +164,124 @@ func editSetting(c *Config, key string, p prompter) error {
 		}
 		c.DryRun = v
 	case settingNumAccounts:
-		return editInt(key,"Number of accounts", &c.NumAccounts, p)
+		return editInt(key, "Number of accounts", &c.NumAccounts, p)
 	case settingNumMultisig23:
-		return editInt(key,"Number of 2-of-3 multisig accounts", &c.NumMultisig23, p)
+		return editInt(key, "Number of 2-of-3 multisig accounts", &c.NumMultisig23, p)
 	case settingNumMultisig35:
-		return editInt(key,"Number of 3-of-5 multisig accounts", &c.NumMultisig35, p)
+		return editInt(key, "Number of 3-of-5 multisig accounts", &c.NumMultisig35, p)
 	case settingParallelism:
-		return editInt(key,"Parallelism", &c.Parallelism, p)
+		return editInt(key, "Parallelism", &c.Parallelism, p)
 	case settingFundingBatch:
-		return editInt(key,"Funding batch size", &c.FundingBatchSize, p)
+		return editInt(key, "Funding batch size", &c.FundingBatchSize, p)
 	default:
 		return fmt.Errorf("unknown setting %q", key)
 	}
 	return nil
+}
+
+// runWizard drives the interactive flow: optionally pick a chain (re-seeding cfg
+// from that chain's config section), then loop the settings menu until the user
+// chooses Run (validate + invoke runner) or Quit (return without running).
+// runner is injected so tests can assert invocation without a live chain.
+func runWizard(cfg *Config, fc *FileConfig, p prompter, runner func(*Config) error) error {
+	if fc != nil && len(fc.Chains) > 0 {
+		names := fc.ChainNames()
+		def := cfg.Chain
+		if def == "" {
+			def = names[0]
+		}
+		chosen, err := p.SelectOne("Select chain", names, def)
+		if err != nil {
+			return err
+		}
+		cfg.Chain = chosen
+		// Re-seed defaults from the chosen chain (wizard is interactive: the
+		// chain's values become the working defaults the user can then edit).
+		applyLayer(cfg, fc.Common, nil)
+		applyLayer(cfg, fc.Chains[chosen], nil)
+	} else {
+		// Manual entry when there is no config file / no chains defined.
+		if err := promptManualChain(cfg, p); err != nil {
+			return err
+		}
+	}
+
+	for {
+		choice, err := p.SelectOne("Settings (select to edit, then Run)", menuItems(cfg), menuRun)
+		if err != nil {
+			return err
+		}
+		key := menuKeyFromItem(choice)
+		switch key {
+		case menuRun:
+			if err := cfg.Validate(); err != nil {
+				fmt.Printf("  cannot run: %v\n", err)
+				continue
+			}
+			return runner(cfg)
+		case menuQuit:
+			return nil
+		default:
+			if err := editSetting(cfg, key, p); err != nil {
+				fmt.Printf("  %v\n", err)
+			}
+		}
+	}
+}
+
+// promptManualChain asks for the minimum connection settings when no config file
+// is present, so a bare `gen-activity` invocation still works.
+func promptManualChain(cfg *Config, p prompter) error {
+	rpc, err := p.Input("rpc", "RPC endpoint", cfg.RPC)
+	if err != nil {
+		return err
+	}
+	cfg.RPC = rpc
+	grpc, err := p.Input("grpc", "gRPC endpoint", cfg.GRPC)
+	if err != nil {
+		return err
+	}
+	cfg.GRPC = grpc
+	chainID, err := p.Input("chain-id", "Chain ID", cfg.ChainID)
+	if err != nil {
+		return err
+	}
+	cfg.ChainID = chainID
+	return nil
+}
+
+// surveyPrompter is the production prompter backed by survey/v2.
+type surveyPrompter struct{}
+
+func newSurveyPrompter() prompter { return surveyPrompter{} }
+
+func (surveyPrompter) SelectOne(label string, options []string, def string) (string, error) {
+	answer := def
+	prompt := &survey.Select{Message: label, Options: options, Default: def}
+	if err := survey.AskOne(prompt, &answer); err != nil {
+		return "", err
+	}
+	return answer, nil
+}
+
+// The first parameter (the setting key) is unused by the survey impl but
+// required by the prompter interface, so it is named _.
+func (surveyPrompter) Input(_ string, label, def string) (string, error) {
+	answer := def
+	prompt := &survey.Input{Message: label, Default: def}
+	if err := survey.AskOne(prompt, &answer); err != nil {
+		return "", err
+	}
+	return answer, nil
+}
+
+func (surveyPrompter) Confirm(_ string, label string, def bool) (bool, error) {
+	answer := def
+	prompt := &survey.Confirm{Message: label, Default: def}
+	if err := survey.AskOne(prompt, &answer); err != nil {
+		return false, err
+	}
+	return answer, nil
 }
 
 // editInt prompts for an integer setting and applies it only on a clean parse.

--- a/devnet/tests/gen-activity/wizard.go
+++ b/devnet/tests/gen-activity/wizard.go
@@ -1,0 +1,192 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// prompter abstracts the interactive prompts so the wizard's control flow is
+// unit-testable with a scripted fake. The production implementation
+// (surveyPrompter) is backed by github.com/AlecAivazis/survey/v2. Input/Confirm
+// take a stable `key` (the setting key) plus a human label so tests can script
+// answers without matching on display text.
+type prompter interface {
+	SelectOne(label string, options []string, def string) (string, error)
+	Input(key, label, def string) (string, error)
+	Confirm(key, label string, def bool) (bool, error)
+}
+
+// Setting keys: stable identifiers for editable settings.
+const (
+	settingFundingKey    = "funding-key"
+	settingMode          = "mode"
+	settingNumAccounts   = "num-accounts"
+	settingNumMultisig23 = "num-multisig23-accounts"
+	settingNumMultisig35 = "num-multisig35-accounts"
+	settingAccountsPath  = "accounts"
+	settingParallelism   = "parallelism"
+	settingActions       = "actions"
+	settingFundingBatch  = "funding-batch-size"
+	settingMaxAmount     = "max-account-amount"
+	settingDryRun        = "dry-run"
+)
+
+// Menu sentinels.
+const (
+	menuRun  = "▶ Run now"
+	menuQuit = "✗ Quit"
+)
+
+// editableSettings is the ordered list of setting keys shown in the menu.
+var editableSettings = []string{
+	settingFundingKey,
+	settingMode,
+	settingNumAccounts,
+	settingNumMultisig23,
+	settingNumMultisig35,
+	settingAccountsPath,
+	settingParallelism,
+	settingActions,
+	settingFundingBatch,
+	settingMaxAmount,
+	settingDryRun,
+}
+
+// settingValue returns the current value of a setting as a display string.
+func settingValue(c *Config, key string) string {
+	switch key {
+	case settingFundingKey:
+		return c.FundingKey
+	case settingMode:
+		return modeLabel(c)
+	case settingNumAccounts:
+		return strconv.Itoa(c.NumAccounts)
+	case settingNumMultisig23:
+		return strconv.Itoa(c.NumMultisig23)
+	case settingNumMultisig35:
+		return strconv.Itoa(c.NumMultisig35)
+	case settingAccountsPath:
+		return c.AccountsPath
+	case settingParallelism:
+		return strconv.Itoa(c.Parallelism)
+	case settingActions:
+		return strconv.FormatBool(c.Actions)
+	case settingFundingBatch:
+		return strconv.Itoa(c.FundingBatchSize)
+	case settingMaxAmount:
+		return c.MaxAccountAmount
+	case settingDryRun:
+		return strconv.FormatBool(c.DryRun)
+	default:
+		return ""
+	}
+}
+
+// modeLabel renders the current run mode derived from the AddAccounts /
+// ActivityExisting flags.
+func modeLabel(c *Config) string {
+	switch {
+	case c.AddAccounts:
+		return "add-accounts"
+	case c.ActivityExisting:
+		return "activity-existing"
+	default:
+		return "fresh"
+	}
+}
+
+// menuItems renders the settings menu: one entry per editable setting (with its
+// current value) followed by the Run and Quit sentinels.
+func menuItems(c *Config) []string {
+	items := make([]string, 0, len(editableSettings)+2)
+	for _, key := range editableSettings {
+		items = append(items, fmt.Sprintf("%-24s %s", key, settingValue(c, key)))
+	}
+	items = append(items, menuRun, menuQuit)
+	return items
+}
+
+// menuKeyFromItem maps a rendered menu line back to its setting key (or the
+// sentinel itself for Run/Quit).
+func menuKeyFromItem(item string) string {
+	if item == menuRun || item == menuQuit {
+		return item
+	}
+	for i := 0; i < len(item); i++ {
+		if item[i] == ' ' {
+			return item[:i]
+		}
+	}
+	return item
+}
+
+// editSetting prompts for a new value for one setting and applies it to c. A
+// parse error on a numeric field is returned and leaves c unchanged.
+func editSetting(c *Config, key string, p prompter) error {
+	switch key {
+	case settingFundingKey:
+		v, err := p.Input(key, "Funder key name", c.FundingKey)
+		if err != nil {
+			return err
+		}
+		c.FundingKey = v
+	case settingMode:
+		v, err := p.SelectOne("Run mode", []string{"fresh", "add-accounts", "activity-existing"}, modeLabel(c))
+		if err != nil {
+			return err
+		}
+		c.AddAccounts = v == "add-accounts"
+		c.ActivityExisting = v == "activity-existing"
+	case settingAccountsPath:
+		v, err := p.Input(key, "Accounts registry path", c.AccountsPath)
+		if err != nil {
+			return err
+		}
+		c.AccountsPath = v
+	case settingMaxAmount:
+		v, err := p.Input(key, "Max per-account amount", c.MaxAccountAmount)
+		if err != nil {
+			return err
+		}
+		c.MaxAccountAmount = v
+	case settingActions:
+		v, err := p.Confirm(key, "Include CASCADE action activity?", c.Actions)
+		if err != nil {
+			return err
+		}
+		c.Actions = v
+	case settingDryRun:
+		v, err := p.Confirm(key, "Dry run (plan only, no txs)?", c.DryRun)
+		if err != nil {
+			return err
+		}
+		c.DryRun = v
+	case settingNumAccounts:
+		return editInt(key,"Number of accounts", &c.NumAccounts, p)
+	case settingNumMultisig23:
+		return editInt(key,"Number of 2-of-3 multisig accounts", &c.NumMultisig23, p)
+	case settingNumMultisig35:
+		return editInt(key,"Number of 3-of-5 multisig accounts", &c.NumMultisig35, p)
+	case settingParallelism:
+		return editInt(key,"Parallelism", &c.Parallelism, p)
+	case settingFundingBatch:
+		return editInt(key,"Funding batch size", &c.FundingBatchSize, p)
+	default:
+		return fmt.Errorf("unknown setting %q", key)
+	}
+	return nil
+}
+
+// editInt prompts for an integer setting and applies it only on a clean parse.
+func editInt(key, label string, dst *int, p prompter) error {
+	v, err := p.Input(key, label, strconv.Itoa(*dst))
+	if err != nil {
+		return err
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fmt.Errorf("%s: %q is not an integer", key, v)
+	}
+	*dst = n
+	return nil
+}

--- a/devnet/tests/gen-activity/wizard.go
+++ b/devnet/tests/gen-activity/wizard.go
@@ -20,17 +20,19 @@ type prompter interface {
 
 // Setting keys: stable identifiers for editable settings.
 const (
-	settingFundingKey    = "funding-key"
-	settingMode          = "mode"
-	settingNumAccounts   = "num-accounts"
-	settingNumMultisig23 = "num-multisig23-accounts"
-	settingNumMultisig35 = "num-multisig35-accounts"
-	settingAccountsPath  = "accounts"
-	settingParallelism   = "parallelism"
-	settingActions       = "actions"
-	settingFundingBatch  = "funding-batch-size"
-	settingMaxAmount     = "max-account-amount"
-	settingDryRun        = "dry-run"
+	settingFundingKey     = "funding-key"
+	settingMode           = "mode"
+	settingNumAccounts    = "num-accounts"
+	settingNumMultisig23  = "num-multisig23-accounts"
+	settingNumMultisig35  = "num-multisig35-accounts"
+	settingAccountsPath   = "accounts"
+	settingParallelism    = "parallelism"
+	settingActions        = "actions"
+	settingFundingBatch   = "funding-batch-size"
+	settingMaxAmount      = "max-account-amount"
+	settingDryRun         = "dry-run"
+	settingVestingPercent = "vesting-percent"
+	settingNumPermLocked  = "num-permanent-locked-accounts"
 )
 
 // Menu sentinels.
@@ -52,6 +54,8 @@ var editableSettings = []string{
 	settingFundingBatch,
 	settingMaxAmount,
 	settingDryRun,
+	settingVestingPercent,
+	settingNumPermLocked,
 }
 
 // settingValue returns the current value of a setting as a display string.
@@ -79,6 +83,10 @@ func settingValue(c *Config, key string) string {
 		return c.MaxAccountAmount
 	case settingDryRun:
 		return strconv.FormatBool(c.DryRun)
+	case settingVestingPercent:
+		return strconv.Itoa(c.VestingPercent)
+	case settingNumPermLocked:
+		return strconv.Itoa(c.NumPermanentLocked)
 	default:
 		return ""
 	}
@@ -173,6 +181,10 @@ func editSetting(c *Config, key string, p prompter) error {
 		return editInt(key, "Parallelism", &c.Parallelism, p)
 	case settingFundingBatch:
 		return editInt(key, "Funding batch size", &c.FundingBatchSize, p)
+	case settingVestingPercent:
+		return editInt(key, "Vesting percent (0-100)", &c.VestingPercent, p)
+	case settingNumPermLocked:
+		return editInt(key, "Number of permanent-locked accounts", &c.NumPermanentLocked, p)
 	default:
 		return fmt.Errorf("unknown setting %q", key)
 	}

--- a/devnet/tests/gen-activity/wizard.go
+++ b/devnet/tests/gen-activity/wizard.go
@@ -202,7 +202,12 @@ func chainSummary(cfg *Config) string {
 // from that chain's config section), then loop the settings menu until the user
 // chooses Run (validate + invoke runner) or Quit (return without running).
 // runner is injected so tests can assert invocation without a live chain.
-func runWizard(cfg *Config, fc *FileConfig, p prompter, runner func(*Config) error) error {
+//
+// setFlags marks the CLI flags the user set explicitly (the same map
+// resolveConfig built). The chain re-seed honors it so explicit overrides keep
+// winning over [common]/[chains.*], preserving the documented
+// flag > chain > common precedence even after the user switches chains.
+func runWizard(cfg *Config, fc *FileConfig, setFlags map[string]bool, p prompter, runner func(*Config) error) error {
 	if fc != nil && len(fc.Chains) > 0 {
 		names := fc.ChainNames()
 		def := cfg.Chain
@@ -215,11 +220,12 @@ func runWizard(cfg *Config, fc *FileConfig, p prompter, runner func(*Config) err
 		}
 		cfg.Chain = chosen
 		// Re-seed defaults from the chosen chain (wizard is interactive: the
-		// chain's values become the working defaults the user can then edit).
-		if err := applyLayer(cfg, fc.Common, nil); err != nil {
+		// chain's values become the working defaults the user can then edit),
+		// but never clobber values the user set explicitly on the CLI.
+		if err := applyLayer(cfg, fc.Common, setFlags); err != nil {
 			return err
 		}
-		if err := applyLayer(cfg, fc.Chains[chosen], nil); err != nil {
+		if err := applyLayer(cfg, fc.Chains[chosen], setFlags); err != nil {
 			return err
 		}
 		fmt.Print(chainSummary(cfg))

--- a/devnet/tests/gen-activity/wizard.go
+++ b/devnet/tests/gen-activity/wizard.go
@@ -209,8 +209,12 @@ func runWizard(cfg *Config, fc *FileConfig, p prompter, runner func(*Config) err
 		cfg.Chain = chosen
 		// Re-seed defaults from the chosen chain (wizard is interactive: the
 		// chain's values become the working defaults the user can then edit).
-		applyLayer(cfg, fc.Common, nil)
-		applyLayer(cfg, fc.Chains[chosen], nil)
+		if err := applyLayer(cfg, fc.Common, nil); err != nil {
+			return err
+		}
+		if err := applyLayer(cfg, fc.Chains[chosen], nil); err != nil {
+			return err
+		}
 	} else {
 		// Manual entry when there is no config file / no chains defined.
 		if err := promptManualChain(cfg, p); err != nil {

--- a/devnet/tests/gen-activity/wizard_test.go
+++ b/devnet/tests/gen-activity/wizard_test.go
@@ -233,3 +233,13 @@ func TestMenuItemsIncludeVesting(t *testing.T) {
 		}
 	}
 }
+
+func TestChainSummaryShowsConnectionAndDivider(t *testing.T) {
+	c := &Config{Chain: "devnet", ChainID: "lumera-devnet-1", RPC: "tcp://localhost:26657", GRPC: "localhost:9090"}
+	out := chainSummary(c)
+	for _, want := range []string{"devnet", "lumera-devnet-1", "tcp://localhost:26657", "localhost:9090", "----------"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("chainSummary missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/devnet/tests/gen-activity/wizard_test.go
+++ b/devnet/tests/gen-activity/wizard_test.go
@@ -69,24 +69,21 @@ func TestEditSettingRejectsBadInt(t *testing.T) {
 }
 
 func TestEditSettingModeMapping(t *testing.T) {
-	cases := []struct {
-		choice           string
-		addAccounts      bool
-		activityExisting bool
-	}{
-		{"fresh", false, false},
-		{"add-accounts", true, false},
-		{"activity-existing", false, true},
-	}
-	for _, tc := range cases {
+	// Mode is first-class: editing it sets c.Mode and clears the legacy booleans.
+	for _, choice := range []string{ModeFresh, ModeAddAccounts, ModeActivityExisting, ModeMigrate} {
 		c := &Config{}
-		p := &fakePrompter{selectQueue: []string{tc.choice}}
+		p := &fakePrompter{selectQueue: []string{choice}}
 		if err := editSetting(c, settingMode, p); err != nil {
-			t.Fatalf("edit mode %q: %v", tc.choice, err)
+			t.Fatalf("edit mode %q: %v", choice, err)
 		}
-		if c.AddAccounts != tc.addAccounts || c.ActivityExisting != tc.activityExisting {
-			t.Errorf("mode %q -> AddAccounts=%v ActivityExisting=%v, want %v/%v",
-				tc.choice, c.AddAccounts, c.ActivityExisting, tc.addAccounts, tc.activityExisting)
+		if c.Mode != choice {
+			t.Errorf("mode %q -> c.Mode=%q, want %q", choice, c.Mode, choice)
+		}
+		if c.AddAccounts || c.ActivityExisting {
+			t.Errorf("mode %q left legacy bools set: add=%v activity=%v", choice, c.AddAccounts, c.ActivityExisting)
+		}
+		if got, err := c.resolveMode(); err != nil || got != choice {
+			t.Errorf("resolveMode after selecting %q = (%q,%v), want (%q,nil)", choice, got, err, choice)
 		}
 	}
 }

--- a/devnet/tests/gen-activity/wizard_test.go
+++ b/devnet/tests/gen-activity/wizard_test.go
@@ -108,7 +108,7 @@ func TestRunWizardManualChainNoConfig(t *testing.T) {
 			"chain-id": "lumera-manual-1",
 		},
 	}
-	if err := runWizard(cfg, nil, p, func(*Config) error { return nil }); err != nil {
+	if err := runWizard(cfg, nil, nil, p, func(*Config) error { return nil }); err != nil {
 		t.Fatalf("runWizard: %v", err)
 	}
 	if cfg.RPC != "tcp://manual:26657" || cfg.GRPC != "manual:9090" || cfg.ChainID != "lumera-manual-1" {
@@ -171,7 +171,7 @@ func TestRunWizardEditsThenRuns(t *testing.T) {
 	var ran *Config
 	runner := func(c *Config) error { ran = c; return nil }
 
-	if err := runWizard(cfg, fc, p, runner); err != nil {
+	if err := runWizard(cfg, fc, nil, p, runner); err != nil {
 		t.Fatalf("runWizard: %v", err)
 	}
 	if ran == nil {
@@ -185,13 +185,49 @@ func TestRunWizardEditsThenRuns(t *testing.T) {
 	}
 }
 
+func TestRunWizardPreservesCLIOverridesOnReseed(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, sampleTOML))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	// Simulate `-funding-key cliuser -accounts cli-accounts.json -w`: resolveConfig
+	// already layered the file onto cfg honoring these flags, so cfg holds the CLI
+	// values and setFlags marks them as explicitly set.
+	cfg := &Config{
+		Bin: "lumerad", KeyringBackend: "test",
+		FundingKey: "cliuser", AccountsPath: "cli-accounts.json",
+		MaxAccountAmount: "10000000ulume", ActionStates: "pending,done,approved",
+		MaxActionsPerRun: 3, FundingBatchSize: 10, Parallelism: 5,
+	}
+	setFlags := map[string]bool{"funding-key": true, "accounts": true}
+
+	// Pick the devnet chain (which re-seeds [common]+[chains.devnet]), then Quit.
+	// [common] sets funding-key=faucet and [chains.devnet] sets accounts=...; both
+	// must NOT clobber the explicit CLI overrides.
+	p := &fakePrompter{selectQueue: []string{"devnet", menuQuit}}
+
+	if err := runWizard(cfg, fc, setFlags, p, func(*Config) error { return nil }); err != nil {
+		t.Fatalf("runWizard: %v", err)
+	}
+	if cfg.FundingKey != "cliuser" {
+		t.Errorf("FundingKey = %q, want cliuser (CLI override must survive reseed)", cfg.FundingKey)
+	}
+	if cfg.AccountsPath != "cli-accounts.json" {
+		t.Errorf("AccountsPath = %q, want cli-accounts.json (CLI override must survive reseed)", cfg.AccountsPath)
+	}
+	// Non-overridden chain values should still be seeded from the chosen chain.
+	if cfg.ChainID != "lumera-devnet-1" {
+		t.Errorf("ChainID = %q, want lumera-devnet-1 (chain seeded)", cfg.ChainID)
+	}
+}
+
 func TestRunWizardQuitDoesNotRun(t *testing.T) {
 	cfg := &Config{Bin: "lumerad"}
 	p := &fakePrompter{selectQueue: []string{menuQuit}}
 	called := false
 	runner := func(*Config) error { called = true; return nil }
 
-	if err := runWizard(cfg, nil, p, runner); err != nil {
+	if err := runWizard(cfg, nil, nil, p, runner); err != nil {
 		t.Fatalf("runWizard: %v", err)
 	}
 	if called {

--- a/devnet/tests/gen-activity/wizard_test.go
+++ b/devnet/tests/gen-activity/wizard_test.go
@@ -198,3 +198,38 @@ func TestRunWizardQuitDoesNotRun(t *testing.T) {
 		t.Error("runner must not be called when user quits")
 	}
 }
+
+func TestEditSettingVesting(t *testing.T) {
+	c := &Config{}
+	p := &fakePrompter{inputs: map[string]string{
+		"vesting-percent":               "25",
+		"num-permanent-locked-accounts": "3",
+	}}
+	if err := editSetting(c, settingVestingPercent, p); err != nil {
+		t.Fatalf("edit vesting-percent: %v", err)
+	}
+	if c.VestingPercent != 25 {
+		t.Errorf("VestingPercent = %d, want 25", c.VestingPercent)
+	}
+	if err := editSetting(c, settingNumPermLocked, p); err != nil {
+		t.Fatalf("edit num-permanent-locked: %v", err)
+	}
+	if c.NumPermanentLocked != 3 {
+		t.Errorf("NumPermanentLocked = %d, want 3", c.NumPermanentLocked)
+	}
+}
+
+func TestMenuItemsIncludeVesting(t *testing.T) {
+	items := menuItems(&Config{})
+	for _, want := range []string{settingVestingPercent, settingNumPermLocked} {
+		found := false
+		for _, it := range items {
+			if menuKeyFromItem(it) == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("menu missing setting %q", want)
+		}
+	}
+}

--- a/devnet/tests/gen-activity/wizard_test.go
+++ b/devnet/tests/gen-activity/wizard_test.go
@@ -68,6 +68,54 @@ func TestEditSettingRejectsBadInt(t *testing.T) {
 	}
 }
 
+func TestEditSettingModeMapping(t *testing.T) {
+	cases := []struct {
+		choice           string
+		addAccounts      bool
+		activityExisting bool
+	}{
+		{"fresh", false, false},
+		{"add-accounts", true, false},
+		{"activity-existing", false, true},
+	}
+	for _, tc := range cases {
+		c := &Config{}
+		p := &fakePrompter{selectQueue: []string{tc.choice}}
+		if err := editSetting(c, settingMode, p); err != nil {
+			t.Fatalf("edit mode %q: %v", tc.choice, err)
+		}
+		if c.AddAccounts != tc.addAccounts || c.ActivityExisting != tc.activityExisting {
+			t.Errorf("mode %q -> AddAccounts=%v ActivityExisting=%v, want %v/%v",
+				tc.choice, c.AddAccounts, c.ActivityExisting, tc.addAccounts, tc.activityExisting)
+		}
+	}
+}
+
+func TestRunWizardManualChainNoConfig(t *testing.T) {
+	cfg := &Config{
+		Bin: "lumerad", KeyringBackend: "test", FundingKey: "faucet",
+		AccountsPath: "accounts.json", MaxAccountAmount: "10000000ulume",
+		ActionStates: "pending,done,approved", MaxActionsPerRun: 3,
+		FundingBatchSize: 10, Parallelism: 5,
+	}
+	// fc == nil: runWizard takes the manual-entry branch (promptManualChain),
+	// then the menu loop exits immediately on Quit.
+	p := &fakePrompter{
+		selectQueue: []string{menuQuit},
+		inputs: map[string]string{
+			"rpc":      "tcp://manual:26657",
+			"grpc":     "manual:9090",
+			"chain-id": "lumera-manual-1",
+		},
+	}
+	if err := runWizard(cfg, nil, p, func(*Config) error { return nil }); err != nil {
+		t.Fatalf("runWizard: %v", err)
+	}
+	if cfg.RPC != "tcp://manual:26657" || cfg.GRPC != "manual:9090" || cfg.ChainID != "lumera-manual-1" {
+		t.Errorf("manual chain not applied: rpc=%q grpc=%q chain-id=%q", cfg.RPC, cfg.GRPC, cfg.ChainID)
+	}
+}
+
 // fakePrompter scripts wizard answers keyed by setting key. selectQueue is a
 // FIFO of answers for SelectOne calls.
 type fakePrompter struct {
@@ -97,4 +145,56 @@ func (f *fakePrompter) Confirm(key, label string, def bool) (bool, error) {
 		return v, nil
 	}
 	return def, nil
+}
+
+func TestRunWizardEditsThenRuns(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, sampleTOML))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	cfg := &Config{
+		Bin: "lumerad", KeyringBackend: "test",
+		MaxAccountAmount: "10000000ulume", ActionStates: "pending,done,approved",
+		MaxActionsPerRun: 3, FundingBatchSize: 10, Parallelism: 5,
+	}
+
+	// Script: pick chain "devnet", edit funding-key, then Run.
+	p := &fakePrompter{
+		selectQueue: []string{
+			"devnet",                           // chain picker
+			menuKeyFromItem(menuItems(cfg)[0]), // first menu choice -> funding-key setting line
+			menuRun,                            // then run
+		},
+		inputs: map[string]string{"funding-key": "wizfunder"},
+	}
+
+	var ran *Config
+	runner := func(c *Config) error { ran = c; return nil }
+
+	if err := runWizard(cfg, fc, p, runner); err != nil {
+		t.Fatalf("runWizard: %v", err)
+	}
+	if ran == nil {
+		t.Fatal("runner was not invoked on Run")
+	}
+	if ran.ChainID != "lumera-devnet-1" {
+		t.Errorf("ChainID = %q, want lumera-devnet-1 (chain applied)", ran.ChainID)
+	}
+	if ran.FundingKey != "wizfunder" {
+		t.Errorf("FundingKey = %q, want wizfunder (edited)", ran.FundingKey)
+	}
+}
+
+func TestRunWizardQuitDoesNotRun(t *testing.T) {
+	cfg := &Config{Bin: "lumerad"}
+	p := &fakePrompter{selectQueue: []string{menuQuit}}
+	called := false
+	runner := func(*Config) error { called = true; return nil }
+
+	if err := runWizard(cfg, nil, p, runner); err != nil {
+		t.Fatalf("runWizard: %v", err)
+	}
+	if called {
+		t.Error("runner must not be called when user quits")
+	}
 }

--- a/devnet/tests/gen-activity/wizard_test.go
+++ b/devnet/tests/gen-activity/wizard_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMenuItemsRenderCurrentValues(t *testing.T) {
+	c := &Config{
+		FundingKey:    "faucet",
+		NumAccounts:   10,
+		NumMultisig23: 2,
+		Parallelism:   5,
+		Actions:       true,
+		AccountsPath:  "accounts.json",
+	}
+	items := menuItems(c)
+
+	joined := strings.Join(items, "\n")
+	if !strings.Contains(joined, menuRun) {
+		t.Errorf("menu missing run entry %q:\n%s", menuRun, joined)
+	}
+	if !strings.Contains(joined, menuQuit) {
+		t.Errorf("menu missing quit entry %q:\n%s", menuQuit, joined)
+	}
+	if !strings.Contains(joined, "faucet") || !strings.Contains(joined, "10") {
+		t.Errorf("menu missing current values:\n%s", joined)
+	}
+}
+
+func TestEditSettingUpdatesConfig(t *testing.T) {
+	c := &Config{FundingKey: "old", NumAccounts: 1, Actions: false}
+	p := &fakePrompter{
+		inputs:   map[string]string{"funding-key": "newfunder", "num-accounts": "7"},
+		confirms: map[string]bool{"actions": true},
+	}
+
+	if err := editSetting(c, settingFundingKey, p); err != nil {
+		t.Fatalf("edit funding-key: %v", err)
+	}
+	if c.FundingKey != "newfunder" {
+		t.Errorf("FundingKey = %q, want newfunder", c.FundingKey)
+	}
+
+	if err := editSetting(c, settingNumAccounts, p); err != nil {
+		t.Fatalf("edit num-accounts: %v", err)
+	}
+	if c.NumAccounts != 7 {
+		t.Errorf("NumAccounts = %d, want 7", c.NumAccounts)
+	}
+
+	if err := editSetting(c, settingActions, p); err != nil {
+		t.Fatalf("edit actions: %v", err)
+	}
+	if !c.Actions {
+		t.Errorf("Actions = %v, want true", c.Actions)
+	}
+}
+
+func TestEditSettingRejectsBadInt(t *testing.T) {
+	c := &Config{NumAccounts: 3}
+	p := &fakePrompter{inputs: map[string]string{"num-accounts": "notanumber"}}
+	if err := editSetting(c, settingNumAccounts, p); err == nil {
+		t.Error("expected error for non-integer num-accounts input")
+	}
+	if c.NumAccounts != 3 {
+		t.Errorf("NumAccounts mutated to %d on bad input, want unchanged 3", c.NumAccounts)
+	}
+}
+
+// fakePrompter scripts wizard answers keyed by setting key. selectQueue is a
+// FIFO of answers for SelectOne calls.
+type fakePrompter struct {
+	selectQueue []string
+	inputs      map[string]string
+	confirms    map[string]bool
+}
+
+func (f *fakePrompter) SelectOne(label string, options []string, def string) (string, error) {
+	if len(f.selectQueue) == 0 {
+		return def, nil
+	}
+	ans := f.selectQueue[0]
+	f.selectQueue = f.selectQueue[1:]
+	return ans, nil
+}
+
+func (f *fakePrompter) Input(key, label, def string) (string, error) {
+	if v, ok := f.inputs[key]; ok {
+		return v, nil
+	}
+	return def, nil
+}
+
+func (f *fakePrompter) Confirm(key, label string, def bool) (bool, error) {
+	if v, ok := f.confirms[key]; ok {
+		return v, nil
+	}
+	return def, nil
+}

--- a/docs/design/gen-activity-config-wizard-plan.md
+++ b/docs/design/gen-activity-config-wizard-plan.md
@@ -1,0 +1,1483 @@
+# gen-activity Config File + Wizard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `gen-activity-config.toml` file with named chains + a `[common]` section selectable via `-chain`, layered config precedence (flag > chain > common > default), and an interactive survey wizard that is the default when the tool is run with no flags.
+
+**Architecture:** A new `configfile.go` parses TOML into a pointer-field `FileConfig` (nil = unset), then layers it onto the existing flag-parsed `Config` using `flag.Visit` to skip any field the user set explicitly on the command line. `main` picks wizard vs command-line mode from `flag.NFlag()` (plus a `-w` override). A new `wizard.go` drives an arrow-key menu through a small `prompter` interface (survey in production, a scripted fake in tests) and ends by calling the same `run(cfg)` path as command-line mode.
+
+**Tech Stack:** Go, `github.com/pelletier/go-toml/v2` (promote to direct dep), `github.com/AlecAivazis/survey/v2` (new dep), Go stdlib `flag`. Module: `gen` at `devnet/go.mod`. Package: `main` at `devnet/tests/gen-activity`.
+
+**Scope note:** The `-num-multisig23-accounts` / `-num-multisig35-accounts` flags are *defined and validated* here (plain ints, default 0, surfaced in the wizard) but their generation **behavior** is implemented in the companion plan `2026-06-12-gen-activity-multisig-accounts.md`. Until then a non-zero value is accepted and ignored by `run()`.
+
+---
+
+## File Structure
+
+New:
+- `devnet/tests/gen-activity/configfile.go` — `FileConfig`/`ChainSection` types, `LoadFileConfig`, `ChainNames`, `applyLayer`, `ApplyFileConfig`.
+- `devnet/tests/gen-activity/configfile_test.go` — TOML parse + precedence tests.
+- `devnet/tests/gen-activity/wizard.go` — `prompter` interface, `surveyPrompter`, `menuItems`, `editSetting`, `runWizard`.
+- `devnet/tests/gen-activity/wizard_test.go` — menu state-machine tests with a scripted fake prompter.
+- `gen-activity-config.toml.example` — documented sample config (repo root).
+
+Modified:
+- `devnet/tests/gen-activity/config.go` — new `Config` fields (`ConfigPath`, `Chain`, `Wizard`, `NumMultisig23`, `NumMultisig35`) + multisig-count validation.
+- `devnet/tests/gen-activity/main.go` — register new flags, mode selection, config layering, wizard dispatch.
+- `devnet/go.mod` / `devnet/go.sum` — deps.
+- `docs/design/gen-activity-design.md` — document config, wizard, mode rule.
+
+---
+
+## Task 1: Add dependencies (go-toml direct + survey/v2)
+
+**Files:**
+- Modify: `devnet/go.mod`
+
+- [ ] **Step 1: Add the survey dependency and tidy**
+
+Run (from the module dir):
+
+```bash
+cd devnet && go get github.com/AlecAivazis/survey/v2@v2.3.7 && go mod tidy
+```
+
+Expected: `devnet/go.mod` now lists `github.com/AlecAivazis/survey/v2` as a direct dependency, and `github.com/pelletier/go-toml/v2` moves out of the `// indirect` block once it is imported (it is imported in Task 4; tidy again then). `go.sum` updated.
+
+- [ ] **Step 2: Verify the module still builds**
+
+Run:
+
+```bash
+cd devnet && go build ./...
+```
+
+Expected: builds with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add devnet/go.mod devnet/go.sum
+git commit -m "build(gen-activity): add survey/v2 dependency for wizard"
+```
+
+---
+
+## Task 2: Add new Config fields + multisig-count validation
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/config.go`
+- Test: `devnet/tests/gen-activity/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/config_test.go`:
+
+```go
+func TestConfigValidateMultisigCounts(t *testing.T) {
+	t.Run("zero multisig counts pass", func(t *testing.T) {
+		c := validConfig()
+		c.NumMultisig23 = 0
+		c.NumMultisig35 = 0
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("negative num-multisig23 fails", func(t *testing.T) {
+		c := validConfig()
+		c.NumMultisig23 = -1
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for negative num-multisig23-accounts")
+		}
+	})
+
+	t.Run("negative num-multisig35 fails", func(t *testing.T) {
+		c := validConfig()
+		c.NumMultisig35 = -2
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for negative num-multisig35-accounts")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestConfigValidateMultisigCounts -v
+```
+
+Expected: FAIL — `c.NumMultisig23 undefined` (compile error).
+
+- [ ] **Step 3: Add the fields and validation**
+
+In `devnet/tests/gen-activity/config.go`, add to the `Config` struct (after the `AccountPrefix` field, in the "Registry and account generation" block):
+
+```go
+	// Multisig account generation. Behavior implemented in the multisig plan;
+	// validated here so the flag/wizard surface is complete.
+	NumMultisig23 int // 2-of-3 multisig accounts
+	NumMultisig35 int // 3-of-5 multisig accounts
+```
+
+Add to the "Connection / runtime" block (top of struct):
+
+```go
+	// Config file + chain selection + mode.
+	ConfigPath string
+	Chain      string
+	Wizard     bool
+```
+
+In `Config.Validate()`, add after the `MaxActionsPerRun` check (before the `MaxAccountAmount` parse):
+
+```go
+	if c.NumMultisig23 < 0 {
+		return fmt.Errorf("-num-multisig23-accounts must be >= 0, got %d", c.NumMultisig23)
+	}
+	if c.NumMultisig35 < 0 {
+		return fmt.Errorf("-num-multisig35-accounts must be >= 0, got %d", c.NumMultisig35)
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestConfigValidateMultisigCounts -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/config.go devnet/tests/gen-activity/config_test.go
+git commit -m "feat(gen-activity): add config fields for config-file, chain, wizard, multisig counts"
+```
+
+---
+
+## Task 3: Register new flags
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/main.go`
+- Test: `devnet/tests/gen-activity/main_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/main_test.go`:
+
+```go
+func TestConfigureFlagsRegistersNewFlags(t *testing.T) {
+	var cfg Config
+	fs := flag.NewFlagSet("tests-gen-activity", flag.ContinueOnError)
+	configureFlags(fs, &cfg)
+
+	for _, name := range []string{
+		"config", "chain", "wizard", "w",
+		"num-multisig23-accounts", "num-multisig35-accounts",
+	} {
+		if fs.Lookup(name) == nil {
+			t.Errorf("flag -%s not registered", name)
+		}
+	}
+
+	if got := fs.Lookup("config").DefValue; got != "gen-activity-config.toml" {
+		t.Errorf("-config default = %q, want gen-activity-config.toml", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestConfigureFlagsRegistersNewFlags -v
+```
+
+Expected: FAIL — flag `-config` not registered (`fs.Lookup("config")` is nil).
+
+- [ ] **Step 3: Register the flags**
+
+In `devnet/tests/gen-activity/main.go`, inside `configureFlags`, add after the existing `fs.StringVar(&c.Bin, ...)` line and before `fs.StringVar(&c.RPC, ...)`:
+
+```go
+	fs.StringVar(&c.ConfigPath, "config", "gen-activity-config.toml", "path to gen-activity TOML config file (optional)")
+	fs.StringVar(&c.Chain, "chain", "", "named chain section from the config file (e.g. devnet, testnet, mainnet)")
+	fs.BoolVar(&c.Wizard, "wizard", false, "run the interactive wizard (also the default when no flags are passed)")
+	fs.BoolVar(&c.Wizard, "w", false, "shorthand for -wizard")
+```
+
+Add after the existing `fs.IntVar(&c.NumAccounts, "num-accounts", ...)` line:
+
+```go
+	fs.IntVar(&c.NumMultisig23, "num-multisig23-accounts", 0, "number of 2-of-3 multisig accounts to generate")
+	fs.IntVar(&c.NumMultisig35, "num-multisig35-accounts", 0, "number of 3-of-5 multisig accounts to generate")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestConfigureFlagsRegistersNewFlags -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/main.go devnet/tests/gen-activity/main_test.go
+git commit -m "feat(gen-activity): register -config/-chain/-wizard and multisig-count flags"
+```
+
+---
+
+## Task 4: TOML config file parsing (`configfile.go`)
+
+**Files:**
+- Create: `devnet/tests/gen-activity/configfile.go`
+- Test: `devnet/tests/gen-activity/configfile_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `devnet/tests/gen-activity/configfile_test.go`:
+
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const sampleTOML = `
+[common]
+bin = "lumerad"
+funding-key = "faucet"
+parallelism = 8
+
+[chains.devnet]
+rpc = "tcp://localhost:26657"
+chain-id = "lumera-devnet-1"
+accounts = "accounts-devnet.json"
+
+[chains.testnet]
+rpc = "https://rpc.testnet:443"
+chain-id = "lumera-testnet-1"
+`
+
+func writeTempTOML(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gen-activity-config.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write temp toml: %v", err)
+	}
+	return path
+}
+
+func TestLoadFileConfigMissingFileReturnsNil(t *testing.T) {
+	fc, err := LoadFileConfig(filepath.Join(t.TempDir(), "does-not-exist.toml"))
+	if err != nil {
+		t.Fatalf("unexpected error for missing file: %v", err)
+	}
+	if fc != nil {
+		t.Fatalf("expected nil FileConfig for missing file, got %+v", fc)
+	}
+}
+
+func TestLoadFileConfigParsesSections(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, sampleTOML))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	if fc == nil {
+		t.Fatal("expected non-nil FileConfig")
+	}
+	if fc.Common.FundingKey == nil || *fc.Common.FundingKey != "faucet" {
+		t.Errorf("common funding-key not parsed: %+v", fc.Common.FundingKey)
+	}
+	if fc.Common.Parallelism == nil || *fc.Common.Parallelism != 8 {
+		t.Errorf("common parallelism not parsed: %+v", fc.Common.Parallelism)
+	}
+	dev, ok := fc.Chains["devnet"]
+	if !ok {
+		t.Fatal("devnet chain section missing")
+	}
+	if dev.ChainID == nil || *dev.ChainID != "lumera-devnet-1" {
+		t.Errorf("devnet chain-id not parsed: %+v", dev.ChainID)
+	}
+	if want := []string{"devnet", "testnet"}; !reflect.DeepEqual(fc.ChainNames(), want) {
+		t.Errorf("ChainNames() = %v, want %v (sorted)", fc.ChainNames(), want)
+	}
+}
+
+func TestLoadFileConfigRejectsUnknownKey(t *testing.T) {
+	_, err := LoadFileConfig(writeTempTOML(t, "[common]\nbogus-key = 1\n"))
+	if err == nil {
+		t.Error("expected error for unknown TOML key (strict decoding)")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestLoadFileConfig -v
+```
+
+Expected: FAIL — `undefined: LoadFileConfig` (compile error).
+
+- [ ] **Step 3: Write the implementation**
+
+Create `devnet/tests/gen-activity/configfile.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+// ChainSection holds the config values for one chain (or the shared [common]
+// section). Every field is a pointer so an absent TOML key is distinguishable
+// from an explicit zero value; nil means "not set in this section". Keys mirror
+// the CLI flag names so config and flags map one-to-one.
+type ChainSection struct {
+	Bin              *string `toml:"bin"`
+	RPC              *string `toml:"rpc"`
+	GRPC             *string `toml:"grpc"`
+	ChainID          *string `toml:"chain-id"`
+	Home             *string `toml:"home"`
+	KeyringBackend   *string `toml:"keyring-backend"`
+	EVMCutoverVer    *string `toml:"evm-cutover-version"`
+	FundingKey       *string `toml:"funding-key"`
+	AccountsPath     *string `toml:"accounts"`
+	NumAccounts      *int    `toml:"num-accounts"`
+	MaxAccountAmount *string `toml:"max-account-amount"`
+	AccountPrefix    *string `toml:"account-prefix"`
+	Actions          *bool   `toml:"actions"`
+	FundingBatchSize *int    `toml:"funding-batch-size"`
+	Parallelism      *int    `toml:"parallelism"`
+	NumMultisig23    *int    `toml:"num-multisig23-accounts"`
+	NumMultisig35    *int    `toml:"num-multisig35-accounts"`
+}
+
+// FileConfig is the parsed gen-activity-config.toml: a shared [common] section
+// plus any number of named [chains.<name>] sections.
+type FileConfig struct {
+	Common ChainSection            `toml:"common"`
+	Chains map[string]ChainSection `toml:"chains"`
+}
+
+// LoadFileConfig reads and strictly decodes the TOML config at path. A missing
+// file returns (nil, nil) so the caller can fall back to pure flag behavior; an
+// unparseable file or an unknown key is a hard error.
+func LoadFileConfig(path string) (*FileConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+	var fc FileConfig
+	if err := strictUnmarshal(data, &fc); err != nil {
+		return nil, fmt.Errorf("parse config %s: %w", path, err)
+	}
+	return &fc, nil
+}
+
+// strictUnmarshal decodes TOML with unknown keys rejected so typos in the
+// config file surface as errors instead of being silently ignored.
+func strictUnmarshal(data []byte, v any) error {
+	d := toml.NewDecoder(bytes.NewReader(data))
+	d.DisallowUnknownFields()
+	return d.Decode(v)
+}
+
+// ChainNames returns the configured chain names in sorted order (stable wizard
+// menu ordering).
+func (fc *FileConfig) ChainNames() []string {
+	names := make([]string, 0, len(fc.Chains))
+	for name := range fc.Chains {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+```
+
+Also add the small `bytesReader` helper at the bottom of the file (avoids an extra import alias confusion):
+
+```go
+import "bytes" // add to the import block
+
+func bytesReader(b []byte) *bytes.Reader { return bytes.NewReader(b) }
+```
+
+> Implementation note: delete the `dec := toml.NewDecoder(nil)` placeholder line shown above — it was illustrative. The real decode path is `strictUnmarshal`. Final `LoadFileConfig` body is:
+>
+> ```go
+> 	var fc FileConfig
+> 	if err := strictUnmarshal(data, &fc); err != nil {
+> 		return nil, fmt.Errorf("parse config %s: %w", path, err)
+> 	}
+> 	return &fc, nil
+> ```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go mod tidy && go test ./tests/gen-activity/ -run TestLoadFileConfig -v
+```
+
+Expected: PASS for all three subtests. `go mod tidy` moves `pelletier/go-toml/v2` to a direct dependency now that it is imported.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/configfile.go devnet/tests/gen-activity/configfile_test.go devnet/go.mod devnet/go.sum
+git commit -m "feat(gen-activity): parse gen-activity-config.toml chains/common sections"
+```
+
+---
+
+## Task 5: Config layering with flag precedence (`applyLayer` + `ApplyFileConfig`)
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/configfile.go`
+- Test: `devnet/tests/gen-activity/configfile_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/configfile_test.go`:
+
+```go
+func TestApplyFileConfigPrecedence(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, sampleTOML))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+
+	t.Run("common then chain overlay onto unset fields", func(t *testing.T) {
+		c := &Config{}
+		setFlags := map[string]bool{} // nothing set explicitly
+		if err := ApplyFileConfig(c, fc, "devnet", setFlags); err != nil {
+			t.Fatalf("ApplyFileConfig: %v", err)
+		}
+		if c.FundingKey != "faucet" { // from [common]
+			t.Errorf("FundingKey = %q, want faucet", c.FundingKey)
+		}
+		if c.Parallelism != 8 { // from [common]
+			t.Errorf("Parallelism = %d, want 8", c.Parallelism)
+		}
+		if c.ChainID != "lumera-devnet-1" { // from [chains.devnet]
+			t.Errorf("ChainID = %q, want lumera-devnet-1", c.ChainID)
+		}
+	})
+
+	t.Run("explicit flags win over config", func(t *testing.T) {
+		c := &Config{FundingKey: "cli-funder", Parallelism: 99}
+		setFlags := map[string]bool{"funding-key": true, "parallelism": true}
+		if err := ApplyFileConfig(c, fc, "devnet", setFlags); err != nil {
+			t.Fatalf("ApplyFileConfig: %v", err)
+		}
+		if c.FundingKey != "cli-funder" {
+			t.Errorf("FundingKey = %q, want cli-funder (flag wins)", c.FundingKey)
+		}
+		if c.Parallelism != 99 {
+			t.Errorf("Parallelism = %d, want 99 (flag wins)", c.Parallelism)
+		}
+		if c.ChainID != "lumera-devnet-1" { // not set as flag → config applies
+			t.Errorf("ChainID = %q, want lumera-devnet-1", c.ChainID)
+		}
+	})
+
+	t.Run("unknown chain errors", func(t *testing.T) {
+		c := &Config{}
+		err := ApplyFileConfig(c, fc, "nosuchchain", map[string]bool{})
+		if err == nil {
+			t.Error("expected error for unknown chain name")
+		}
+	})
+
+	t.Run("empty chain applies only common", func(t *testing.T) {
+		c := &Config{}
+		if err := ApplyFileConfig(c, fc, "", map[string]bool{}); err != nil {
+			t.Fatalf("ApplyFileConfig: %v", err)
+		}
+		if c.FundingKey != "faucet" {
+			t.Errorf("FundingKey = %q, want faucet (common)", c.FundingKey)
+		}
+		if c.ChainID != "" {
+			t.Errorf("ChainID = %q, want empty (no chain selected)", c.ChainID)
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestApplyFileConfigPrecedence -v
+```
+
+Expected: FAIL — `undefined: ApplyFileConfig`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `devnet/tests/gen-activity/configfile.go`:
+
+```go
+// ApplyFileConfig layers a parsed FileConfig onto c following the precedence
+// defaults < [common] < [chains.<chain>] < explicit CLI flags. setFlags is the
+// set of flag names the user passed on the command line (collected via
+// flag.Visit); fields whose flag was set are never overwritten by the config.
+// An empty chain applies only [common]; a non-empty chain that is absent from
+// the file is an error.
+func ApplyFileConfig(c *Config, fc *FileConfig, chain string, setFlags map[string]bool) error {
+	if fc == nil {
+		return nil
+	}
+	applyLayer(c, fc.Common, setFlags)
+	if chain == "" {
+		return nil
+	}
+	sec, ok := fc.Chains[chain]
+	if !ok {
+		return fmt.Errorf("chain %q not found in config (available: %v)", chain, fc.ChainNames())
+	}
+	applyLayer(c, sec, setFlags)
+	return nil
+}
+
+// applyLayer overlays the non-nil fields of sec onto c, skipping any field
+// whose corresponding flag name appears in setFlags (so explicit CLI flags are
+// never clobbered). The flag names here MUST match those registered in
+// configureFlags.
+func applyLayer(c *Config, sec ChainSection, setFlags map[string]bool) {
+	str := func(flagName string, src *string, dst *string) {
+		if src != nil && !setFlags[flagName] {
+			*dst = *src
+		}
+	}
+	intf := func(flagName string, src *int, dst *int) {
+		if src != nil && !setFlags[flagName] {
+			*dst = *src
+		}
+	}
+	boolf := func(flagName string, src *bool, dst *bool) {
+		if src != nil && !setFlags[flagName] {
+			*dst = *src
+		}
+	}
+
+	str("bin", sec.Bin, &c.Bin)
+	str("rpc", sec.RPC, &c.RPC)
+	str("grpc", sec.GRPC, &c.GRPC)
+	str("chain-id", sec.ChainID, &c.ChainID)
+	str("home", sec.Home, &c.Home)
+	str("keyring-backend", sec.KeyringBackend, &c.KeyringBackend)
+	str("evm-cutover-version", sec.EVMCutoverVer, &c.EVMCutoverVer)
+	str("funding-key", sec.FundingKey, &c.FundingKey)
+	str("accounts", sec.AccountsPath, &c.AccountsPath)
+	str("max-account-amount", sec.MaxAccountAmount, &c.MaxAccountAmount)
+	str("account-prefix", sec.AccountPrefix, &c.AccountPrefix)
+	intf("num-accounts", sec.NumAccounts, &c.NumAccounts)
+	intf("funding-batch-size", sec.FundingBatchSize, &c.FundingBatchSize)
+	intf("parallelism", sec.Parallelism, &c.Parallelism)
+	intf("num-multisig23-accounts", sec.NumMultisig23, &c.NumMultisig23)
+	intf("num-multisig35-accounts", sec.NumMultisig35, &c.NumMultisig35)
+	boolf("actions", sec.Actions, &c.Actions)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestApplyFileConfigPrecedence -v
+```
+
+Expected: PASS for all four subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/configfile.go devnet/tests/gen-activity/configfile_test.go
+git commit -m "feat(gen-activity): layer config file with flag>chain>common>default precedence"
+```
+
+---
+
+## Task 6: Wire config loading + mode selection into `main`
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/main.go`
+- Test: `devnet/tests/gen-activity/main_test.go`
+
+This task extracts the load/layer/mode logic into a testable helper `resolveConfig`, then calls it from `main`. `main` itself stays a thin shell (untested), but `resolveConfig` is unit-tested.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/main_test.go`:
+
+```go
+func TestResolveConfigAppliesFileAndDetectsWizard(t *testing.T) {
+	t.Run("no flags -> wizard mode, common applied", func(t *testing.T) {
+		cfg := &Config{}
+		fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+		configureFlags(fs, cfg)
+		if err := fs.Parse([]string{}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		path := writeTempTOML(t, sampleTOML)
+		cfg.ConfigPath = path
+
+		wizard, err := resolveConfig(cfg, fs)
+		if err != nil {
+			t.Fatalf("resolveConfig: %v", err)
+		}
+		if !wizard {
+			t.Error("expected wizard=true when no flags passed")
+		}
+		if cfg.FundingKey != "faucet" {
+			t.Errorf("FundingKey = %q, want faucet (from common)", cfg.FundingKey)
+		}
+	})
+
+	t.Run("flags passed -> command-line mode", func(t *testing.T) {
+		cfg := &Config{}
+		fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+		configureFlags(fs, cfg)
+		path := writeTempTOML(t, sampleTOML)
+		if err := fs.Parse([]string{"-chain", "devnet", "-config", path}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		wizard, err := resolveConfig(cfg, fs)
+		if err != nil {
+			t.Fatalf("resolveConfig: %v", err)
+		}
+		if wizard {
+			t.Error("expected wizard=false when flags passed")
+		}
+		if cfg.ChainID != "lumera-devnet-1" {
+			t.Errorf("ChainID = %q, want lumera-devnet-1 (chain layered)", cfg.ChainID)
+		}
+	})
+
+	t.Run("-w forces wizard even with flags", func(t *testing.T) {
+		cfg := &Config{}
+		fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+		configureFlags(fs, cfg)
+		path := writeTempTOML(t, sampleTOML)
+		if err := fs.Parse([]string{"-w", "-config", path}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		wizard, err := resolveConfig(cfg, fs)
+		if err != nil {
+			t.Fatalf("resolveConfig: %v", err)
+		}
+		if !wizard {
+			t.Error("expected wizard=true when -w passed")
+		}
+	})
+
+	t.Run("explicit missing -config is an error", func(t *testing.T) {
+		cfg := &Config{}
+		fs := flag.NewFlagSet("gen", flag.ContinueOnError)
+		configureFlags(fs, cfg)
+		if err := fs.Parse([]string{"-config", filepath.Join(t.TempDir(), "nope.toml"), "-chain", "devnet"}); err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if _, err := resolveConfig(cfg, fs); err == nil {
+			t.Error("expected error when explicit -config path is missing")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestResolveConfigAppliesFileAndDetectsWizard -v
+```
+
+Expected: FAIL — `undefined: resolveConfig`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `devnet/tests/gen-activity/main.go`, add the helper:
+
+```go
+// resolveConfig loads any config file referenced by cfg.ConfigPath, layers it
+// onto cfg honoring CLI-flag precedence, and reports whether the tool should run
+// in wizard mode (no flags passed, or -w/-wizard). fs must be the FlagSet that
+// already parsed the command line (so fs.Visit/fs.NFlag reflect what the user
+// set).
+func resolveConfig(cfg *Config, fs *flag.FlagSet) (wizard bool, err error) {
+	setFlags := map[string]bool{}
+	fs.Visit(func(f *flag.Flag) { setFlags[f.Name] = true })
+
+	fc, err := LoadFileConfig(cfg.ConfigPath)
+	if err != nil {
+		return false, err
+	}
+	if fc == nil && setFlags["config"] {
+		return false, fmt.Errorf("config file %q not found", cfg.ConfigPath)
+	}
+	if err := ApplyFileConfig(cfg, fc, cfg.Chain, setFlags); err != nil {
+		return false, err
+	}
+
+	wizard = cfg.Wizard || fs.NFlag() == 0
+	return wizard, nil
+}
+```
+
+Rewrite `main` to use it (replace the current `main` body):
+
+```go
+func main() {
+	cfg := &Config{}
+	configureFlags(flag.CommandLine, cfg)
+	flag.Parse()
+
+	wizard, err := resolveConfig(cfg, flag.CommandLine)
+	if err != nil {
+		log.Fatalf("configuration: %v", err)
+	}
+
+	if wizard {
+		fc, _ := LoadFileConfig(cfg.ConfigPath)
+		if err := runWizard(cfg, fc, newSurveyPrompter(), run); err != nil {
+			log.Fatalf("wizard: %v", err)
+		}
+		return
+	}
+
+	if err := cfg.Validate(); err != nil {
+		log.Fatalf("invalid configuration: %v", err)
+	}
+	if err := run(cfg); err != nil {
+		log.Fatalf("gen-activity failed: %v", err)
+	}
+}
+```
+
+Delete the now-unused `parseFlags` function (its logic moved into `main`).
+
+> Note: `runWizard` and `newSurveyPrompter` are defined in Task 7/8. This task will not compile until those exist; that is expected. To keep this task's test green in isolation, the test for `resolveConfig` does not call `main`. If you implement strictly task-by-task and need a green build between Task 6 and Task 7, temporarily stub `func runWizard(*Config, *FileConfig, prompter, func(*Config) error) error { return nil }` and `func newSurveyPrompter() prompter { return nil }` in `main.go`, then remove the stubs in Task 7/8. Prefer implementing Tasks 6–8 back-to-back.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run (with the temporary stubs from the note, or after Task 8):
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestResolveConfigAppliesFileAndDetectsWizard -v
+```
+
+Expected: PASS for all four subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/main.go devnet/tests/gen-activity/main_test.go
+git commit -m "feat(gen-activity): resolve config file + select wizard vs command-line mode"
+```
+
+---
+
+## Task 7: Wizard pure helpers (`prompter`, `menuItems`, `editSetting`)
+
+**Files:**
+- Create: `devnet/tests/gen-activity/wizard.go`
+- Test: `devnet/tests/gen-activity/wizard_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `devnet/tests/gen-activity/wizard_test.go`:
+
+```go
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMenuItemsRenderCurrentValues(t *testing.T) {
+	c := &Config{
+		FundingKey:    "faucet",
+		NumAccounts:   10,
+		NumMultisig23: 2,
+		Parallelism:   5,
+		Actions:       true,
+		AccountsPath:  "accounts.json",
+	}
+	items := menuItems(c)
+
+	// Must include the run + quit sentinels.
+	joined := strings.Join(items, "\n")
+	if !strings.Contains(joined, menuRun) {
+		t.Errorf("menu missing run entry %q:\n%s", menuRun, joined)
+	}
+	if !strings.Contains(joined, menuQuit) {
+		t.Errorf("menu missing quit entry %q:\n%s", menuQuit, joined)
+	}
+	// Current values rendered into labels.
+	if !strings.Contains(joined, "faucet") || !strings.Contains(joined, "10") {
+		t.Errorf("menu missing current values:\n%s", joined)
+	}
+}
+
+func TestEditSettingUpdatesConfig(t *testing.T) {
+	c := &Config{FundingKey: "old", NumAccounts: 1, Actions: false}
+	p := &fakePrompter{
+		inputs:   map[string]string{"funding-key": "newfunder", "num-accounts": "7"},
+		confirms: map[string]bool{"actions": true},
+	}
+
+	if err := editSetting(c, settingFundingKey, p); err != nil {
+		t.Fatalf("edit funding-key: %v", err)
+	}
+	if c.FundingKey != "newfunder" {
+		t.Errorf("FundingKey = %q, want newfunder", c.FundingKey)
+	}
+
+	if err := editSetting(c, settingNumAccounts, p); err != nil {
+		t.Fatalf("edit num-accounts: %v", err)
+	}
+	if c.NumAccounts != 7 {
+		t.Errorf("NumAccounts = %d, want 7", c.NumAccounts)
+	}
+
+	if err := editSetting(c, settingActions, p); err != nil {
+		t.Fatalf("edit actions: %v", err)
+	}
+	if !c.Actions {
+		t.Errorf("Actions = %v, want true", c.Actions)
+	}
+}
+
+func TestEditSettingRejectsBadInt(t *testing.T) {
+	c := &Config{NumAccounts: 3}
+	p := &fakePrompter{inputs: map[string]string{"num-accounts": "notanumber"}}
+	if err := editSetting(c, settingNumAccounts, p); err == nil {
+		t.Error("expected error for non-integer num-accounts input")
+	}
+	if c.NumAccounts != 3 {
+		t.Errorf("NumAccounts mutated to %d on bad input, want unchanged 3", c.NumAccounts)
+	}
+}
+
+// fakePrompter scripts wizard answers keyed by setting key. selectQueue is a
+// FIFO of answers for SelectOne calls.
+type fakePrompter struct {
+	selectQueue []string
+	inputs      map[string]string
+	confirms    map[string]bool
+}
+
+func (f *fakePrompter) SelectOne(label string, options []string, def string) (string, error) {
+	if len(f.selectQueue) == 0 {
+		return def, nil
+	}
+	ans := f.selectQueue[0]
+	f.selectQueue = f.selectQueue[1:]
+	return ans, nil
+}
+
+func (f *fakePrompter) Input(key, label, def string) (string, error) {
+	if v, ok := f.inputs[key]; ok {
+		return v, nil
+	}
+	return def, nil
+}
+
+func (f *fakePrompter) Confirm(key, label string, def bool) (bool, error) {
+	if v, ok := f.confirms[key]; ok {
+		return v, nil
+	}
+	return def, nil
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestMenuItems|TestEditSetting' -v
+```
+
+Expected: FAIL — `undefined: menuItems` / `settingFundingKey` etc.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `devnet/tests/gen-activity/wizard.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// prompter abstracts the interactive prompts so the wizard's control flow is
+// unit-testable with a scripted fake. The production implementation
+// (surveyPrompter) is backed by github.com/AlecAivazis/survey/v2. Input/Confirm
+// take a stable `key` (the setting key) plus a human label so tests can script
+// answers without matching on display text.
+type prompter interface {
+	SelectOne(label string, options []string, def string) (string, error)
+	Input(key, label, def string) (string, error)
+	Confirm(key, label string, def bool) (bool, error)
+}
+
+// Setting keys: stable identifiers for editable settings.
+const (
+	settingFundingKey      = "funding-key"
+	settingMode            = "mode"
+	settingNumAccounts     = "num-accounts"
+	settingNumMultisig23   = "num-multisig23-accounts"
+	settingNumMultisig35   = "num-multisig35-accounts"
+	settingAccountsPath    = "accounts"
+	settingParallelism     = "parallelism"
+	settingActions         = "actions"
+	settingFundingBatch    = "funding-batch-size"
+	settingMaxAmount       = "max-account-amount"
+	settingDryRun          = "dry-run"
+)
+
+// Menu sentinels.
+const (
+	menuRun  = "▶ Run now"
+	menuQuit = "✗ Quit"
+)
+
+// editableSettings is the ordered list of setting keys shown in the menu.
+var editableSettings = []string{
+	settingFundingKey,
+	settingMode,
+	settingNumAccounts,
+	settingNumMultisig23,
+	settingNumMultisig35,
+	settingAccountsPath,
+	settingParallelism,
+	settingActions,
+	settingFundingBatch,
+	settingMaxAmount,
+	settingDryRun,
+}
+
+// settingValue returns the current value of a setting as a display string.
+func settingValue(c *Config, key string) string {
+	switch key {
+	case settingFundingKey:
+		return c.FundingKey
+	case settingMode:
+		return modeLabel(c)
+	case settingNumAccounts:
+		return strconv.Itoa(c.NumAccounts)
+	case settingNumMultisig23:
+		return strconv.Itoa(c.NumMultisig23)
+	case settingNumMultisig35:
+		return strconv.Itoa(c.NumMultisig35)
+	case settingAccountsPath:
+		return c.AccountsPath
+	case settingParallelism:
+		return strconv.Itoa(c.Parallelism)
+	case settingActions:
+		return strconv.FormatBool(c.Actions)
+	case settingFundingBatch:
+		return strconv.Itoa(c.FundingBatchSize)
+	case settingMaxAmount:
+		return c.MaxAccountAmount
+	case settingDryRun:
+		return strconv.FormatBool(c.DryRun)
+	default:
+		return ""
+	}
+}
+
+// modeLabel renders the current run mode derived from the AddAccounts /
+// ActivityExisting flags.
+func modeLabel(c *Config) string {
+	switch {
+	case c.AddAccounts:
+		return "add-accounts"
+	case c.ActivityExisting:
+		return "activity-existing"
+	default:
+		return "fresh"
+	}
+}
+
+// menuItems renders the settings menu: one entry per editable setting (with its
+// current value) followed by the Run and Quit sentinels.
+func menuItems(c *Config) []string {
+	items := make([]string, 0, len(editableSettings)+2)
+	for _, key := range editableSettings {
+		items = append(items, fmt.Sprintf("%-24s %s", key, settingValue(c, key)))
+	}
+	items = append(items, menuRun, menuQuit)
+	return items
+}
+
+// menuKeyFromItem maps a rendered menu line back to its setting key (or the
+// sentinel itself for Run/Quit).
+func menuKeyFromItem(item string) string {
+	if item == menuRun || item == menuQuit {
+		return item
+	}
+	// The key is the first whitespace-delimited token.
+	for i := 0; i < len(item); i++ {
+		if item[i] == ' ' {
+			return item[:i]
+		}
+	}
+	return item
+}
+
+// editSetting prompts for a new value for one setting and applies it to c. A
+// parse error on a numeric field is returned and leaves c unchanged.
+func editSetting(c *Config, key string, p prompter) error {
+	switch key {
+	case settingFundingKey:
+		v, err := p.Input(key, "Funder key name", c.FundingKey)
+		if err != nil {
+			return err
+		}
+		c.FundingKey = v
+	case settingMode:
+		v, err := p.SelectOne("Run mode", []string{"fresh", "add-accounts", "activity-existing"}, modeLabel(c))
+		if err != nil {
+			return err
+		}
+		c.AddAccounts = v == "add-accounts"
+		c.ActivityExisting = v == "activity-existing"
+	case settingAccountsPath:
+		v, err := p.Input(key, "Accounts registry path", c.AccountsPath)
+		if err != nil {
+			return err
+		}
+		c.AccountsPath = v
+	case settingMaxAmount:
+		v, err := p.Input(key, "Max per-account amount", c.MaxAccountAmount)
+		if err != nil {
+			return err
+		}
+		c.MaxAccountAmount = v
+	case settingActions:
+		v, err := p.Confirm(key, "Include CASCADE action activity?", c.Actions)
+		if err != nil {
+			return err
+		}
+		c.Actions = v
+	case settingDryRun:
+		v, err := p.Confirm(key, "Dry run (plan only, no txs)?", c.DryRun)
+		if err != nil {
+			return err
+		}
+		c.DryRun = v
+	case settingNumAccounts:
+		return editInt(c, key, "Number of accounts", &c.NumAccounts, p)
+	case settingNumMultisig23:
+		return editInt(c, key, "Number of 2-of-3 multisig accounts", &c.NumMultisig23, p)
+	case settingNumMultisig35:
+		return editInt(c, key, "Number of 3-of-5 multisig accounts", &c.NumMultisig35, p)
+	case settingParallelism:
+		return editInt(c, key, "Parallelism", &c.Parallelism, p)
+	case settingFundingBatch:
+		return editInt(c, key, "Funding batch size", &c.FundingBatchSize, p)
+	default:
+		return fmt.Errorf("unknown setting %q", key)
+	}
+	return nil
+}
+
+// editInt prompts for an integer setting and applies it only on a clean parse.
+func editInt(c *Config, key, label string, dst *int, p prompter) error {
+	v, err := p.Input(key, label, strconv.Itoa(*dst))
+	if err != nil {
+		return err
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fmt.Errorf("%s: %q is not an integer", key, v)
+	}
+	*dst = n
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestMenuItems|TestEditSetting' -v
+```
+
+Expected: PASS for all subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/wizard.go devnet/tests/gen-activity/wizard_test.go
+git commit -m "feat(gen-activity): wizard menu rendering + per-setting editing"
+```
+
+---
+
+## Task 8: Wizard loop + survey-backed prompter + main wiring
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/wizard.go`
+- Test: `devnet/tests/gen-activity/wizard_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/wizard_test.go`:
+
+```go
+func TestRunWizardEditsThenRuns(t *testing.T) {
+	fc, err := LoadFileConfig(writeTempTOML(t, sampleTOML))
+	if err != nil {
+		t.Fatalf("LoadFileConfig: %v", err)
+	}
+	cfg := &Config{
+		Bin: "lumerad", KeyringBackend: "test",
+		MaxAccountAmount: "10000000ulume", ActionStates: "pending,done,approved",
+		MaxActionsPerRun: 3, FundingBatchSize: 10, Parallelism: 5,
+	}
+
+	// Script: pick chain "devnet", edit funding-key, then Run.
+	p := &fakePrompter{
+		selectQueue: []string{
+			"devnet",                          // chain picker
+			menuKeyFromItem(menuItems(cfg)[0]), // first menu choice -> funding-key setting line
+			menuRun,                            // then run
+		},
+		inputs: map[string]string{"funding-key": "wizfunder"},
+	}
+
+	var ran *Config
+	runner := func(c *Config) error { ran = c; return nil }
+
+	if err := runWizard(cfg, fc, p, runner); err != nil {
+		t.Fatalf("runWizard: %v", err)
+	}
+	if ran == nil {
+		t.Fatal("runner was not invoked on Run")
+	}
+	if ran.ChainID != "lumera-devnet-1" {
+		t.Errorf("ChainID = %q, want lumera-devnet-1 (chain applied)", ran.ChainID)
+	}
+	if ran.FundingKey != "wizfunder" {
+		t.Errorf("FundingKey = %q, want wizfunder (edited)", ran.FundingKey)
+	}
+}
+
+func TestRunWizardQuitDoesNotRun(t *testing.T) {
+	cfg := &Config{Bin: "lumerad"}
+	p := &fakePrompter{selectQueue: []string{menuQuit}}
+	called := false
+	runner := func(*Config) error { called = true; return nil }
+
+	if err := runWizard(cfg, nil, p, runner); err != nil {
+		t.Fatalf("runWizard: %v", err)
+	}
+	if called {
+		t.Error("runner must not be called when user quits")
+	}
+}
+```
+
+> Note: the menu line selected (`menuItems(cfg)[0]`) is the funding-key line because `settingFundingKey` is first in `editableSettings`. `runWizard` maps the selected line back to its key via `menuKeyFromItem`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestRunWizard -v
+```
+
+Expected: FAIL — `undefined: runWizard`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `devnet/tests/gen-activity/wizard.go` (add `github.com/AlecAivazis/survey/v2` to the import block; `fmt` and `strconv` are already imported from Task 7):
+
+```go
+// runWizard drives the interactive flow: optionally pick a chain (re-seeding cfg
+// from that chain's config section), then loop the settings menu until the user
+// chooses Run (validate + invoke runner) or Quit (return without running).
+// runner is injected so tests can assert invocation without a live chain.
+func runWizard(cfg *Config, fc *FileConfig, p prompter, runner func(*Config) error) error {
+	if fc != nil && len(fc.Chains) > 0 {
+		names := fc.ChainNames()
+		def := cfg.Chain
+		if def == "" {
+			def = names[0]
+		}
+		chosen, err := p.SelectOne("Select chain", names, def)
+		if err != nil {
+			return err
+		}
+		cfg.Chain = chosen
+		// Re-seed defaults from the chosen chain (wizard is interactive: the
+		// chain's values become the working defaults the user can then edit).
+		applyLayer(cfg, fc.Common, nil)
+		applyLayer(cfg, fc.Chains[chosen], nil)
+	} else if fc == nil || len(fc.Chains) == 0 {
+		// Manual entry when there is no config file / no chains defined.
+		if err := promptManualChain(cfg, p); err != nil {
+			return err
+		}
+	}
+
+	for {
+		choice, err := p.SelectOne("Settings (select to edit, then Run)", menuItems(cfg), menuRun)
+		if err != nil {
+			return err
+		}
+		key := menuKeyFromItem(choice)
+		switch key {
+		case menuRun:
+			if err := cfg.Validate(); err != nil {
+				fmt.Printf("  cannot run: %v\n", err)
+				continue
+			}
+			return runner(cfg)
+		case menuQuit:
+			return nil
+		default:
+			if err := editSetting(cfg, key, p); err != nil {
+				fmt.Printf("  %v\n", err)
+			}
+		}
+	}
+}
+
+// promptManualChain asks for the minimum connection settings when no config file
+// is present, so a bare `gen-activity` invocation still works.
+func promptManualChain(cfg *Config, p prompter) error {
+	rpc, err := p.Input("rpc", "RPC endpoint", cfg.RPC)
+	if err != nil {
+		return err
+	}
+	cfg.RPC = rpc
+	grpc, err := p.Input("grpc", "gRPC endpoint", cfg.GRPC)
+	if err != nil {
+		return err
+	}
+	cfg.GRPC = grpc
+	chainID, err := p.Input("chain-id", "Chain ID", cfg.ChainID)
+	if err != nil {
+		return err
+	}
+	cfg.ChainID = chainID
+	return nil
+}
+```
+
+Add the survey-backed prompter at the bottom of `wizard.go`:
+
+```go
+// surveyPrompter is the production prompter backed by survey/v2.
+type surveyPrompter struct{}
+
+func newSurveyPrompter() prompter { return surveyPrompter{} }
+
+func (surveyPrompter) SelectOne(label string, options []string, def string) (string, error) {
+	answer := def
+	prompt := &survey.Select{Message: label, Options: options, Default: def}
+	if err := survey.AskOne(prompt, &answer); err != nil {
+		return "", err
+	}
+	return answer, nil
+}
+
+// The first parameter (the setting key) is unused by the survey impl but
+// required by the prompter interface, so it is named _.
+func (surveyPrompter) Input(_ string, label, def string) (string, error) {
+	answer := def
+	prompt := &survey.Input{Message: label, Default: def}
+	if err := survey.AskOne(prompt, &answer); err != nil {
+		return "", err
+	}
+	return answer, nil
+}
+
+func (surveyPrompter) Confirm(_ string, label string, def bool) (bool, error) {
+	answer := def
+	prompt := &survey.Confirm{Message: label, Default: def}
+	if err := survey.AskOne(prompt, &answer); err != nil {
+		return false, err
+	}
+	return answer, nil
+}
+```
+
+> Implementation note: remove the temporary stubs added in Task 6
+> (`runWizard`/`newSurveyPrompter`) now that the real implementations exist.
+> `runWizard` does not use `os`/`sort` — only add an import if your final code
+> references it (the code above imports just `fmt`, `strconv`, and
+> `github.com/AlecAivazis/survey/v2`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestRunWizard -v
+```
+
+Expected: PASS for both subtests.
+
+- [ ] **Step 5: Run the full gen-activity package test + build**
+
+Run:
+
+```bash
+cd devnet && go build ./... && go test ./tests/gen-activity/ -v
+```
+
+Expected: builds clean; all gen-activity tests pass (existing + new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add devnet/tests/gen-activity/wizard.go devnet/tests/gen-activity/wizard_test.go devnet/tests/gen-activity/main.go
+git commit -m "feat(gen-activity): interactive wizard loop with survey prompts as the default mode"
+```
+
+---
+
+## Task 9: Example config + documentation
+
+**Files:**
+- Create: `gen-activity-config.toml.example`
+- Modify: `docs/design/gen-activity-design.md`
+
+- [ ] **Step 1: Write the example config**
+
+Create `gen-activity-config.toml.example` (repo root):
+
+```toml
+# gen-activity-config.toml — copy to gen-activity-config.toml and edit.
+#
+# Precedence (low -> high): built-in defaults < [common] < [chains.<name>] <
+# explicit CLI flags. Select a chain with `-chain <name>`. Keys mirror the CLI
+# flag names. Running with NO flags launches the interactive wizard.
+
+[common]
+bin = "lumerad"
+home = "~/.lumera"
+keyring-backend = "test"
+funding-key = "faucet"
+evm-cutover-version = "v1.20.0"
+account-prefix = "gen"
+max-account-amount = "10000000ulume"
+parallelism = 5
+funding-batch-size = 10
+actions = true
+
+[chains.devnet]
+rpc = "tcp://localhost:26657"
+grpc = "localhost:9090"
+chain-id = "lumera-devnet-1"
+accounts = "devnet/tests/gen-activity/accounts-devnet.json"
+
+[chains.testnet]
+rpc = "https://rpc.testnet.lumera.io:443"
+grpc = "grpc.testnet.lumera.io:443"
+chain-id = "lumera-testnet-1"
+accounts = "devnet/tests/gen-activity/accounts-testnet.json"
+
+[chains.mainnet]
+rpc = "https://rpc.lumera.io:443"
+grpc = "grpc.lumera.io:443"
+chain-id = "lumera-mainnet-1"
+accounts = "devnet/tests/gen-activity/accounts-mainnet.json"
+```
+
+- [ ] **Step 2: Document in the design doc**
+
+In `docs/design/gen-activity-design.md`, add a section (place after the existing flags/configuration section; match the doc's heading style):
+
+```markdown
+## Config file, chain selection, and wizard
+
+`gen-activity` reads an optional `gen-activity-config.toml` (path via `-config`,
+default `gen-activity-config.toml` in the working directory). It has a shared
+`[common]` section and any number of `[chains.<name>]` sections; select one with
+`-chain <name>`. TOML keys mirror the CLI flag names.
+
+**Precedence** (low to high): built-in defaults → `[common]` → `[chains.<name>]`
+→ explicitly-set CLI flags. A flag passed on the command line always wins over
+the config file (implemented via `flag.Visit`).
+
+**Mode selection:**
+- No flags at all → the interactive **wizard** (arrow-key chain picker + settings
+  menu, powered by survey/v2).
+- Any flag passed → non-interactive command-line mode (unchanged behavior).
+- `-w` / `-wizard` → force the wizard even with flags present (those flags
+  pre-seed the wizard defaults).
+
+See `gen-activity-config.toml.example` for a documented template.
+```
+
+- [ ] **Step 3: Verify the build and run lint**
+
+Run:
+
+```bash
+cd devnet && go build ./... && go vet ./tests/gen-activity/
+cd /home/akobrin/p/lumera && make lint
+```
+
+Expected: build clean, vet clean, `make lint` reports 0 issues.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add gen-activity-config.toml.example docs/design/gen-activity-design.md
+git commit -m "docs(gen-activity): example config + document config/wizard/mode behavior"
+```
+
+---
+
+## Self-Review checklist (for the plan author)
+
+- **Spec coverage:** §3.1 config file → Tasks 4–6 + 9; §3.2 mode + wizard → Tasks 3, 6, 7, 8; multisig-flag surface (deferred behavior) → Tasks 2, 3, 7; deps/docs → Tasks 1, 9. The multisig *generation behavior* (spec §3.3, §3.4) is intentionally out of scope here — covered by the companion multisig plan.
+- **Placeholder scan:** the two "Implementation note" blocks in Tasks 4 and 8 flag illustrative lines to delete/rename; they contain the exact final code, not TODOs.
+- **Type consistency:** `prompter` interface (`SelectOne`/`Input`/`Confirm`) is identical across `wizard.go` and the `fakePrompter` test; `Config` field names (`NumMultisig23`, `NumMultisig35`, `ConfigPath`, `Chain`, `Wizard`) match between config.go, configfile.go, main.go, and wizard.go; flag names in `applyLayer` match those registered in `configureFlags`.
+```

--- a/docs/design/gen-activity-design.md
+++ b/docs/design/gen-activity-design.md
@@ -70,8 +70,8 @@ Additional flags:
 
 - `-config=gen-activity-config.toml`: optional TOML config file.
 - `-chain=devnet`: named chain section to use from the config file.
-- `-wizard=false` / `-w=false`: run the interactive wizard; this is also the
-  default when no flags are passed.
+- `-wizard` / `-w`: run the interactive wizard; this is also the default when
+  no flags are passed. Use `-wizard=false` or `-w=false` to disable it.
 - `-keyring-backend=test`: local funder keyring backend.
 - `-add-accounts=true`: add `-num-accounts` new regular users to an existing
   registry.

--- a/docs/design/gen-activity-design.md
+++ b/docs/design/gen-activity-design.md
@@ -345,6 +345,26 @@ the config file (implemented via `flag.Visit`).
 
 See `gen-activity-config.toml.example` for a documented template.
 
+## Multisig accounts
+
+`-num-multisig23-accounts` and `-num-multisig35-accounts` generate K-of-N
+multisig accounts (2-of-3 and 3-of-5). For each, gen-activity:
+
+1. Creates N member keys (`<composite>-signer-<i>`) using the detected key style
+   and a composite key via `keys add --multisig --nosort` (shared
+   `common.Multisig.CreateMultisigKey`).
+2. Funds the composite from the funder (multisig composites are ordinary funding
+   targets).
+3. Publishes the composite pubkey on-chain via a 1-ulume self-send.
+4. Exercises the account with one multisign bank-send to a regular peer
+   (`sign × K → multisign → broadcast`), recorded in the registry.
+
+Records are stored as `AccountRecord.Multisig` (member names, threshold,
+signers) under registry schema v2. Multisig composites are excluded from the
+regular single-sig activity mix (they cannot sign a single-sig `--from` tx). The
+generic ceremony lives in `devnet/tests/common` (`multisig.go`) and is shared
+with the evmigration tool.
+
 ## Open Implementation Notes
 
 - Prefer moving common primitives in small slices so evmigration remains

--- a/docs/design/gen-activity-design.md
+++ b/docs/design/gen-activity-design.md
@@ -324,6 +324,27 @@ Integration smoke tests should cover:
 `devnet-tests-build` should build `tests-gen-activity` alongside
 `tests_evmigration`.
 
+## Config file, chain selection, and wizard
+
+`gen-activity` reads an optional `gen-activity-config.toml` (path via `-config`,
+default `gen-activity-config.toml` in the working directory). It has a shared
+`[common]` section and any number of `[chains.<name>]` sections; select one with
+`-chain <name>`. TOML keys mirror the CLI flag names.
+
+**Precedence** (low to high): built-in defaults → `[common]` → `[chains.<name>]`
+→ explicitly-set CLI flags. A flag passed on the command line always wins over
+the config file (implemented via `flag.Visit`).
+
+**Mode selection:**
+
+- No flags at all → the interactive **wizard** (arrow-key chain picker + settings
+  menu, powered by survey/v2).
+- Any flag passed → non-interactive command-line mode (unchanged behavior).
+- `-w` / `-wizard` → force the wizard even with flags present (those flags
+  pre-seed the wizard defaults).
+
+See `gen-activity-config.toml.example` for a documented template.
+
 ## Open Implementation Notes
 
 - Prefer moving common primitives in small slices so evmigration remains

--- a/docs/design/gen-activity-design.md
+++ b/docs/design/gen-activity-design.md
@@ -365,6 +365,22 @@ regular single-sig activity mix (they cannot sign a single-sig `--from` tx). The
 generic ceremony lives in `devnet/tests/common` (`multisig.go`) and is shared
 with the evmigration tool.
 
+## Vesting accounts
+
+`-vesting-percent N` (0–100) randomly designates that share of the run's regular
+generated accounts as **vesting** accounts; each is randomly continuous or
+delayed (cliff) with an end time in now + [1h, 30d]. `-num-permanent-locked-accounts N`
+creates N dedicated **PermanentLocked** accounts (`<prefix>-plock-NNNN`).
+
+Because Cosmos-SDK rejects creating a vesting/locked account at an address that
+already exists, these accounts are created **at funding time** via
+`tx vesting create-vesting-account` / `create-permanent-locked-account` (funding
+the locked amount), then topped up with a small liquid balance so they can pay
+gas. They then participate in the normal activity mix (delegation can use locked
+coins; sends draw on the liquid top-up). Records carry `AccountRecord.Vesting`
+(type, end time, locked amount) under registry schema v2. The create helpers live
+in `devnet/tests/common/vesting.go`.
+
 ## Open Implementation Notes
 
 - Prefer moving common primitives in small slices so evmigration remains

--- a/docs/design/gen-activity-design.md
+++ b/docs/design/gen-activity-design.md
@@ -11,9 +11,10 @@ generated account metadata and activity in a rerunnable JSON registry.
 ## Non-Goals
 
 - Do not depend on the controlled Docker devnet status directories.
-- Do not create EVM migration-specific fixtures such as permanent-locked
-  accounts, multisig migration accounts, migration records, or pre/post-upgrade
-  modes.
+- Do not create EVM migration-specific records or pre/post-upgrade modes.
+  Generic multisig accounts and vesting/permanent-locked account types are now
+  supported as devnet activity fixtures, but they stay in the gen-activity
+  registry schema rather than reusing evmigration's migration registry envelope.
 - Do not require devnet chain resets between runs.
 - Do not make action generation fatal by default when supernodes are
   temporarily unavailable.
@@ -67,10 +68,20 @@ tests-gen-activity \
 
 Additional flags:
 
+- `-config=gen-activity-config.toml`: optional TOML config file.
+- `-chain=devnet`: named chain section to use from the config file.
+- `-wizard=false` / `-w=false`: run the interactive wizard; this is also the
+  default when no flags are passed.
 - `-keyring-backend=test`: local funder keyring backend.
-- `-add-accounts=true`: add `-num-accounts` new users to an existing registry.
+- `-add-accounts=true`: add `-num-accounts` new regular users to an existing
+  registry.
 - `-activity-existing=true`: generate more activity for accounts already in the
   registry.
+- `-num-multisig23-accounts=0`: create 2-of-3 multisig accounts.
+- `-num-multisig35-accounts=0`: create 3-of-5 multisig accounts.
+- `-vesting-percent=0`: percentage of newly generated regular accounts to
+  create as continuous or delayed vesting accounts.
+- `-num-permanent-locked-accounts=0`: create dedicated PermanentLocked accounts.
 - `-actions=true`: include CASCADE action activity, enabled by default.
 - `-require-actions=false`: fail the run if action activity cannot be created.
 - `-max-actions-per-run=3`: cap action uploads/registrations per run.

--- a/docs/design/gen-activity-multisig-plan.md
+++ b/docs/design/gen-activity-multisig-plan.md
@@ -1,0 +1,1318 @@
+# gen-activity Multisig Accounts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the generic multisig key + signing ceremony from `devnet/tests/evmigration` into the shared `devnet/tests/common` package, refactor evmigration to delegate to it, and use it in `gen-activity` to create, fund, and exercise K-of-N multisig accounts (2-of-3 via `-num-multisig23-accounts`, 3-of-5 via `-num-multisig35-accounts`).
+
+**Architecture:** A new `common.Multisig` wraps a `*common.ChainCLI` plus an injectable exec seam. Pure argument-builder methods (unit-tested) encode the exact CLI flags (`--nosort`, `--multisig`, `--sign-mode amino-json`, first-K signature files); thin methods compose them with the exec seam and `ChainCLI` queries to run the ceremony. evmigration keeps its mnemonic-based member-key generation and delegates only the composite-key creation and the sign/broadcast ceremony. gen-activity adds schema-v2 registry records with a `MultisigInfo` field and integrates generation/funding/exercise into `run()`.
+
+**Tech Stack:** Go, `gen` module (`devnet/go.mod`), `common.ChainCLI`. Companion to `gen-activity-config-wizard-plan.md` (which defines the `-num-multisig23/35` flags this plan implements behavior for).
+
+**Prerequisite:** The config/wizard plan's Task 2 (Config fields `NumMultisig23`/`NumMultisig35`) and Task 3 (flag registration) should be done first. If executing this plan standalone, add those two `Config` fields and their flags first (see that plan's Tasks 2–3).
+
+---
+
+## File Structure
+
+New:
+- `devnet/tests/common/multisig.go` — `Multisig` type, arg builders, ceremony methods.
+- `devnet/tests/common/multisig_test.go` — arg-builder + orchestration tests (fake exec seam).
+
+Modified:
+- `devnet/tests/evmigration/multisig.go` — `ensureMultisigCompositeKey`, `registerMultisigPubKey`, `signAndBroadcastMultisigTx`, `buildUnsignedMultisigBankSendTx`, `buildUnsignedMultisigDelegateTx` delegate to `common.Multisig`.
+- `devnet/tests/gen-activity/registry.go` — schema v2, `MultisigInfo`, generalized name allocation.
+- `devnet/tests/gen-activity/config.go` — `multisigPlan()` helper (counts → kinds).
+- `devnet/tests/gen-activity/chain.go` — multisig member/ceremony wiring on top of `common.Multisig`.
+- `devnet/tests/gen-activity/main.go` — generate/fund/exercise multisig accounts in `run()`.
+- `docs/design/gen-activity-design.md` — document multisig accounts.
+
+---
+
+## Task 1: Multisig arg builders in `common`
+
+**Files:**
+- Create: `devnet/tests/common/multisig.go`
+- Test: `devnet/tests/common/multisig_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `devnet/tests/common/multisig_test.go`:
+
+```go
+package common
+
+import (
+	"strings"
+	"testing"
+)
+
+func testMultisig() *Multisig {
+	cli := &ChainCLI{
+		Bin: "lumerad", ChainID: "lumera-devnet-1", RPC: "tcp://localhost:26657",
+		Home: "/home/u/.lumera", KeyringBackend: "test",
+		Gas: "500000", GasPrices: "0.025ulume",
+	}
+	return NewMultisig(cli)
+}
+
+func contains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestKeyAddArgsUsesNosortAndThreshold(t *testing.T) {
+	m := testMultisig()
+	args := m.keyAddArgs("msig", []string{"s1", "s2", "s3"}, 2)
+	if !contains(args, "--nosort") {
+		t.Errorf("keys add multisig must pass --nosort: %v", args)
+	}
+	if !contains(args, "--multisig") || !contains(args, "s1,s2,s3") {
+		t.Errorf("keys add must pass --multisig members joined: %v", args)
+	}
+	if !contains(args, "--multisig-threshold") || !contains(args, "2") {
+		t.Errorf("keys add must pass --multisig-threshold 2: %v", args)
+	}
+	if !contains(args, "--home") || !contains(args, "/home/u/.lumera") {
+		t.Errorf("keys add must pass --home when set: %v", args)
+	}
+}
+
+func TestSignArgsUsesAminoJSONAndMultisig(t *testing.T) {
+	m := testMultisig()
+	args := m.signArgs("/tmp/unsigned.json", "s1", "lumera1msig", 7, 3)
+	if !contains(args, "--sign-mode") || !contains(args, "amino-json") {
+		t.Errorf("sign must use amino-json: %v", args)
+	}
+	if !contains(args, "--multisig") || !contains(args, "lumera1msig") {
+		t.Errorf("sign must reference the multisig address: %v", args)
+	}
+	if !contains(args, "--from") || !contains(args, "s1") {
+		t.Errorf("sign must set --from member: %v", args)
+	}
+	if !contains(args, "--account-number") || !contains(args, "7") ||
+		!contains(args, "--sequence") || !contains(args, "3") {
+		t.Errorf("sign must pass offline account-number/sequence: %v", args)
+	}
+}
+
+func TestMultisignArgsConsumesSigFiles(t *testing.T) {
+	m := testMultisig()
+	args := m.multisignArgs("/tmp/unsigned.json", "msig", []string{"/tmp/s1.json", "/tmp/s2.json"})
+	for _, want := range []string{"multisign", "/tmp/unsigned.json", "msig", "/tmp/s1.json", "/tmp/s2.json"} {
+		if !contains(args, want) {
+			t.Errorf("multisign args missing %q: %v", want, args)
+		}
+	}
+}
+
+func TestGenBankSendArgsIsGenerateOnly(t *testing.T) {
+	m := testMultisig()
+	args := m.genBankSendArgs("msig", "lumera1msig", "lumera1peer", "5ulume", 7, 3)
+	if !contains(args, "--generate-only") {
+		t.Errorf("unsigned tx must be generate-only: %v", args)
+	}
+	for _, want := range []string{"send", "lumera1msig", "lumera1peer", "5ulume"} {
+		if !contains(args, want) {
+			t.Errorf("bank send args missing %q: %v", want, args)
+		}
+	}
+}
+
+func TestBroadcastArgsSyncMode(t *testing.T) {
+	m := testMultisig()
+	args := m.broadcastArgs("/tmp/signed.json")
+	if !contains(args, "broadcast") || !contains(args, "/tmp/signed.json") {
+		t.Errorf("broadcast args missing file: %v", args)
+	}
+	if !contains(args, "--broadcast-mode") || !contains(args, "sync") {
+		t.Errorf("broadcast must be sync mode: %v", args)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/common/ -run 'TestKeyAddArgs|TestSignArgs|TestMultisignArgs|TestGenBankSendArgs|TestBroadcastArgs' -v
+```
+
+Expected: FAIL — `undefined: NewMultisig`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `devnet/tests/common/multisig.go`:
+
+```go
+package common
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// Multisig provides the generic K-of-N multisig key + signing ceremony shared by
+// the evmigration and gen-activity tools. It is built on a *ChainCLI for
+// connection config and queries; the command execution is behind an injectable
+// seam (exec) so the ceremony orchestration is unit-testable with a fake.
+//
+// The ceremony is:
+//
+//	keys add --multisig --nosort        (composite key, key-type agnostic)
+//	tx ... --generate-only              (unsigned tx with the multisig as sender)
+//	tx sign --multisig --sign-mode amino-json   (× K members)
+//	tx multisign                        (combine the K signatures)
+//	tx broadcast --broadcast-mode sync  (+ wait for inclusion)
+//
+// --nosort keeps members in caller order so legacy/new sides agree on index
+// ordering; amino-json is required for offline multisig signing.
+type Multisig struct {
+	CLI  *ChainCLI
+	exec func(bin string, args ...string) (string, error)
+}
+
+// NewMultisig builds a Multisig over the given ChainCLI with the real command
+// executor.
+func NewMultisig(cli *ChainCLI) *Multisig {
+	return &Multisig{
+		CLI: cli,
+		exec: func(bin string, args ...string) (string, error) {
+			out, err := exec.Command(bin, args...).CombinedOutput()
+			return strings.TrimSpace(string(out)), err
+		},
+	}
+}
+
+func (m *Multisig) homeArgs() []string {
+	if m.CLI.Home == "" {
+		return nil
+	}
+	return []string{"--home", m.CLI.Home}
+}
+
+func (m *Multisig) nodeArgs() []string {
+	if m.CLI.RPC == "" {
+		return nil
+	}
+	return []string{"--node", m.CLI.RPC}
+}
+
+func (m *Multisig) keyring() string {
+	if m.CLI.KeyringBackend == "" {
+		return "test"
+	}
+	return m.CLI.KeyringBackend
+}
+
+// keyAddArgs builds `keys add <name> --multisig <m1,m2,..> --multisig-threshold K
+// --nosort`. keys add is a pure keyring op (no --node/--chain-id).
+func (m *Multisig) keyAddArgs(name string, members []string, threshold int) []string {
+	args := []string{
+		"keys", "add", name,
+		"--multisig", strings.Join(members, ","),
+		"--multisig-threshold", strconv.Itoa(threshold),
+		"--nosort",
+		"--keyring-backend", m.keyring(),
+	}
+	return append(args, m.homeArgs()...)
+}
+
+// signArgs builds `tx sign <file> --from <member> --multisig <addr>` with offline
+// account-number/sequence and amino-json sign mode.
+func (m *Multisig) signArgs(file, fromKey, multisigAddr string, accNum, seq uint64) []string {
+	args := []string{
+		"tx", "sign", file,
+		"--from", fromKey,
+		"--multisig", multisigAddr,
+		"--keyring-backend", m.keyring(),
+		"--chain-id", m.CLI.ChainID,
+		"--account-number", strconv.FormatUint(accNum, 10),
+		"--sequence", strconv.FormatUint(seq, 10),
+		"--sign-mode", "amino-json",
+		"--output", "json",
+	}
+	args = append(args, m.nodeArgs()...)
+	return append(args, m.homeArgs()...)
+}
+
+// multisignArgs builds `tx multisign <file> <name> <sig1> <sig2> ...`.
+func (m *Multisig) multisignArgs(file, name string, sigFiles []string) []string {
+	args := []string{"tx", "multisign", file, name}
+	args = append(args, sigFiles...)
+	args = append(args,
+		"--keyring-backend", m.keyring(),
+		"--chain-id", m.CLI.ChainID,
+		"--output", "json",
+	)
+	args = append(args, m.nodeArgs()...)
+	return append(args, m.homeArgs()...)
+}
+
+// broadcastArgs builds `tx broadcast <signedFile> --broadcast-mode sync`.
+func (m *Multisig) broadcastArgs(signedFile string) []string {
+	args := []string{
+		"tx", "broadcast", signedFile,
+		"--broadcast-mode", "sync",
+		"--output", "json",
+	}
+	return append(args, m.nodeArgs()...)
+}
+
+// genBankSendArgs builds a generate-only `tx bank send` from the multisig.
+func (m *Multisig) genBankSendArgs(name, fromAddr, toAddr, amount string, accNum, seq uint64) []string {
+	return m.genTxArgs(name, accNum, seq, "bank", "send", fromAddr, toAddr, amount)
+}
+
+// genDelegateArgs builds a generate-only `tx staking delegate` from the multisig.
+func (m *Multisig) genDelegateArgs(name, valoper, amount string, accNum, seq uint64) []string {
+	return m.genTxArgs(name, accNum, seq, "staking", "delegate", valoper, amount)
+}
+
+// genTxArgs builds a generate-only tx with the multisig name as --from and the
+// supplied module/positional args.
+func (m *Multisig) genTxArgs(name string, accNum, seq uint64, module, action string, positional ...string) []string {
+	args := []string{"tx", module, action}
+	args = append(args, positional...)
+	args = append(args,
+		"--from", name,
+		"--keyring-backend", m.keyring(),
+		"--chain-id", m.CLI.ChainID,
+		"--account-number", strconv.FormatUint(accNum, 10),
+		"--sequence", strconv.FormatUint(seq, 10),
+		"--gas", m.gas(),
+		"--gas-prices", m.CLI.GasPrices,
+		"--generate-only",
+		"--output", "json",
+	)
+	args = append(args, m.nodeArgs()...)
+	return append(args, m.homeArgs()...)
+}
+
+func (m *Multisig) gas() string {
+	if m.CLI.Gas == "" {
+		return "auto"
+	}
+	return m.CLI.Gas
+}
+
+// extractTxHash pulls "txhash":"..." from a broadcast/query JSON response.
+func extractTxHash(out string) string {
+	const marker = `"txhash":"`
+	idx := strings.Index(out, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := out[idx+len(marker):]
+	end := strings.IndexByte(rest, '"')
+	if end < 0 {
+		return ""
+	}
+	return strings.TrimSpace(rest[:end])
+}
+
+// unused guard to keep fmt imported for ceremony methods added in Task 2.
+var _ = fmt.Sprintf
+```
+
+> Implementation note: the `var _ = fmt.Sprintf` guard exists only so this file compiles in isolation after Task 1 (no `fmt` use yet). Task 2 adds real `fmt` usage and you delete this guard then.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/common/ -run 'TestKeyAddArgs|TestSignArgs|TestMultisignArgs|TestGenBankSendArgs|TestBroadcastArgs' -v
+```
+
+Expected: PASS for all five.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/common/multisig.go devnet/tests/common/multisig_test.go
+git commit -m "feat(common): multisig CLI arg builders (keys add/sign/multisign/broadcast)"
+```
+
+---
+
+## Task 2: Multisig ceremony methods (composite create + sign/broadcast)
+
+**Files:**
+- Modify: `devnet/tests/common/multisig.go`
+- Test: `devnet/tests/common/multisig_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/common/multisig_test.go`:
+
+```go
+// fakeExec records command invocations and returns canned outputs keyed by a
+// substring match of the joined args (first match wins).
+type fakeExec struct {
+	calls    [][]string
+	canned   []cannedResponse
+}
+
+type cannedResponse struct {
+	match  string
+	output string
+	err    error
+}
+
+func (f *fakeExec) run(bin string, args ...string) (string, error) {
+	f.calls = append(f.calls, args)
+	joined := strings.Join(args, " ")
+	for _, c := range f.canned {
+		if strings.Contains(joined, c.match) {
+			return c.output, c.err
+		}
+	}
+	return "", nil
+}
+
+func (f *fakeExec) calledWith(sub string) bool {
+	for _, c := range f.calls {
+		if strings.Contains(strings.Join(c, " "), sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSignAndBroadcastRunsCeremonyInOrder(t *testing.T) {
+	m := testMultisig()
+	fe := &fakeExec{canned: []cannedResponse{
+		{match: "tx sign", output: `{"some":"sig"}`},
+		{match: "tx multisign", output: `{"signed":"tx"}`},
+		{match: "tx broadcast", output: `{"txhash":"ABC123","code":0}`},
+		{match: "query tx ABC123", output: `{"code":0,"txhash":"ABC123"}`},
+	}}
+	m.exec = fe.run
+
+	txHash, err := m.SignAndBroadcastFile("/tmp/unsigned.json", "msig", "lumera1msig",
+		[]string{"s1", "s2", "s3"}, 2, 7, 3)
+	if err != nil {
+		t.Fatalf("SignAndBroadcastFile: %v", err)
+	}
+	if txHash != "ABC123" {
+		t.Errorf("txHash = %q, want ABC123", txHash)
+	}
+	// Exactly K=2 sign calls (members s1, s2), then multisign, then broadcast.
+	if !fe.calledWith("tx sign /tmp/unsigned.json --from s1") {
+		t.Error("missing sign with s1")
+	}
+	if !fe.calledWith("tx sign /tmp/unsigned.json --from s2") {
+		t.Error("missing sign with s2")
+	}
+	if fe.calledWith("--from s3") {
+		t.Error("must not sign with the 3rd member when threshold=2")
+	}
+	if !fe.calledWith("tx multisign") || !fe.calledWith("tx broadcast") {
+		t.Error("missing multisign/broadcast step")
+	}
+}
+
+func TestSignAndBroadcastRejectsTooFewMembers(t *testing.T) {
+	m := testMultisig()
+	m.exec = (&fakeExec{}).run
+	_, err := m.SignAndBroadcastFile("/tmp/u.json", "msig", "lumera1msig", []string{"s1"}, 2, 7, 3)
+	if err == nil {
+		t.Error("expected error when members < threshold")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/common/ -run TestSignAndBroadcast -v
+```
+
+Expected: FAIL — `m.SignAndBroadcastFile undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `devnet/tests/common/multisig.go`, delete the `var _ = fmt.Sprintf` guard and add (note `os` and `time` imports are needed):
+
+```go
+// CreateMultisigKey creates (or reuses) a K-of-N composite key over the given
+// member key names. Rerun-safe: an existing composite is returned as-is.
+func (m *Multisig) CreateMultisigKey(name string, members []string, threshold int) (string, error) {
+	if threshold < 1 {
+		return "", fmt.Errorf("invalid multisig threshold %d", threshold)
+	}
+	if len(members) < threshold {
+		return "", fmt.Errorf("multisig %s has %d members, need >= threshold %d", name, len(members), threshold)
+	}
+	if m.CLI.HasKey(name) {
+		return m.CLI.ShowAddress(name)
+	}
+	out, err := m.exec(m.CLI.Bin, m.keyAddArgs(name, members, threshold)...)
+	if err != nil {
+		return "", fmt.Errorf("keys add multisig %s: %s: %w", name, out, err)
+	}
+	return m.CLI.ShowAddress(name)
+}
+
+// SignAndBroadcastFile collects `threshold` member signatures over an unsigned
+// tx file, combines them with `tx multisign`, broadcasts the result (sync), and
+// waits for inclusion. Returns the tx hash. Temp signature files are removed.
+func (m *Multisig) SignAndBroadcastFile(unsignedFile, name, multisigAddr string, members []string, threshold int, accNum, seq uint64) (string, error) {
+	if len(members) < threshold {
+		return "", fmt.Errorf("multisig %s has %d members, need >= %d signers", name, len(members), threshold)
+	}
+
+	sigFiles := make([]string, threshold)
+	for i := range sigFiles {
+		f, err := os.CreateTemp("", fmt.Sprintf("multisig-sig%d-*.json", i+1))
+		if err != nil {
+			return "", fmt.Errorf("create temp sig file: %w", err)
+		}
+		_ = f.Close()
+		sigFiles[i] = f.Name()
+		defer os.Remove(sigFiles[i]) //nolint:gocritic // deferred cleanup of all sig files
+	}
+
+	for i, member := range members[:threshold] {
+		out, err := m.exec(m.CLI.Bin, m.signArgs(unsignedFile, member, multisigAddr, accNum, seq)...)
+		if err != nil {
+			return "", fmt.Errorf("sign with %s: %s: %w", member, out, err)
+		}
+		if err := os.WriteFile(sigFiles[i], []byte(out), 0o600); err != nil {
+			return "", fmt.Errorf("write sig %s: %w", sigFiles[i], err)
+		}
+	}
+
+	signedFile, err := os.CreateTemp("", "multisig-signed-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create temp signed file: %w", err)
+	}
+	_ = signedFile.Close()
+	defer os.Remove(signedFile.Name())
+
+	msignOut, err := m.exec(m.CLI.Bin, m.multisignArgs(unsignedFile, name, sigFiles)...)
+	if err != nil {
+		return "", fmt.Errorf("multisign: %s: %w", msignOut, err)
+	}
+	if err := os.WriteFile(signedFile.Name(), []byte(msignOut), 0o600); err != nil {
+		return "", fmt.Errorf("write signed tx: %w", err)
+	}
+
+	bcastOut, err := m.exec(m.CLI.Bin, m.broadcastArgs(signedFile.Name())...)
+	if err != nil {
+		return "", fmt.Errorf("broadcast: %s: %w", bcastOut, err)
+	}
+	txHash := extractTxHash(bcastOut)
+	if txHash != "" {
+		if err := m.CLI.WaitForTxInclusion(txHash, 45*time.Second); err != nil {
+			return txHash, err
+		}
+	}
+	return txHash, nil
+}
+
+// BuildUnsignedToFile generates an unsigned tx (generate-only) using args and
+// writes it to outFile, for the caller to feed into SignAndBroadcastFile.
+func (m *Multisig) BuildUnsignedToFile(outFile string, args []string) error {
+	out, err := m.exec(m.CLI.Bin, args...)
+	if err != nil {
+		return fmt.Errorf("generate unsigned tx: %s: %w", out, err)
+	}
+	return os.WriteFile(outFile, []byte(out), 0o600)
+}
+```
+
+Update the import block of `multisig.go` to:
+
+```go
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/common/ -run 'TestSignAndBroadcast|TestKeyAddArgs|TestSignArgs|TestMultisignArgs|TestGenBankSendArgs|TestBroadcastArgs' -v
+```
+
+Expected: PASS for all.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/common/multisig.go devnet/tests/common/multisig_test.go
+git commit -m "feat(common): multisig composite-create + sign/multisign/broadcast ceremony"
+```
+
+---
+
+## Task 3: Refactor evmigration to delegate to `common.Multisig`
+
+**Files:**
+- Modify: `devnet/tests/evmigration/multisig.go`
+
+This task changes implementations only; behavior must be identical. There is no new test — the gate is that evmigration's existing tests stay green and the package builds.
+
+- [ ] **Step 1: Add a helper that builds a common.Multisig from the evmigration globals**
+
+In `devnet/tests/evmigration/multisig.go`, add near the top (after the imports):
+
+```go
+// commonMultisig builds a *common.Multisig from the evmigration flag globals so
+// the generic ceremony is shared with gen-activity. Gas is fixed (matches the
+// values used across this tool) so generate-only/offline signing works.
+func commonMultisig() *common.Multisig {
+	cli := &common.ChainCLI{
+		Bin:            *flagBin,
+		ChainID:        *flagChainID,
+		RPC:            *flagRPC,
+		Home:           *flagHome,
+		KeyringBackend: "test",
+		Gas:            *flagGas,
+		GasPrices:      *flagGasPrices,
+	}
+	return common.NewMultisig(cli)
+}
+```
+
+Add `"gen/tests/common"` to the imports if not already present (it is, per keys.go; confirm in multisig.go's import block and add if missing).
+
+- [ ] **Step 2: Delegate composite-key creation**
+
+Replace the body of `ensureMultisigCompositeKey` (keep its signature) with:
+
+```go
+func ensureMultisigCompositeKey(multisigKeyName string, members []string, threshold int) (string, error) {
+	addr, err := commonMultisig().CreateMultisigKey(multisigKeyName, members, threshold)
+	if err != nil {
+		return "", err
+	}
+	log.Printf("  multisig key %s -> %s", multisigKeyName, addr)
+	return addr, nil
+}
+```
+
+- [ ] **Step 3: Delegate the sign/broadcast helper**
+
+Replace the body of `signAndBroadcastMultisigTx` (keep its signature) with:
+
+```go
+func signAndBroadcastMultisigTx(unsignedFile, multisigKeyName, multisigAddr string, members []string) error {
+	accNum, seq, err := queryAccountNumberAndSequence(multisigAddr)
+	if err != nil {
+		return fmt.Errorf("query account number/sequence for %s: %w", multisigAddr, err)
+	}
+	_, err = commonMultisig().SignAndBroadcastFile(
+		unsignedFile, multisigKeyName, multisigAddr, members, defaultMultisigThreshold, accNum, seq,
+	)
+	return err
+}
+```
+
+- [ ] **Step 4: Delegate the unsigned-tx builders**
+
+Replace the bodies of `buildUnsignedMultisigBankSendTx` and `buildUnsignedMultisigDelegateTx` (keep signatures) with:
+
+```go
+func buildUnsignedMultisigBankSendTx(multisigKeyName, multisigAddr, toAddr, amount, outFile string) error {
+	accNum, seq, err := queryAccountNumberAndSequence(multisigAddr)
+	if err != nil {
+		if waitErr := waitForAccountOnChain(multisigAddr, 30*time.Second); waitErr != nil {
+			return fmt.Errorf("wait for multisig account on-chain: %w", waitErr)
+		}
+		if accNum, seq, err = queryAccountNumberAndSequence(multisigAddr); err != nil {
+			return fmt.Errorf("query account number/sequence for %s: %w", multisigAddr, err)
+		}
+	}
+	m := commonMultisig()
+	return m.BuildUnsignedToFile(outFile, m.GenBankSendArgs(multisigKeyName, multisigAddr, toAddr, amount, accNum, seq))
+}
+
+func buildUnsignedMultisigDelegateTx(multisigKeyName, multisigAddr, validatorAddr, amount, outFile string) error {
+	accNum, seq, err := queryAccountNumberAndSequence(multisigAddr)
+	if err != nil {
+		if waitErr := waitForAccountOnChain(multisigAddr, 30*time.Second); waitErr != nil {
+			return fmt.Errorf("wait for multisig account on-chain: %w", waitErr)
+		}
+		if accNum, seq, err = queryAccountNumberAndSequence(multisigAddr); err != nil {
+			return fmt.Errorf("query account number/sequence for %s: %w", multisigAddr, err)
+		}
+	}
+	m := commonMultisig()
+	return m.BuildUnsignedToFile(outFile, m.GenDelegateArgs(multisigKeyName, validatorAddr, amount, accNum, seq))
+}
+```
+
+> Note: `GenBankSendArgs` / `GenDelegateArgs` must be **exported** in common (Task 1 defined them lowercase). In `devnet/tests/common/multisig.go`, rename `genBankSendArgs`→`GenBankSendArgs` and `genDelegateArgs`→`GenDelegateArgs` (and update the Task 1 tests that reference `m.genBankSendArgs` to `m.GenBankSendArgs`). Keep `genTxArgs`, `keyAddArgs`, `signArgs`, `multisignArgs`, `broadcastArgs` lowercase (used only within common). Make this rename now.
+
+- [ ] **Step 5: Keep `registerMultisigPubKey` delegating to the shared signer**
+
+`registerMultisigPubKey` already constructs an unsigned self-send and calls a sign/broadcast path. Leave its self-send construction in place but route its final sign/multisign/broadcast through `signAndBroadcastMultisigTx` (now delegating to common). Concretely, ensure its tail uses `signAndBroadcastMultisigTx(unsignedFile, multisigKeyName, multisigAddr, members)` instead of the inline sign/multisign/broadcast block. If `registerMultisigPubKey` currently inlines those steps, replace that block with the single delegating call. Do not change the 1-ulume self-send semantics.
+
+- [ ] **Step 6: Remove the now-duplicate local `extractTxHash`**
+
+`common.extractTxHash` is unexported (package-internal), so the evmigration `extractTxHash` in `multisig.go` is a separate symbol and still compiles — leave it. (No action; this step is a checkpoint to confirm there is no symbol clash. If the build reports a redeclaration, it means an accidental same-package duplicate; there is none across packages.)
+
+- [ ] **Step 7: Build and run evmigration unit tests**
+
+Run:
+
+```bash
+cd devnet && go build ./... && go test ./tests/evmigration/ -v
+```
+
+Expected: builds clean; evmigration unit tests pass (same set as before the refactor). If any multisig test requires the `integration`/`test` build tags, run the tagged suite per CLAUDE.md instead:
+
+```bash
+cd /home/akobrin/p/lumera && go test -tags='integration test' ./tests/integration/evmigration/... -v
+```
+
+Expected: no new failures attributable to this refactor.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add devnet/tests/common/multisig.go devnet/tests/common/multisig_test.go devnet/tests/evmigration/multisig.go
+git commit -m "refactor(evmigration): delegate generic multisig ceremony to common.Multisig"
+```
+
+---
+
+## Task 4: Registry schema v2 + MultisigInfo + name allocation
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/registry.go`
+- Test: `devnet/tests/gen-activity/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/registry_test.go`:
+
+```go
+func TestRegistrySchemaIsV2(t *testing.T) {
+	if schemaVersion != 2 {
+		t.Fatalf("schemaVersion = %d, want 2", schemaVersion)
+	}
+	reg := NewRegistry("lumera-devnet-1", "faucet", "", "legacy", "2026-06-12T00:00:00Z")
+	if reg.SchemaVersion != 2 {
+		t.Errorf("NewRegistry schema = %d, want 2", reg.SchemaVersion)
+	}
+}
+
+func TestMultisigRecordRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "accounts.json")
+	reg := NewRegistry("lumera-devnet-1", "faucet", "", "legacy", "2026-06-12T00:00:00Z")
+	reg.UpsertAccount(&AccountRecord{
+		AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0001", Address: "lumera1msig"},
+		Multisig: &MultisigInfo{
+			MemberNames: []string{"gen-msig23-0001-signer-1", "gen-msig23-0001-signer-2", "gen-msig23-0001-signer-3"},
+			Threshold:   2,
+			Signers:     3,
+		},
+	})
+	if err := reg.Save(path, "2026-06-12T00:00:00Z"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(got.Accounts) != 1 || got.Accounts[0].Multisig == nil {
+		t.Fatalf("multisig info not persisted: %+v", got.Accounts)
+	}
+	if got.Accounts[0].Multisig.Threshold != 2 || got.Accounts[0].Multisig.Signers != 3 {
+		t.Errorf("multisig threshold/signers = %d/%d, want 2/3",
+			got.Accounts[0].Multisig.Threshold, got.Accounts[0].Multisig.Signers)
+	}
+}
+
+func TestAllocateNamesPerKindContinuesIndex(t *testing.T) {
+	reg := NewRegistry("c", "f", "", "legacy", "t")
+	reg.Accounts = []*AccountRecord{
+		{AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0001"}},
+		{AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0002"}},
+	}
+	names := reg.AllocateNames("gen-msig23", 2)
+	want := []string{"gen-msig23-0003", "gen-msig23-0004"}
+	if !reflect.DeepEqual(names, want) {
+		t.Errorf("AllocateNames = %v, want %v", names, want)
+	}
+}
+```
+
+Add imports `reflect` and (if missing) `path/filepath`, `gen/tests/common` to `registry_test.go`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestRegistrySchemaIsV2|TestMultisigRecordRoundTrip|TestAllocateNamesPerKind' -v
+```
+
+Expected: FAIL — `schemaVersion` is 1 / `MultisigInfo` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+In `devnet/tests/gen-activity/registry.go`:
+
+Change the schema constant:
+
+```go
+// schemaVersion identifies the gen-activity registry layout. v2 adds multisig
+// account records (AccountRecord.Multisig). v1 files are not supported and must
+// be regenerated.
+const schemaVersion = 2
+```
+
+Add the `MultisigInfo` type and the `Multisig` field on `AccountRecord`:
+
+```go
+// MultisigInfo describes a generated K-of-N multisig account: its member key
+// names, signing threshold (K), and total signer count (N).
+type MultisigInfo struct {
+	MemberNames []string `json:"member_names"`
+	Threshold   int      `json:"threshold"`
+	Signers     int      `json:"signers"`
+}
+```
+
+In the `AccountRecord` struct, add (after the embedded `common.ActivityLog`):
+
+```go
+	Multisig *MultisigInfo `json:"multisig,omitempty"`
+```
+
+The existing `LoadRegistry` already rejects any `schema_version` != `schemaVersion`, which now means it accepts only v2 — no change needed there. `AllocateNames` already continues past the highest index matching the given prefix, so it works for `"gen-msig23"` as-is — no change needed.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestRegistrySchemaIsV2|TestMultisigRecordRoundTrip|TestAllocateNamesPerKind' -v
+```
+
+Expected: PASS for all three.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/registry.go devnet/tests/gen-activity/registry_test.go
+git commit -m "feat(gen-activity): registry schema v2 with multisig account records"
+```
+
+---
+
+## Task 5: Multisig generation plan + member/composite creation
+
+**Files:**
+- Create: `devnet/tests/gen-activity/multisig.go`
+- Test: `devnet/tests/gen-activity/multisig_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `devnet/tests/gen-activity/multisig_test.go`:
+
+```go
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMultisigPlanFromCounts(t *testing.T) {
+	plan := multisigPlan(2, 1)
+	want := []multisigSpec{
+		{Prefix: "msig23", Threshold: 2, Signers: 3},
+		{Prefix: "msig23", Threshold: 2, Signers: 3},
+		{Prefix: "msig35", Threshold: 3, Signers: 5},
+	}
+	if !reflect.DeepEqual(plan, want) {
+		t.Errorf("multisigPlan(2,1) = %+v, want %+v", plan, want)
+	}
+}
+
+func TestMultisigPlanZeroIsEmpty(t *testing.T) {
+	if plan := multisigPlan(0, 0); len(plan) != 0 {
+		t.Errorf("multisigPlan(0,0) = %+v, want empty", plan)
+	}
+}
+
+func TestMemberNamesForComposite(t *testing.T) {
+	got := memberNames("gen-msig35-0007", 5)
+	want := []string{
+		"gen-msig35-0007-signer-1", "gen-msig35-0007-signer-2", "gen-msig35-0007-signer-3",
+		"gen-msig35-0007-signer-4", "gen-msig35-0007-signer-5",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("memberNames = %v, want %v", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestMultisigPlan|TestMemberNames' -v
+```
+
+Expected: FAIL — `undefined: multisigPlan`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `devnet/tests/gen-activity/multisig.go`:
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"gen/tests/common"
+)
+
+// multisigSpec describes one multisig account to generate.
+type multisigSpec struct {
+	Prefix    string // name infix, e.g. "msig23"
+	Threshold int    // K
+	Signers   int    // N
+}
+
+// multisigPlan expands the 2-of-3 and 3-of-5 counts into a flat list of specs.
+func multisigPlan(num23, num35 int) []multisigSpec {
+	var plan []multisigSpec
+	for i := 0; i < num23; i++ {
+		plan = append(plan, multisigSpec{Prefix: "msig23", Threshold: 2, Signers: 3})
+	}
+	for i := 0; i < num35; i++ {
+		plan = append(plan, multisigSpec{Prefix: "msig35", Threshold: 3, Signers: 5})
+	}
+	return plan
+}
+
+// memberNames returns deterministic member key names for a composite.
+func memberNames(composite string, signers int) []string {
+	names := make([]string, signers)
+	for i := 0; i < signers; i++ {
+		names[i] = fmt.Sprintf("%s-signer-%d", composite, i+1)
+	}
+	return names
+}
+
+// generateMultisigAccounts creates member keys + composite keys for the planned
+// multisig accounts, returning new AccountRecords (with Multisig info set). It is
+// rerun-safe: existing keys/composites are reused. Member keys use the detected
+// key style; the composite is key-type agnostic.
+func generateMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accountPrefix string, specs []multisigSpec, keyStyle common.KeyStyle) []*AccountRecord {
+	ms := common.NewMultisig(cli)
+	now := time.Now().UTC().Format(time.RFC3339)
+	var recs []*AccountRecord
+
+	for _, spec := range specs {
+		names := reg.AllocateNames(accountPrefix+"-"+spec.Prefix, 1)
+		composite := names[0]
+		members := memberNames(composite, spec.Signers)
+
+		if err := ensureMembers(cli, members, keyStyle); err != nil {
+			log.Printf("  WARN: multisig %s members: %v", composite, err)
+			continue
+		}
+		addr, err := ms.CreateMultisigKey(composite, members, spec.Threshold)
+		if err != nil {
+			log.Printf("  WARN: create multisig %s: %v", composite, err)
+			continue
+		}
+		rec := &AccountRecord{
+			AccountIdentity: common.AccountIdentity{Name: composite, Address: addr, KeyStyle: keyStyle.Name()},
+			Multisig:        &MultisigInfo{MemberNames: members, Threshold: spec.Threshold, Signers: spec.Signers},
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		reg.UpsertAccount(rec)
+		recs = append(recs, rec)
+		log.Printf("  created %d-of-%d multisig %s (%s)", spec.Threshold, spec.Signers, composite, addr)
+	}
+	return recs
+}
+
+// ensureMembers creates any missing member keys with the detected key style.
+func ensureMembers(cli *common.ChainCLI, names []string, keyStyle common.KeyStyle) error {
+	for _, name := range names {
+		if cli.HasKey(name) {
+			continue
+		}
+		if _, err := cli.AddKeyWithStyle(name, keyStyle); err != nil {
+			return fmt.Errorf("add member key %s: %w", name, err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestMultisigPlan|TestMemberNames' -v
+```
+
+Expected: PASS for all three.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/multisig.go devnet/tests/gen-activity/multisig_test.go
+git commit -m "feat(gen-activity): plan + create multisig member/composite keys"
+```
+
+---
+
+## Task 6: Wire multisig generation, funding, and exercise into `run()`
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/multisig.go`
+- Modify: `devnet/tests/gen-activity/main.go`
+- Test: `devnet/tests/gen-activity/multisig_test.go`
+
+- [ ] **Step 1: Write the failing test (exercise step is pure-ish: assert the unsigned-tx + ceremony are invoked via a seam)**
+
+Add to `devnet/tests/gen-activity/multisig_test.go`:
+
+```go
+func TestExerciseMultisigRecordsBankSend(t *testing.T) {
+	rec := &AccountRecord{
+		AccountIdentity: common.AccountIdentity{Name: "gen-msig23-0001", Address: "lumera1msig"},
+		Multisig:        &MultisigInfo{MemberNames: []string{"m1", "m2", "m3"}, Threshold: 2, Signers: 3},
+		Funded:          true,
+	}
+	fake := &fakeMultisigExerciser{txHash: "DEAD01"}
+
+	err := exerciseMultisig(fake, rec, "lumera1peer", "5ulume")
+	if err != nil {
+		t.Fatalf("exerciseMultisig: %v", err)
+	}
+	if len(rec.BankSends) != 1 || rec.BankSends[0].To != "lumera1peer" {
+		t.Fatalf("expected one recorded bank send to peer, got %+v", rec.BankSends)
+	}
+	if rec.BankSends[0].TxHash != "DEAD01" {
+		t.Errorf("recorded tx hash = %q, want DEAD01", rec.BankSends[0].TxHash)
+	}
+	if !fake.called {
+		t.Error("multisig exerciser was not invoked")
+	}
+}
+
+// fakeMultisigExerciser satisfies multisigExerciser for the test.
+type fakeMultisigExerciser struct {
+	called bool
+	txHash string
+}
+
+func (f *fakeMultisigExerciser) MultisigBankSend(rec *AccountRecord, to, amount string) (string, error) {
+	f.called = true
+	return f.txHash, nil
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestExerciseMultisigRecordsBankSend -v
+```
+
+Expected: FAIL — `undefined: exerciseMultisig` / `multisigExerciser`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `devnet/tests/gen-activity/multisig.go`:
+
+```go
+// multisigExerciser performs one multisign tx for a multisig account. It is an
+// interface so the recording logic is testable without a live chain.
+type multisigExerciser interface {
+	// MultisigBankSend builds, signs (K members), and broadcasts a bank send
+	// from the multisig account to `to`, returning the tx hash.
+	MultisigBankSend(rec *AccountRecord, to, amount string) (string, error)
+}
+
+// exerciseMultisig runs one multisign bank-send for the account and records it.
+func exerciseMultisig(ex multisigExerciser, rec *AccountRecord, peer, amount string) error {
+	if rec.Multisig == nil {
+		return fmt.Errorf("account %s is not a multisig account", rec.Name)
+	}
+	txHash, err := ex.MultisigBankSend(rec, peer, amount)
+	if err != nil {
+		return err
+	}
+	rec.AddBankSend(common.BankSendActivity{To: peer, Amount: amount, TxHash: txHash})
+	return nil
+}
+
+// cliMultisigExerciser is the production exerciser backed by common.Multisig.
+type cliMultisigExerciser struct {
+	cli *common.ChainCLI
+	ms  *common.Multisig
+}
+
+func newCLIMultisigExerciser(cli *common.ChainCLI) *cliMultisigExerciser {
+	return &cliMultisigExerciser{cli: cli, ms: common.NewMultisig(cli)}
+}
+
+func (e *cliMultisigExerciser) MultisigBankSend(rec *AccountRecord, to, amount string) (string, error) {
+	accNum, seq, err := e.cli.AccountNumberAndSequence(rec.Address)
+	if err != nil {
+		return "", fmt.Errorf("query account number/sequence for %s: %w", rec.Address, err)
+	}
+	unsigned, err := os.CreateTemp("", "msig-unsigned-*.json")
+	if err != nil {
+		return "", fmt.Errorf("create temp unsigned file: %w", err)
+	}
+	_ = unsigned.Close()
+	defer os.Remove(unsigned.Name())
+
+	args := e.ms.GenBankSendArgs(rec.Name, rec.Address, to, amount, accNum, seq)
+	if err := e.ms.BuildUnsignedToFile(unsigned.Name(), args); err != nil {
+		return "", err
+	}
+	return e.ms.SignAndBroadcastFile(unsigned.Name(), rec.Name, rec.Address,
+		rec.Multisig.MemberNames, rec.Multisig.Threshold, accNum, seq)
+}
+```
+
+Add `"os"` to the import block of `multisig.go`.
+
+- [ ] **Step 4: Integrate into `run()`**
+
+In `devnet/tests/gen-activity/main.go`, inside `run()`, after the existing `generateAccounts` + first `reg.Save` block (right after `log.Printf("generated %d new account(s); registry saved", ...)`), add multisig generation:
+
+```go
+	// Generate multisig accounts (2-of-3 / 3-of-5) alongside regular accounts.
+	var newMultisig []*AccountRecord
+	if specs := multisigPlan(cfg.NumMultisig23, cfg.NumMultisig35); len(specs) > 0 && !cfg.ActivityExisting {
+		newMultisig = generateMultisigAccounts(cli, reg, cfg.AccountPrefix, specs, keyStyle)
+		if err := reg.Save(cfg.AccountsPath, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("save registry after multisig key generation: %w", err)
+		}
+		log.Printf("generated %d new multisig account(s)", len(newMultisig))
+	}
+```
+
+Multisig composites are funded by the existing funding phase because `unfundedTargets(reg)` already returns every `!Funded` record, including the multisig ones just upserted. No change to the funding call is required.
+
+After the funding phase and `reg.Save` (after `log.Printf("funded %d/%d account(s)", ...)` and its save), add the pubkey-registration + exercise step:
+
+```go
+	// Register multisig pubkeys on-chain and exercise each with one multisign
+	// bank-send to a peer. Non-fatal: a failure logs and continues.
+	exerciseMultisigAccounts(cli, reg, newMultisig, cfg)
+	if err := reg.Save(cfg.AccountsPath, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return fmt.Errorf("save registry after multisig exercise: %w", err)
+	}
+```
+
+Add the orchestration helper to `multisig.go`:
+
+```go
+// exerciseMultisigAccounts registers each funded multisig composite's pubkey
+// on-chain (via the shared ceremony's self-send) and runs one multisign
+// bank-send to a regular peer address. Failures are logged, never fatal.
+func exerciseMultisigAccounts(cli *common.ChainCLI, reg *ActivityRegistry, newMultisig []*AccountRecord, cfg *Config) {
+	targets := newMultisig
+	if cfg.ActivityExisting {
+		targets = nil
+		for _, rec := range reg.Accounts {
+			if rec.Multisig != nil && rec.Funded {
+				targets = append(targets, rec)
+			}
+		}
+	}
+	if len(targets) == 0 {
+		return
+	}
+
+	peer := firstRegularPeer(reg)
+	if peer == "" {
+		log.Printf("  no regular peer account to receive multisig sends; skipping multisig exercise")
+		return
+	}
+
+	ms := common.NewMultisig(cli)
+	ex := newCLIMultisigExerciser(cli)
+	amount := common.Coin{Amount: 1, Denom: common.ChainDenom}.String()
+
+	for _, rec := range targets {
+		if !rec.Funded {
+			continue
+		}
+		// Publish the composite pubkey on-chain via a 1-ulume self-send.
+		if err := registerMultisigPubkey(cli, ms, rec); err != nil {
+			log.Printf("  WARN: register pubkey for %s: %v", rec.Name, err)
+			continue
+		}
+		if err := exerciseMultisig(ex, rec, peer, amount); err != nil {
+			log.Printf("  WARN: exercise multisig %s: %v", rec.Name, err)
+		}
+	}
+}
+
+// registerMultisigPubkey publishes a multisig composite's pubkey on-chain via a
+// 1-ulume self-send (required before it can be queried for account number).
+func registerMultisigPubkey(cli *common.ChainCLI, ms *common.Multisig, rec *AccountRecord) error {
+	accNum, seq, err := cli.AccountNumberAndSequence(rec.Address)
+	if err != nil {
+		return fmt.Errorf("query account number/sequence for %s: %w", rec.Address, err)
+	}
+	unsigned, err := os.CreateTemp("", "msig-selfsend-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp unsigned file: %w", err)
+	}
+	_ = unsigned.Close()
+	defer os.Remove(unsigned.Name())
+
+	args := ms.GenBankSendArgs(rec.Name, rec.Address, rec.Address, "1"+common.ChainDenom, accNum, seq)
+	if err := ms.BuildUnsignedToFile(unsigned.Name(), args); err != nil {
+		return err
+	}
+	_, err = ms.SignAndBroadcastFile(unsigned.Name(), rec.Name, rec.Address,
+		rec.Multisig.MemberNames, rec.Multisig.Threshold, accNum, seq)
+	return err
+}
+
+// firstRegularPeer returns the address of the first funded non-multisig account
+// to serve as a recipient for multisig sends.
+func firstRegularPeer(reg *ActivityRegistry) string {
+	for _, rec := range reg.Accounts {
+		if rec.Multisig == nil && rec.Funded && rec.Address != "" {
+			return rec.Address
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 5: Run the package tests + build**
+
+Run:
+
+```bash
+cd devnet && go build ./... && go test ./tests/gen-activity/ -v
+```
+
+Expected: builds clean; all gen-activity tests (including `TestExerciseMultisigRecordsBankSend`) pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add devnet/tests/gen-activity/multisig.go devnet/tests/gen-activity/main.go devnet/tests/gen-activity/multisig_test.go
+git commit -m "feat(gen-activity): generate, fund, and exercise multisig accounts in run()"
+```
+
+---
+
+## Task 7: Verification + documentation
+
+**Files:**
+- Modify: `docs/design/gen-activity-design.md`
+
+- [ ] **Step 1: Document multisig accounts**
+
+In `docs/design/gen-activity-design.md`, add a section:
+
+```markdown
+## Multisig accounts
+
+`-num-multisig23-accounts` and `-num-multisig35-accounts` generate K-of-N
+multisig accounts (2-of-3 and 3-of-5). For each, gen-activity:
+
+1. Creates N member keys (`<composite>-signer-<i>`) using the detected key style
+   and a composite key via `keys add --multisig --nosort` (shared
+   `common.Multisig.CreateMultisigKey`).
+2. Funds the composite from the funder (multisig composites are ordinary funding
+   targets).
+3. Publishes the composite pubkey on-chain via a 1-ulume self-send.
+4. Exercises the account with one multisign bank-send to a regular peer
+   (`sign × K → multisign → broadcast`), recorded in the registry.
+
+Records are stored as `AccountRecord.Multisig` (member names, threshold,
+signers) under registry schema v2. The generic ceremony lives in
+`devnet/tests/common` (`multisig.go`) and is shared with the evmigration tool.
+```
+
+- [ ] **Step 2: Full verification sweep**
+
+Run:
+
+```bash
+cd devnet && go build ./... && go test ./tests/common/ ./tests/gen-activity/ ./tests/evmigration/ -v
+cd /home/akobrin/p/lumera && make lint
+```
+
+Expected: all packages build; all listed unit tests pass; `make lint` reports 0 issues.
+
+- [ ] **Step 3: Exercise the evmigration multisig modes (devnet) to confirm the refactor**
+
+Per the spec's verification requirement, run the evmigration multisig modes against a devnet (manual; requires a running devnet + EVM-enabled lumerad):
+
+```bash
+cd devnet/tests/evmigration
+go run . -mode multisig
+go run . -mode multisig-vesting
+go run . -mode multisig-validator   # SKIPs cleanly if no multisig validator seeded
+```
+
+Expected: `=== MULTISIG MODE: SUCCESS ===` (and the vesting variant); behavior identical to before the refactor.
+
+- [ ] **Step 4: Exercise gen-activity multisig generation (devnet)**
+
+Run (against a running devnet):
+
+```bash
+cd devnet/tests/gen-activity
+go run . -chain devnet -num-accounts 3 -num-multisig23-accounts 1 -num-multisig35-accounts 1
+```
+
+Expected: regular + multisig accounts created and funded; multisig accounts show a recorded `bank_sends` entry in the accounts JSON; run completes without fatal errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/design/gen-activity-design.md
+git commit -m "docs(gen-activity): document multisig accounts and shared ceremony"
+```
+
+---
+
+## Self-Review checklist (for the plan author)
+
+- **Spec coverage:** §3.3 extraction to common → Tasks 1–2; evmigration refactor → Task 3; §3.4 registry v2 + MultisigInfo → Task 4; multisig naming + generation → Task 5; funding (reuses existing `unfundedTargets`) + exercise → Task 6; §4 verification (common/gen-activity/evmigration tests, lint, devnet modes) → Tasks 3, 7; docs → Task 7.
+- **Placeholder scan:** the `var _ = fmt.Sprintf` guard in Task 1 and the export-rename note in Task 3 are explicit, with exact final code given (not TODOs).
+- **Type consistency:** `MultisigInfo{MemberNames, Threshold, Signers}` is identical across registry.go, multisig.go, and the tests; `common.Multisig` method names (`CreateMultisigKey`, `SignAndBroadcastFile`, `BuildUnsignedToFile`, `GenBankSendArgs`, `GenDelegateArgs`) match between common, evmigration (Task 3), and gen-activity (Tasks 5–6); `multisigExerciser.MultisigBankSend(rec, to, amount)` matches its fake and the `cliMultisigExerciser` impl.
+- **Testability tradeoff:** orchestration of the full ceremony is unit-tested in `common` via the injectable `exec` seam (Task 2); the gen-activity `MultisigBankSend` integration and the on-chain steps are covered by the devnet exercises in Task 7 rather than unit tests (they require a live keyring + chain). This is intentional and called out so coverage gaps aren't silent.
+```

--- a/docs/design/gen-activity-vesting-plan.md
+++ b/docs/design/gen-activity-vesting-plan.md
@@ -1,0 +1,1005 @@
+# gen-activity Vesting Accounts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add vesting account generation to gen-activity: `-vesting-percent` randomly designates a share of regular accounts as continuous/delayed vesting, and `-num-permanent-locked-accounts` creates a dedicated set of PermanentLocked accounts. All are created at funding time via `x/vesting` `create-*` txs, then exercised by the normal activity mix.
+
+**Architecture:** A new `common.Vesting`-style helper set (`common/vesting.go`) provides pure CLI arg builders + funder-signed wrappers for `create-vesting-account` (continuous / `--delayed`) and `create-permanent-locked-account`. gen-activity tags selected accounts with a `VestingInfo` before funding, then a funding split routes vesting/locked accounts through a create-tx + liquid top-up path instead of the batched bank-send. Registry schema v2 (from the multisig plan) carries `AccountRecord.Vesting`.
+
+**Tech Stack:** Go, `gen` module, `common.ChainCLI`, stock Cosmos-SDK `x/vesting` CLI. Companion to `gen-activity-config-wizard-plan.md` and `gen-activity-multisig-plan.md`.
+
+**Prerequisites:**
+- The multisig plan's Task 4 (registry **schema v2**, `MultisigInfo`, `AccountRecord` with embedded identity/activity) must be done — this plan adds a sibling `Vesting` field.
+- The config/wizard plan's flag-registration + wizard menu must be done — this plan adds two flags and two wizard entries.
+
+**SDK constraint (why "at funding time"):** `MsgCreateVestingAccount` / `MsgCreatePermanentLockedAccount` reject a destination that already exists on-chain. An account that has been bank-funded or done activity already exists, so it cannot be converted. Hence vesting/locked accounts are created by the funding tx itself (the account does not exist on-chain until then), and the regular bank-send funding path must skip them.
+
+---
+
+## File Structure
+
+New:
+- `devnet/tests/common/vesting.go` — vesting/permanent-locked arg builders + funder-signed wrappers.
+- `devnet/tests/common/vesting_test.go` — arg-builder tests.
+- `devnet/tests/gen-activity/vesting.go` — selection/assignment, permanent-locked generation, funding split, vesting funder.
+- `devnet/tests/gen-activity/vesting_test.go` — selection + split tests.
+
+Modified:
+- `devnet/tests/gen-activity/config.go` — `VestingPercent`, `NumPermanentLocked` fields + validation.
+- `devnet/tests/gen-activity/main.go` — register flags; tag/generate/fund vesting accounts in `run()`.
+- `devnet/tests/gen-activity/registry.go` — `VestingInfo` type + `AccountRecord.Vesting` field.
+- `devnet/tests/gen-activity/wizard.go` — two new editable settings.
+- `docs/design/gen-activity-design.md` — document vesting accounts.
+
+---
+
+## Task 1: Common vesting CLI helpers
+
+**Files:**
+- Create: `devnet/tests/common/vesting.go`
+- Test: `devnet/tests/common/vesting_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `devnet/tests/common/vesting_test.go`:
+
+```go
+package common
+
+import "testing"
+
+func vcontains(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestVestingCreateArgsContinuous(t *testing.T) {
+	args := VestingCreateArgs("faucet", "lumera1to", "5000000ulume", 1800000000, false)
+	for _, want := range []string{"vesting", "create-vesting-account", "lumera1to", "5000000ulume", "1800000000"} {
+		if !vcontains(args, want) {
+			t.Errorf("continuous vesting args missing %q: %v", want, args)
+		}
+	}
+	if !vcontains(args, "--from") || !vcontains(args, "faucet") {
+		t.Errorf("must sign with funder: %v", args)
+	}
+	if vcontains(args, "--delayed") {
+		t.Errorf("continuous vesting must NOT pass --delayed: %v", args)
+	}
+}
+
+func TestVestingCreateArgsDelayed(t *testing.T) {
+	args := VestingCreateArgs("faucet", "lumera1to", "5000000ulume", 1800000000, true)
+	if !vcontains(args, "--delayed") {
+		t.Errorf("delayed vesting must pass --delayed: %v", args)
+	}
+}
+
+func TestPermanentLockedArgs(t *testing.T) {
+	args := PermanentLockedArgs("faucet", "lumera1to", "5000000ulume")
+	for _, want := range []string{"vesting", "create-permanent-locked-account", "lumera1to", "5000000ulume"} {
+		if !vcontains(args, want) {
+			t.Errorf("permanent-locked args missing %q: %v", want, args)
+		}
+	}
+	if !vcontains(args, "--from") || !vcontains(args, "faucet") {
+		t.Errorf("must sign with funder: %v", args)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/common/ -run 'TestVestingCreateArgs|TestPermanentLockedArgs' -v
+```
+
+Expected: FAIL — `undefined: VestingCreateArgs`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `devnet/tests/common/vesting.go`:
+
+```go
+package common
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// VestingType labels the vesting/locked account variants gen-activity creates.
+type VestingType string
+
+const (
+	VestingContinuous      VestingType = "continuous"
+	VestingDelayed         VestingType = "delayed"
+	VestingPermanentLocked VestingType = "permanent_locked"
+)
+
+// VestingCreateArgs builds `tx vesting create-vesting-account <to> <amount>
+// <end-unix> [--delayed] --from <funder>`. Gas/broadcast/keyring/node flags are
+// appended by ChainCLI.SubmitTx, so they are intentionally absent here.
+func VestingCreateArgs(funderKey, to, amount string, endUnix int64, delayed bool) []string {
+	args := []string{
+		"tx", "vesting", "create-vesting-account",
+		to, amount, strconv.FormatInt(endUnix, 10),
+		"--from", funderKey,
+	}
+	if delayed {
+		args = append(args, "--delayed")
+	}
+	return args
+}
+
+// PermanentLockedArgs builds `tx vesting create-permanent-locked-account <to>
+// <amount> --from <funder>`.
+func PermanentLockedArgs(funderKey, to, amount string) []string {
+	return []string{
+		"tx", "vesting", "create-permanent-locked-account",
+		to, amount,
+		"--from", funderKey,
+	}
+}
+
+// CreateVestingAccount creates a continuous (delayed=false) or delayed/cliff
+// (delayed=true) vesting account funded with amount, signed by funderKey. It
+// waits for inclusion (SubmitTx semantics) and returns the tx hash.
+func (c *ChainCLI) CreateVestingAccount(funderKey, to, amount string, endUnix int64, delayed bool) (string, error) {
+	txHash, err := c.SubmitTx(VestingCreateArgs(funderKey, to, amount, endUnix, delayed)...)
+	if err != nil {
+		return txHash, fmt.Errorf("create vesting account %s: %w", to, err)
+	}
+	return txHash, nil
+}
+
+// CreatePermanentLockedAccount creates a PermanentLockedAccount funded with
+// amount, signed by funderKey.
+func (c *ChainCLI) CreatePermanentLockedAccount(funderKey, to, amount string) (string, error) {
+	txHash, err := c.SubmitTx(PermanentLockedArgs(funderKey, to, amount)...)
+	if err != nil {
+		return txHash, fmt.Errorf("create permanent-locked account %s: %w", to, err)
+	}
+	return txHash, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/common/ -run 'TestVestingCreateArgs|TestPermanentLockedArgs' -v
+```
+
+Expected: PASS for all three.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/common/vesting.go devnet/tests/common/vesting_test.go
+git commit -m "feat(common): vesting + permanent-locked account create helpers"
+```
+
+---
+
+## Task 2: Registry VestingInfo field
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/registry.go`
+- Test: `devnet/tests/gen-activity/registry_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/registry_test.go`:
+
+```go
+func TestVestingRecordRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "accounts.json")
+	reg := NewRegistry("lumera-devnet-1", "faucet", "", "legacy", "2026-06-12T00:00:00Z")
+	reg.UpsertAccount(&AccountRecord{
+		AccountIdentity: common.AccountIdentity{Name: "gen-0003", Address: "lumera1vest"},
+		Vesting:         &VestingInfo{Type: "continuous", EndTime: 1800000000, LockedAmount: "5000000ulume"},
+		Funded:          true,
+	})
+	if err := reg.Save(path, "2026-06-12T00:00:00Z"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.Accounts[0].Vesting == nil || got.Accounts[0].Vesting.Type != "continuous" {
+		t.Fatalf("vesting info not persisted: %+v", got.Accounts[0].Vesting)
+	}
+	if got.Accounts[0].Vesting.EndTime != 1800000000 {
+		t.Errorf("vesting end-time = %d, want 1800000000", got.Accounts[0].Vesting.EndTime)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestVestingRecordRoundTrip -v
+```
+
+Expected: FAIL — `VestingInfo` / `Vesting` field undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+In `devnet/tests/gen-activity/registry.go`, add the type:
+
+```go
+// VestingInfo describes a vesting or permanent-locked account. Type is one of
+// the common.VestingType values ("continuous", "delayed", "permanent_locked").
+// EndTime is the unix unlock time (0 for permanent_locked).
+type VestingInfo struct {
+	Type         string `json:"type"`
+	EndTime      int64  `json:"end_time,omitempty"`
+	LockedAmount string `json:"locked_amount"`
+}
+```
+
+In the `AccountRecord` struct, add (next to the `Multisig` field added by the multisig plan):
+
+```go
+	Vesting *VestingInfo `json:"vesting,omitempty"`
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestVestingRecordRoundTrip -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/registry.go devnet/tests/gen-activity/registry_test.go
+git commit -m "feat(gen-activity): registry VestingInfo for vesting/locked accounts"
+```
+
+---
+
+## Task 3: Config flags + validation
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/config.go`
+- Modify: `devnet/tests/gen-activity/main.go`
+- Test: `devnet/tests/gen-activity/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/config_test.go`:
+
+```go
+func TestConfigValidateVesting(t *testing.T) {
+	t.Run("valid vesting-percent passes", func(t *testing.T) {
+		c := validConfig()
+		c.VestingPercent = 30
+		c.NumPermanentLocked = 2
+		if err := c.Validate(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+	t.Run("vesting-percent over 100 fails", func(t *testing.T) {
+		c := validConfig()
+		c.VestingPercent = 101
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for vesting-percent > 100")
+		}
+	})
+	t.Run("negative vesting-percent fails", func(t *testing.T) {
+		c := validConfig()
+		c.VestingPercent = -1
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for negative vesting-percent")
+		}
+	})
+	t.Run("negative num-permanent-locked fails", func(t *testing.T) {
+		c := validConfig()
+		c.NumPermanentLocked = -1
+		if err := c.Validate(); err == nil {
+			t.Error("expected error for negative num-permanent-locked-accounts")
+		}
+	})
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestConfigValidateVesting -v
+```
+
+Expected: FAIL — `c.VestingPercent undefined`.
+
+- [ ] **Step 3: Add the fields, validation, and flags**
+
+In `devnet/tests/gen-activity/config.go`, add to the `Config` struct (in the "Registry and account generation" block, near the multisig counts):
+
+```go
+	VestingPercent     int // percent of regular accounts created as vesting (0-100)
+	NumPermanentLocked int // dedicated PermanentLocked accounts
+```
+
+In `Config.Validate()`, add after the multisig-count checks:
+
+```go
+	if c.VestingPercent < 0 || c.VestingPercent > 100 {
+		return fmt.Errorf("-vesting-percent must be in [0,100], got %d", c.VestingPercent)
+	}
+	if c.NumPermanentLocked < 0 {
+		return fmt.Errorf("-num-permanent-locked-accounts must be >= 0, got %d", c.NumPermanentLocked)
+	}
+```
+
+In `devnet/tests/gen-activity/main.go` `configureFlags`, add after the multisig-count flags:
+
+```go
+	fs.IntVar(&c.VestingPercent, "vesting-percent", 0, "percent of regular accounts to create as continuous/delayed vesting (0-100)")
+	fs.IntVar(&c.NumPermanentLocked, "num-permanent-locked-accounts", 0, "number of dedicated PermanentLocked accounts to generate")
+```
+
+If implementing alongside the config plan, also add these two keys to `ChainSection` in `configfile.go` and to `applyLayer` (mirroring the `num-multisig*` handling):
+
+```go
+	// in ChainSection:
+	VestingPercent     *int `toml:"vesting-percent"`
+	NumPermanentLocked *int `toml:"num-permanent-locked-accounts"`
+	// in applyLayer:
+	intf("vesting-percent", sec.VestingPercent, &c.VestingPercent)
+	intf("num-permanent-locked-accounts", sec.NumPermanentLocked, &c.NumPermanentLocked)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestConfigValidateVesting -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/config.go devnet/tests/gen-activity/main.go devnet/tests/gen-activity/config_test.go
+git commit -m "feat(gen-activity): -vesting-percent and -num-permanent-locked-accounts flags"
+```
+
+---
+
+## Task 4: Vesting selection + assignment
+
+**Files:**
+- Create: `devnet/tests/gen-activity/vesting.go`
+- Test: `devnet/tests/gen-activity/vesting_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `devnet/tests/gen-activity/vesting_test.go`:
+
+```go
+package main
+
+import (
+	"math/rand"
+	"testing"
+
+	"gen/tests/common"
+)
+
+func vestingRecs(n int) []*AccountRecord {
+	recs := make([]*AccountRecord, n)
+	for i := range recs {
+		recs[i] = &AccountRecord{AccountIdentity: common.AccountIdentity{
+			Name: "gen-acct", Address: "lumera1a",
+		}}
+	}
+	return recs
+}
+
+func TestPlanVestingSelectsPercentage(t *testing.T) {
+	recs := vestingRecs(10)
+	rng := rand.New(rand.NewSource(1))
+	selected := planVesting(recs, 30, "1000000ulume", rng, 1_700_000_000)
+	if len(selected) != 3 { // floor(10 * 30 / 100)
+		t.Fatalf("selected %d accounts, want 3", len(selected))
+	}
+	for _, rec := range selected {
+		if rec.Vesting == nil {
+			t.Fatalf("selected account %s has no Vesting info", rec.Name)
+		}
+		if rec.Vesting.Type != string(common.VestingContinuous) && rec.Vesting.Type != string(common.VestingDelayed) {
+			t.Errorf("vesting type = %q, want continuous or delayed", rec.Vesting.Type)
+		}
+		if rec.Vesting.Type == string(common.VestingContinuous) || rec.Vesting.Type == string(common.VestingDelayed) {
+			if rec.Vesting.EndTime <= 1_700_000_000 {
+				t.Errorf("end-time %d must be after now", rec.Vesting.EndTime)
+			}
+		}
+		if rec.Vesting.LockedAmount != "1000000ulume" {
+			t.Errorf("locked amount = %q, want 1000000ulume", rec.Vesting.LockedAmount)
+		}
+	}
+}
+
+func TestPlanVestingZeroPercentSelectsNone(t *testing.T) {
+	recs := vestingRecs(10)
+	rng := rand.New(rand.NewSource(1))
+	if selected := planVesting(recs, 0, "1000000ulume", rng, 1_700_000_000); len(selected) != 0 {
+		t.Errorf("0%% selected %d accounts, want 0", len(selected))
+	}
+}
+
+func TestNewPermanentLockedInfo(t *testing.T) {
+	info := newPermanentLockedInfo("5000000ulume")
+	if info.Type != string(common.VestingPermanentLocked) {
+		t.Errorf("type = %q, want permanent_locked", info.Type)
+	}
+	if info.EndTime != 0 {
+		t.Errorf("permanent-locked end-time = %d, want 0", info.EndTime)
+	}
+	if info.LockedAmount != "5000000ulume" {
+		t.Errorf("locked amount = %q, want 5000000ulume", info.LockedAmount)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestPlanVesting|TestNewPermanentLockedInfo' -v
+```
+
+Expected: FAIL — `undefined: planVesting`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `devnet/tests/gen-activity/vesting.go`:
+
+```go
+package main
+
+import (
+	"math/rand"
+
+	"gen/tests/common"
+)
+
+// vestingWindow bounds the random vesting end time: now + [1h, 30 days].
+const (
+	vestingMinSeconds int64 = 3600
+	vestingMaxSeconds int64 = 30 * 24 * 3600
+)
+
+// planVesting randomly designates floor(len*percent/100) of recs as vesting
+// accounts, assigning each a continuous or delayed type and a random end time in
+// the vesting window. rng and nowUnix are injected for deterministic tests.
+// Returns the selected records (whose .Vesting was set in place).
+func planVesting(recs []*AccountRecord, percent int, lockedAmount string, rng *rand.Rand, nowUnix int64) []*AccountRecord {
+	if percent <= 0 || len(recs) == 0 {
+		return nil
+	}
+	count := len(recs) * percent / 100
+	if count == 0 {
+		return nil
+	}
+	// Random subset via partial Fisher-Yates over a copy of indices.
+	idx := rng.Perm(len(recs))[:count]
+	selected := make([]*AccountRecord, 0, count)
+	for _, i := range idx {
+		rec := recs[i]
+		typ := common.VestingContinuous
+		if rng.Intn(2) == 0 {
+			typ = common.VestingDelayed
+		}
+		endTime := nowUnix + vestingMinSeconds + rng.Int63n(vestingMaxSeconds-vestingMinSeconds+1)
+		rec.Vesting = &VestingInfo{
+			Type:         string(typ),
+			EndTime:      endTime,
+			LockedAmount: lockedAmount,
+		}
+		selected = append(selected, rec)
+	}
+	return selected
+}
+
+// newPermanentLockedInfo builds the VestingInfo for a dedicated PermanentLocked
+// account (no end time).
+func newPermanentLockedInfo(lockedAmount string) *VestingInfo {
+	return &VestingInfo{
+		Type:         string(common.VestingPermanentLocked),
+		LockedAmount: lockedAmount,
+	}
+}
+
+// generatePermanentLockedAccounts creates `count` fresh keys named
+// "<prefix>-plock-NNNN", tags each with a permanent-locked VestingInfo, upserts
+// them into the registry, and returns the new records. Keys are created with the
+// detected key style; the accounts are NOT yet on-chain (the funding phase
+// creates them via create-permanent-locked-account). Rerun-safe.
+func generatePermanentLockedAccounts(cli *common.ChainCLI, reg *ActivityRegistry, accountPrefix string, count int, keyStyle common.KeyStyle, lockedAmount, now string) []*AccountRecord {
+	if count <= 0 {
+		return nil
+	}
+	names := reg.AllocateNames(accountPrefix+"-plock", count)
+	var recs []*AccountRecord
+	for _, name := range names {
+		var addr string
+		if cli.HasKey(name) {
+			a, err := cli.ShowAddress(name)
+			if err != nil {
+				continue
+			}
+			addr = a
+		} else {
+			gk, err := cli.AddKeyWithStyle(name, keyStyle)
+			if err != nil {
+				continue
+			}
+			addr = gk.Address
+		}
+		rec := &AccountRecord{
+			AccountIdentity: common.AccountIdentity{Name: name, Address: addr, KeyStyle: keyStyle.Name()},
+			Vesting:         newPermanentLockedInfo(lockedAmount),
+			CreatedAt:       now,
+			UpdatedAt:       now,
+		}
+		reg.UpsertAccount(rec)
+		recs = append(recs, rec)
+	}
+	return recs
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestPlanVesting|TestNewPermanentLockedInfo' -v
+```
+
+Expected: PASS for all three.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/vesting.go devnet/tests/gen-activity/vesting_test.go
+git commit -m "feat(gen-activity): vesting account selection + permanent-locked generation"
+```
+
+---
+
+## Task 5: Funding split + vesting funder
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/vesting.go`
+- Test: `devnet/tests/gen-activity/vesting_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/vesting_test.go`:
+
+```go
+func TestSplitFundingTargets(t *testing.T) {
+	reg := NewRegistry("c", "f", "", "legacy", "t")
+	reg.Accounts = []*AccountRecord{
+		{AccountIdentity: common.AccountIdentity{Name: "regular"}},                                   // bank
+		{AccountIdentity: common.AccountIdentity{Name: "msig"}, Multisig: &MultisigInfo{Threshold: 2}}, // bank (composite funded from funder)
+		{AccountIdentity: common.AccountIdentity{Name: "vest"}, Vesting: &VestingInfo{Type: "continuous"}}, // vesting
+		{AccountIdentity: common.AccountIdentity{Name: "plock"}, Vesting: &VestingInfo{Type: "permanent_locked"}}, // vesting
+		{AccountIdentity: common.AccountIdentity{Name: "already"}, Funded: true},                      // skipped
+	}
+	bank, vesting := splitFundingTargets(reg)
+
+	names := func(recs []*AccountRecord) []string {
+		var out []string
+		for _, r := range recs {
+			out = append(out, r.Name)
+		}
+		return out
+	}
+	gotBank := names(bank)
+	if len(gotBank) != 2 || gotBank[0] != "regular" || gotBank[1] != "msig" {
+		t.Errorf("bank targets = %v, want [regular msig]", gotBank)
+	}
+	gotVest := names(vesting)
+	if len(gotVest) != 2 || gotVest[0] != "vest" || gotVest[1] != "plock" {
+		t.Errorf("vesting targets = %v, want [vest plock]", gotVest)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestSplitFundingTargets -v
+```
+
+Expected: FAIL — `undefined: splitFundingTargets`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `devnet/tests/gen-activity/vesting.go` (add imports `fmt`, `log`, `time`):
+
+```go
+// splitFundingTargets divides unfunded accounts into those funded by the normal
+// batched bank-send (regular + multisig composites) and those funded by a
+// vesting create tx (any account carrying VestingInfo).
+func splitFundingTargets(reg *ActivityRegistry) (bank, vesting []*AccountRecord) {
+	for _, rec := range reg.Accounts {
+		if rec.Funded {
+			continue
+		}
+		if rec.Vesting != nil {
+			vesting = append(vesting, rec)
+		} else {
+			bank = append(bank, rec)
+		}
+	}
+	return bank, vesting
+}
+
+// fundVestingAccounts creates each vesting/locked account on-chain via the
+// appropriate create-* tx (funding the locked amount), then tops it up with a
+// small liquid amount so it can pay gas. Marks Funded on success. Failures are
+// logged and skipped (never fatal). Returns the count funded.
+func fundVestingAccounts(cli *common.ChainCLI, funderKey, funderAddr string, targets []*AccountRecord, liquidTopUp string) int {
+	funded := 0
+	for _, rec := range targets {
+		if rec.Vesting == nil {
+			continue
+		}
+		if err := createVestingOnChain(cli, funderKey, rec); err != nil {
+			log.Printf("  WARN: create vesting account %s: %v", rec.Name, err)
+			continue
+		}
+		// Liquid top-up so the locked account can pay fees / make small sends.
+		if _, err := cli.SubmitTx("tx", "bank", "send", funderAddr, rec.Address, liquidTopUp, "--from", funderKey); err != nil {
+			log.Printf("  WARN: top up vesting account %s: %v", rec.Name, err)
+			// Account exists and is locked; mark funded so it is recorded, but it
+			// may be unable to pay gas. Still counts as created.
+		}
+		rec.Funded = true
+		rec.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		funded++
+		log.Printf("  funded %s vesting account %s (%s)", rec.Vesting.Type, rec.Name, rec.Address)
+	}
+	return funded
+}
+
+// createVestingOnChain dispatches the correct create-* tx for the account's
+// vesting type.
+func createVestingOnChain(cli *common.ChainCLI, funderKey string, rec *AccountRecord) error {
+	switch rec.Vesting.Type {
+	case string(common.VestingContinuous):
+		_, err := cli.CreateVestingAccount(funderKey, rec.Address, rec.Vesting.LockedAmount, rec.Vesting.EndTime, false)
+		return err
+	case string(common.VestingDelayed):
+		_, err := cli.CreateVestingAccount(funderKey, rec.Address, rec.Vesting.LockedAmount, rec.Vesting.EndTime, true)
+		return err
+	case string(common.VestingPermanentLocked):
+		_, err := cli.CreatePermanentLockedAccount(funderKey, rec.Address, rec.Vesting.LockedAmount)
+		return err
+	default:
+		return fmt.Errorf("unknown vesting type %q for %s", rec.Vesting.Type, rec.Name)
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run TestSplitFundingTargets -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/vesting.go devnet/tests/gen-activity/vesting_test.go
+git commit -m "feat(gen-activity): funding split + vesting/locked account funder"
+```
+
+---
+
+## Task 6: Integrate vesting into `run()`
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/main.go`
+
+This task wires Tasks 4–5 into the runtime flow. No new unit test (it is I/O orchestration verified on devnet in Task 8); the gate is build + existing tests pass.
+
+- [ ] **Step 1: Tag regular accounts + generate permanent-locked accounts after key generation**
+
+In `devnet/tests/gen-activity/main.go` `run()`, immediately after the new-account key generation + first `reg.Save` (and after the multisig generation block from the multisig plan), add:
+
+```go
+	// Designate a random share of new regular accounts as vesting, and generate
+	// dedicated permanent-locked accounts. Tagged BEFORE funding so the funding
+	// split routes them to the vesting funder (vesting/locked accounts must be
+	// created at funding time — see design §3.5).
+	if !cfg.ActivityExisting {
+		lockedAmount := common.Coin{Amount: randomFundingAmount(cfg.maxAmount.Amount, rng), Denom: common.ChainDenom}.String()
+		if sel := planVesting(newRecs, cfg.VestingPercent, lockedAmount, rng, time.Now().Unix()); len(sel) > 0 {
+			log.Printf("designated %d/%d new account(s) as vesting", len(sel), len(newRecs))
+		}
+		if cfg.NumPermanentLocked > 0 {
+			plocked := generatePermanentLockedAccounts(cli, reg, cfg.AccountPrefix, cfg.NumPermanentLocked, keyStyle, lockedAmount, time.Now().UTC().Format(time.RFC3339))
+			log.Printf("generated %d permanent-locked account(s)", len(plocked))
+		}
+		if err := reg.Save(cfg.AccountsPath, time.Now().UTC().Format(time.RFC3339)); err != nil {
+			return fmt.Errorf("save registry after vesting designation: %w", err)
+		}
+	}
+```
+
+> Note: `rng` and `newRecs` already exist in `run()` (the funding RNG and the new account records). `planVesting` mutates `newRecs` entries in place, so the subsequent registry save persists the `Vesting` tags. Each vesting/locked account currently shares one `lockedAmount`; if you want per-account amounts, move the `randomFundingAmount` call inside `planVesting`/`generatePermanentLockedAccounts` — optional refinement, not required.
+
+- [ ] **Step 2: Replace the funding call with the split**
+
+In `run()`, replace the existing funding block:
+
+```go
+	targets := unfundedTargets(reg)
+	amountFor := func(*AccountRecord) string {
+		return common.Coin{Amount: randomFundingAmount(cfg.maxAmount.Amount, rng), Denom: common.ChainDenom}.String()
+	}
+	funded, fundErr := FundAccounts(chain, targets, amountFor, cfg.FundingBatchSize, 3)
+	log.Printf("funded %d/%d account(s)", funded, len(targets))
+```
+
+with:
+
+```go
+	bankTargets, vestingTargets := splitFundingTargets(reg)
+	amountFor := func(*AccountRecord) string {
+		return common.Coin{Amount: randomFundingAmount(cfg.maxAmount.Amount, rng), Denom: common.ChainDenom}.String()
+	}
+	funded, fundErr := FundAccounts(chain, bankTargets, amountFor, cfg.FundingBatchSize, 3)
+	log.Printf("funded %d/%d bank account(s)", funded, len(bankTargets))
+
+	// Vesting/locked accounts are created-and-funded via create-* txs + a liquid
+	// top-up so they can pay gas.
+	if len(vestingTargets) > 0 {
+		vfunded := fundVestingAccounts(cli, cfg.FundingKey, funderAddr, vestingTargets, vestingGasTopUp)
+		log.Printf("funded %d/%d vesting/locked account(s)", vfunded, len(vestingTargets))
+	}
+```
+
+Add the top-up constant near the top of `main.go`:
+
+```go
+// vestingGasTopUp is the small liquid balance sent to each vesting/locked
+// account so it can pay transaction fees (locked balances cannot cover gas).
+const vestingGasTopUp = "1000000ulume"
+```
+
+`FundAccounts` already takes `chain` (the `cliFundingChain`); leave it as-is. The `cli` and `funderAddr` variables already exist in `run()`.
+
+- [ ] **Step 3: Build and run the package tests**
+
+Run:
+
+```bash
+cd devnet && go build ./... && go test ./tests/gen-activity/ -v
+```
+
+Expected: builds clean; all gen-activity tests pass. Vesting/locked accounts now flow through the vesting funder, and (being `Funded`) are picked up by the existing `activityTargets` for the normal activity mix.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add devnet/tests/gen-activity/main.go
+git commit -m "feat(gen-activity): create + fund vesting/locked accounts in run()"
+```
+
+---
+
+## Task 7: Wizard entries
+
+**Files:**
+- Modify: `devnet/tests/gen-activity/wizard.go`
+- Test: `devnet/tests/gen-activity/wizard_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `devnet/tests/gen-activity/wizard_test.go`:
+
+```go
+func TestEditSettingVesting(t *testing.T) {
+	c := &Config{}
+	p := &fakePrompter{inputs: map[string]string{
+		"vesting-percent":               "25",
+		"num-permanent-locked-accounts": "3",
+	}}
+	if err := editSetting(c, settingVestingPercent, p); err != nil {
+		t.Fatalf("edit vesting-percent: %v", err)
+	}
+	if c.VestingPercent != 25 {
+		t.Errorf("VestingPercent = %d, want 25", c.VestingPercent)
+	}
+	if err := editSetting(c, settingNumPermLocked, p); err != nil {
+		t.Fatalf("edit num-permanent-locked: %v", err)
+	}
+	if c.NumPermanentLocked != 3 {
+		t.Errorf("NumPermanentLocked = %d, want 3", c.NumPermanentLocked)
+	}
+}
+
+func TestMenuItemsIncludeVesting(t *testing.T) {
+	items := menuItems(&Config{})
+	joined := ""
+	for _, it := range items {
+		joined += it + "\n"
+	}
+	for _, want := range []string{settingVestingPercent, settingNumPermLocked} {
+		found := false
+		for _, it := range items {
+			if menuKeyFromItem(it) == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("menu missing setting %q:\n%s", want, joined)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestEditSettingVesting|TestMenuItemsIncludeVesting' -v
+```
+
+Expected: FAIL — `undefined: settingVestingPercent`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `devnet/tests/gen-activity/wizard.go`, add the setting keys (in the existing `const` block of setting keys):
+
+```go
+	settingVestingPercent = "vesting-percent"
+	settingNumPermLocked  = "num-permanent-locked-accounts"
+```
+
+Add them to `editableSettings` (after `settingNumMultisig35`):
+
+```go
+	settingVestingPercent,
+	settingNumPermLocked,
+```
+
+Add cases to `settingValue`:
+
+```go
+	case settingVestingPercent:
+		return strconv.Itoa(c.VestingPercent)
+	case settingNumPermLocked:
+		return strconv.Itoa(c.NumPermanentLocked)
+```
+
+Add cases to `editSetting`:
+
+```go
+	case settingVestingPercent:
+		return editInt(c, key, "Vesting percent (0-100)", &c.VestingPercent, p)
+	case settingNumPermLocked:
+		return editInt(c, key, "Number of permanent-locked accounts", &c.NumPermanentLocked, p)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+cd devnet && go test ./tests/gen-activity/ -run 'TestEditSettingVesting|TestMenuItemsIncludeVesting' -v
+```
+
+Expected: PASS for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add devnet/tests/gen-activity/wizard.go devnet/tests/gen-activity/wizard_test.go
+git commit -m "feat(gen-activity): wizard entries for vesting-percent and permanent-locked count"
+```
+
+---
+
+## Task 8: Documentation + verification
+
+**Files:**
+- Modify: `docs/design/gen-activity-design.md`
+
+- [ ] **Step 1: Document vesting accounts**
+
+In `docs/design/gen-activity-design.md`, add a section:
+
+```markdown
+## Vesting accounts
+
+`-vesting-percent N` (0–100) randomly designates that share of the run's regular
+generated accounts as **vesting** accounts; each is randomly continuous or
+delayed (cliff) with an end time in now + [1h, 30d]. `-num-permanent-locked-accounts N`
+creates N dedicated **PermanentLocked** accounts (`<prefix>-plock-NNNN`).
+
+Because Cosmos-SDK rejects creating a vesting/locked account at an address that
+already exists, these accounts are created **at funding time** via
+`tx vesting create-vesting-account` / `create-permanent-locked-account` (funding
+the locked amount), then topped up with a small liquid balance so they can pay
+gas. They then participate in the normal activity mix (delegation can use locked
+coins; sends draw on the liquid top-up). Records carry `AccountRecord.Vesting`
+(type, end time, locked amount) under registry schema v2. The create helpers live
+in `devnet/tests/common/vesting.go`.
+```
+
+- [ ] **Step 2: Full verification sweep**
+
+Run:
+
+```bash
+cd devnet && go build ./... && go test ./tests/common/ ./tests/gen-activity/ -v
+cd /home/akobrin/p/lumera && make lint
+```
+
+Expected: all packages build; all unit tests pass; `make lint` reports 0 issues.
+
+- [ ] **Step 3: Exercise vesting generation (devnet)**
+
+Run (against a running devnet):
+
+```bash
+cd devnet/tests/gen-activity
+go run . -chain devnet -num-accounts 10 -vesting-percent 30 -num-permanent-locked-accounts 2
+```
+
+Expected: ~3 of the 10 regular accounts and 2 dedicated `plock` accounts appear in the accounts JSON with a `vesting` block; `lumerad query auth account <addr>` shows `ContinuousVestingAccount` / `DelayedVestingAccount` / `PermanentLockedAccount` types; the run completes without fatal errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/design/gen-activity-design.md
+git commit -m "docs(gen-activity): document vesting accounts"
+```
+
+---
+
+## Self-Review checklist (for the plan author)
+
+- **Spec coverage:** §3.5 account types + create helpers → Task 1; `VestingInfo` registry → Task 2; flags/validation → Task 3; `-vesting-percent` selection + `plock` generation → Task 4; funding split + funder → Tasks 5–6; activity inclusion → reuses existing `activityTargets` (Funded flag), noted in Task 6; wizard surface → Task 7; testing/docs/devnet verification → Task 8.
+- **Placeholder scan:** no TBDs. The Task 3 config-file note and Task 6 per-account-amount note are explicit optional refinements with exact code, not placeholders.
+- **Type consistency:** `VestingInfo{Type, EndTime, LockedAmount}` matches across registry.go, vesting.go, and tests; `common.VestingType` constants (`VestingContinuous`/`VestingDelayed`/`VestingPermanentLocked`) are used consistently; `planVesting(recs, percent, lockedAmount, rng, nowUnix)` and `splitFundingTargets(reg) (bank, vesting)` signatures match their tests; wizard `settingVestingPercent`/`settingNumPermLocked` match config field names `VestingPercent`/`NumPermanentLocked`.
+- **Dependency note:** assumes `AccountRecord.Multisig` and schema v2 from the multisig plan exist; `splitFundingTargets`'s test references `MultisigInfo`, so run after the multisig plan's Task 4.
+- **Coverage gap (intentional, called out):** the on-chain create+topup flow (`fundVestingAccounts`, `createVestingOnChain`) and `run()` wiring are verified on devnet (Task 8 Step 3), not by unit tests, since they require a live funder + chain. Pure logic (selection, split, arg builders) is unit-tested.
+```

--- a/docs/devnet/makefile-commands.md
+++ b/docs/devnet/makefile-commands.md
@@ -11,6 +11,8 @@ All targets are declared in `Makefile.devnet` and exposed through the root `Make
 | `make devnet-build-172` | Build using the `devnet/bin-v1.7.2` bundle and default configs to reproduce the v1.7.2 network. |
 | `make devnet-build-191` | Build using the `devnet/bin-v1.9.1` bundle. |
 | `make devnet-build-1111` | Build using the `devnet/bin-v1.11.1` bundle. |
+| `make devnet-stage-external-version VERSION=v1.12.0` | Stage a devnet locally from `devnet/bin-<VERSION>/` and an external genesis. Skips local Docker image build, disables Hermes through a staged config copy, and does not require a claims CSV unless `EXTERNAL_CLAIMS_FILE` is provided. |
+| `make devnet-new-remote-version VERSION=v1.12.0` | Stage locally from downloaded binaries, sync runtime files to `REMOTE_DEVNET_HOST`, and start the devnet there with Docker Compose. |
 | `make devnet-tests-build` | Build devnet test binaries (`tests_validator`, `tests_hermes`, `tests_evmigration`) into `devnet/bin/`. |
 | `make devnet-tests-lep6` | Run the LEP-6 storage-truth chain-side e2e tests against a running devnet. Requires `make devnet-up-detach`; uses existing registered supernodes or bootstraps validator-owned supernodes from key-resolvable devnet validator accounts when fewer than three are registered. |
 
@@ -90,10 +92,16 @@ Parallel variants (`devnet-evmigrationp-*`) run the same operations but use conc
 | --- | --- | --- |
 | `DEVNET_BIN_DIR` | `devnet/bin` | Directory containing binaries to copy into the devnet |
 | `DEVNET_BUILD_LUMERA` | `1` | Set to `0` to skip building lumerad during `devnet-build` |
+| `DEVNET_BUILD_TESTS` | `1` | Set to `0` to skip building devnet test helper binaries during `devnet-build` |
+| `DEVNET_DOCKER_BUILD` | `1` | Set to `0` to stage config and compose files without running `docker compose build` |
 | `CONFIG_JSON` | `devnet/default-config/config.json` | Path to chain config |
 | `VALIDATORS_JSON` | `devnet/default-config/validators.json` | Path to validator specs |
 | `EXTERNAL_GENESIS_FILE` | (none) | Path to pre-existing genesis to extend |
-| `EXTERNAL_CLAIMS_FILE` | (none) | Path to claims CSV |
+| `EXTERNAL_CLAIMS_FILE` | (none) | Optional path to claims CSV. If unset, no `claims.csv` is staged. |
+| `REMOTE_DEVNET_HOST` | `lumera-devnet` | SSH host used by `devnet-new-remote-version` |
+| `REMOTE_DEVNET_DIR` | `lumera-devnet` | Remote directory that receives the Docker Compose runtime files |
+| `REMOTE_DEVNET_STAGE_DIR` | `build/devnet-remote-stage/lumera-devnet-1` | Local workspace-owned staging directory used before syncing to the remote host |
+| `REMOTE_EXTERNAL_GENESIS_FILE` | `~/external-genesis/lumera-devnet-1/genesis.json` | Default external genesis used by `devnet-stage-external-version` when `EXTERNAL_GENESIS_FILE` is unset |
 | `NOCACHE` | (unset) | Set to `1` to force Docker rebuild without cache |
 
 ## Typical workflows

--- a/docs/evm-integration/user-guides/main.md
+++ b/docs/evm-integration/user-guides/main.md
@@ -12,6 +12,7 @@ This directory holds the operator- and end-user-facing documentation for living 
 | An end user with a legacy (coin-type 118) account | [migration.md](migration.md) | [migration-scripts.md](migration-scripts.md) if you have many accounts to batch |
 | A validator operator | [validator-migration.md](validator-migration.md) | [migration-scripts.md](migration-scripts.md) for the `migrate-validator.sh` wrapper |
 | A supernode operator | [supernode-migration.md](supernode-migration.md) | [migration.md](migration.md) for chain-level mechanics |
+| A Hermes IBC relayer operator | [relayer-migration.md](relayer-migration.md) | [migration-scripts.md](migration-scripts.md) for the `migrate-account.sh` wrapper |
 | A node operator (full node, sentry, public RPC) | [node-evm-config-guide.md](node-evm-config-guide.md) | [tune-guide.md](tune-guide.md) for parameter sizing |
 | A governance participant or chain steward | [tune-guide.md](tune-guide.md) | [node-evm-config-guide.md](node-evm-config-guide.md) for what each knob controls |
 
@@ -32,6 +33,10 @@ The validator-specific procedure: maintenance window planning against `downtime_
 ### [supernode-migration.md](supernode-migration.md) — Supernode Operator Migration
 
 Two paths to the same end state: **Path A** (the daemon migrates for you on restart once `evm_key_name` is set in `config.yml`) or **Path B** (you migrate via Portal/Keplr or the shell helpers first, then the daemon detects the on-chain record and just performs local cleanup). Covers the multisig refusal behavior — the daemon won't drive a K-of-N ceremony and points you to the offline `lumerad` CLI flow — plus troubleshooting for address-mismatch and proto-skew errors.
+
+### [relayer-migration.md](relayer-migration.md) — Hermes IBC Relayer Migration
+
+Migrating a Hermes relayer's Lumera signing account from legacy `secp256k1` to `eth_secp256k1`. The relayer is the one account where a **second tool** (Hermes) must re-derive the same key from the mnemonic, so the guide centers on the HD-path gotcha: Hermes' default `ethermint` derivation does *not* match lumerad's `m/44'/60'/0'/0/0`, so you must set `address_type = { derivation = 'ethermint', proto_type = { pk_type = '/cosmos.evm.crypto.v1.ethsecp256k1.PubKey' } }` and pass `--hd-path "m/44'/60'/0'/0/0"` to `hermes keys add`. Includes a mandatory derived-address gate before the irreversible migration, and the stop → migrate → re-key → restart sequence.
 
 ### [node-evm-config-guide.md](node-evm-config-guide.md) — Node Operator EVM Config
 

--- a/docs/evm-integration/user-guides/relayer-migration.md
+++ b/docs/evm-integration/user-guides/relayer-migration.md
@@ -1,0 +1,168 @@
+# Hermes IBC Relayer EVM Migration Guide
+
+**Last updated**: 2026-06-16
+**Applies to**: operators running a Hermes IBC relayer whose Lumera signing account is a legacy (coin-type 118 `secp256k1`) account, against an EVM-enabled Lumera chain (post-EVM upgrade)
+**Prerequisite reading**: [migration.md](migration.md) for the chain-level mechanics of legacy → EVM account migration
+
+---
+
+## Overview
+
+A Hermes relayer signs IBC packet/ack/timeout transactions on Lumera using a key in its own keyring (`~/.hermes/keys/<chain-id>/keyring-test/<key_name>.json`). If that account was created before the EVM upgrade it is a legacy `secp256k1` (coin-type 118) account, and it appears in `lumerad query evmigration legacy-accounts` until migrated.
+
+Migrating the relayer account is different from migrating a normal user account in one important way: **two independent tools must agree on the key.** `lumerad` performs the migration (it needs the destination key in its keyring to sign `MsgClaimLegacyAccount`), and **Hermes** must independently re-derive the *same* account from the *same* mnemonic so it can keep signing. Those two derivations only line up if you pin the HD path — see the gotcha below.
+
+> **This is a service-affecting, irreversible change.** The legacy relayer address is blocked after migration. Plan a short relaying pause, and do not migrate until the derivation gate (Step 3) passes.
+
+---
+
+## The HD-path gotcha (read this first)
+
+Lumera's EVM keys use `eth_secp256k1` at HD path `m/44'/60'/0'/0/0`. `lumerad keys add --coin-type 60 --algo eth_secp256k1` uses exactly that path.
+
+**Hermes' default `ethermint` derivation does NOT use `m/44'/60'/0'/0/0`.** Given the same mnemonic, Hermes' default and lumerad produce *different* Lumera addresses:
+
+| derivation | address (example) |
+| --- | --- |
+| `lumerad --coin-type 60 --algo eth_secp256k1` (path `m/44'/60'/0'/0/0`) | `lumera1ccvqdk…` |
+| `hermes keys add` (ethermint **default** path) | `lumera1addyff…` ❌ different |
+| `hermes keys add --hd-path "m/44'/60'/0'/0/0"` | `lumera1ccvqdk…` ✅ matches lumerad |
+
+**Always pass `--hd-path "m/44'/60'/0'/0/0"` to `hermes keys add`** for a Lumera EVM relayer key. Without it Hermes derives a key for a different address and will not control the migrated account.
+
+You must also tell Hermes the chain uses Ethereum-style keys, via `address_type` in `config.toml` (Step 1).
+
+---
+
+## Prerequisites
+
+- Hermes ≥ 1.10 (verified on 1.13.2) with `ethermint` address-type support.
+- The relayer mnemonic, or the legacy relayer key present in a `lumerad` keyring (to sign the migration).
+- A `lumerad` binary that supports `eth_secp256k1` (the EVM-era Lumera binary).
+- The migration window open on-chain (`lumerad query evmigration params` → `enable_migration: true`).
+
+Confirm the current relayer account is legacy:
+
+```bash
+# from the Hermes host
+ADDR=$(hermes keys list --chain lumera-mainnet-1 | grep ' relayer ' | grep -oE 'lumera1[0-9a-z]+' | head -1)
+lumerad query evmigration migration-record "$ADDR" --output json   # record.new_address empty == not migrated
+lumerad query auth account "$ADDR" --output json                   # pub_key type secp256k1 == true legacy
+```
+
+---
+
+## Procedure
+
+Throughout, `lumera-mainnet-1` is the chain id and `relayer` is the Hermes `key_name` for the Lumera chain — adjust to your config.
+
+### Step 1 — Tell Hermes the Lumera chain uses Ethereum-style keys
+
+Edit `~/.hermes/config.toml` and add `address_type` to the **Lumera** `[[chains]]` block:
+
+```toml
+[[chains]]
+id = 'lumera-mainnet-1'
+# … existing fields …
+key_name = 'relayer'
+address_type = { derivation = 'ethermint', proto_type = { pk_type = '/cosmos.evm.crypto.v1.ethsecp256k1.PubKey' } }
+```
+
+> The `proto_type.pk_type` is `'/cosmos.evm.crypto.v1.ethsecp256k1.PubKey'` for Cosmos EVM (v0.6.0). It is **not** `pid`, and it is **not** the ethermint `'/ethermint.crypto.v1.ethsecp256k1.PubKey'` URL.
+
+Validate:
+
+```bash
+hermes config validate    # must print: SUCCESS configuration is valid
+```
+
+### Step 2 — Create the EVM destination key in lumerad
+
+The migration's destination key must live in the **lumerad** keyring (alongside the legacy relayer key, so `claim-legacy-account` can sign). Create it and note its address:
+
+```bash
+lumerad keys add relayer-evm --coin-type 60 --algo eth_secp256k1 --keyring-backend test
+NEWADDR=$(lumerad keys show relayer-evm -a --keyring-backend test)
+echo "$NEWADDR"
+```
+
+Capture the mnemonic printed at creation — you need it for Hermes in Step 5. (Alternatively, generate the key inside Hermes in Step 3 and recover it into lumerad; either way the same mnemonic must end up in both keyrings.)
+
+### Step 3 — GATE: prove Hermes derives the same address
+
+Before the irreversible migration, confirm Hermes derives **exactly** `$NEWADDR` from the relayer mnemonic with the pinned path:
+
+```bash
+# pipe the mnemonic in; never write it to a shared path
+printf '%s\n' "$RELAYER_EVM_MNEMONIC" | \
+  hermes keys add --chain lumera-mainnet-1 --key-name relayer-evm-gate \
+    --mnemonic-file /dev/stdin --hd-path "m/44'/60'/0'/0/0"
+
+hermes keys list --chain lumera-mainnet-1 | grep relayer-evm-gate
+# the printed address MUST equal $NEWADDR. If it does not, STOP — do not migrate.
+hermes keys delete --chain lumera-mainnet-1 --key-name relayer-evm-gate
+```
+
+If the addresses differ, re-check Step 1 (`address_type`) and the `--hd-path`. **Do not proceed past this gate on a mismatch** — you would migrate funds to an account Hermes cannot sign for.
+
+### Step 4 — Pause relaying and migrate the account
+
+Stop the relayer so it does not sign with an account that is about to be blocked, then migrate. (`migrate-account.sh` is the bundled helper — see [migration-scripts.md](migration-scripts.md). Both keys must be in the same lumerad keyring.)
+
+```bash
+# stop the hermes process/container (resumes after Step 6)
+./scripts/migrate-account.sh relayer-legacy relayer-evm \
+  --chain-id lumera-mainnet-1 --node tcp://localhost:26657 --yes
+```
+
+`relayer-legacy` is the legacy relayer key in your lumerad keyring. Migration is fee-free; the full balance moves to `$NEWADDR`. Verify:
+
+```bash
+lumerad query evmigration migration-record <legacy-addr> --output json | jq '.record.new_address'  # == $NEWADDR
+lumerad query bank balances "$NEWADDR" --output json | jq '.balances'                               # funds present
+```
+
+### Step 5 — Replace the Hermes relayer key with the EVM key
+
+Back up and remove the old key, then import the EVM key under the relayer's `key_name`, **with the pinned path**:
+
+```bash
+cp ~/.hermes/keys/lumera-mainnet-1/keyring-test/relayer.json /tmp/relayer.json.bak
+hermes keys delete --chain lumera-mainnet-1 --key-name relayer
+
+printf '%s\n' "$RELAYER_EVM_MNEMONIC" | \
+  hermes keys add --chain lumera-mainnet-1 --key-name relayer \
+    --mnemonic-file /dev/stdin --hd-path "m/44'/60'/0'/0/0"
+
+hermes keys list --chain lumera-mainnet-1 | grep ' relayer '   # MUST show $NEWADDR
+```
+
+### Step 6 — Restart and verify
+
+```bash
+# restart the hermes process/container so it loads the ethermint config + new key
+hermes keys balance --chain lumera-mainnet-1     # SUCCESS balance for key `relayer`: <amount> ulume
+hermes health-check                              # chain lumera-mainnet-1 is healthy
+```
+
+Watch the logs for a few packets to confirm it signs and broadcasts cleanly. IBC clients, connections, and channels are **not** owned by the relayer account, so they are unaffected by the key change — Hermes just needs a funded, signable account.
+
+---
+
+## Rollback / abort
+
+- **Before Step 4 (migration):** fully reversible. Restore `address_type` removal in `config.toml`, restore `relayer.json` from backup if you touched it, delete `relayer-evm*` keys. Nothing on-chain changed.
+- **After Step 4:** the legacy address is permanently blocked; there is no rollback. The only recovery is forward — ensure Hermes holds the EVM key (Step 5) and is funded.
+
+Keep `/tmp/relayer.json.bak` only until Step 6 verifies; it is the now-blocked legacy key and a stray `.json` left in the `keyring-test/` directory can confuse Hermes' key loader — delete it once relaying is confirmed.
+
+---
+
+## Why this is fiddly (and the others aren't)
+
+For a normal user/validator/supernode migration, `lumerad` (or the supernode daemon) is the *only* signer, so its derivation never has to agree with anything external. The relayer is the one account where a **second tool** (Hermes) must reconstruct the same key from the mnemonic. That makes the HD path a hard requirement, not a convenience:
+
+- Same mnemonic + same path (`m/44'/60'/0'/0/0`) + same algo (`eth_secp256k1`) ⇒ same private key ⇒ same address.
+- Hermes' default ethermint path differs, so omitting `--hd-path` silently produces a *different* account — which is why the Step 3 gate exists.
+
+> **Runbook rule:** relayer/operator-key migration needs the key transferred (shared mnemonic with a pinned HD path, or an exported private key), not just "use the same seed." Always gate on a derived-address match before the irreversible migration step.

--- a/docs/superpowers/specs/2026-06-12-gen-activity-wizard-config-multisig-design.md
+++ b/docs/superpowers/specs/2026-06-12-gen-activity-wizard-config-multisig-design.md
@@ -1,0 +1,281 @@
+# gen-activity: config file, wizard mode, and multisig accounts
+
+**Date:** 2026-06-12
+**Status:** Approved (design)
+**Tool:** `devnet/tests/gen-activity` (Go module `gen`, package `main`)
+
+## 1. Goal
+
+Make the `tests-gen-activity` utility easier to drive against multiple chains and
+exercise multisig accounts. Three capabilities:
+
+1. A `gen-activity-config.toml` file predefining named chains (devnet, testnet,
+   mainnet) plus a shared `[common]` section, selectable with `-chain`.
+2. An interactive wizard that is the **default** when the tool is run with no
+   flags; passing any flag runs the existing non-interactive command-line mode.
+3. Generation of K-of-N multisig accounts (`-num-multisig23-accounts` = 2-of-3,
+   `-num-multisig35-accounts` = 3-of-5) that are created, funded, and exercised.
+   The generic multisig ceremony is extracted from `devnet/tests/evmigration`
+   into the shared `devnet/tests/common` package and used by both tools.
+
+Non-goals: changing the existing activity mix for regular accounts; changing the
+evmigration proof flow (`generate/sign/combine/submit-proof`), its vesting
+fixtures, or its validator-discovery logic.
+
+## 2. Background / current state
+
+- `gen-activity` is built on the unit-tested `common.ChainCLI` shell-out
+  abstraction and wraps it behind small interfaces (`fundingChain`,
+  `activityChain`) with fakes. Config today is a flat flag struct
+  (`config.go`) validated in `Config.Validate()`.
+- `evmigration/multisig.go` implements the generic multisig primitives
+  (`keys add --multisig --nosort`; the `sign×K → multisign → broadcast`
+  ceremony; the 1-ulume pubkey self-send) *and* migration-specific proof logic.
+  It is coupled to package globals (`*flagBin`, `*flagHome`, `*flagChainID`,
+  `*flagGas`, `*flagGasPrices`, `*flagRPC`) and free helpers (`runTx`,
+  `getAddress`, `queryAccountNumberAndSequence`, `waitForTxResult`, …).
+- `pelletier/go-toml/v2` and `golang.org/x/term` are already present (indirect)
+  in `devnet/go.mod`. There is no TUI/prompt library in the `gen` module.
+
+## 3. Design
+
+### 3.1 Config file + chain selection
+
+New file `configfile.go` in the gen-activity package. Parse with
+`github.com/pelletier/go-toml/v2` (promote from indirect to direct dependency).
+
+Schema:
+
+```toml
+[common]
+bin = "lumerad"
+home = "~/.lumera"
+keyring-backend = "test"
+funding-key = "faucet"
+evm-cutover-version = "v1.20.0"
+account-prefix = "gen"
+max-account-amount = "10000000ulume"
+parallelism = 5
+funding-batch-size = 10
+actions = true
+
+[chains.devnet]
+rpc = "tcp://localhost:26657"
+grpc = "localhost:9090"
+chain-id = "lumera-devnet-1"
+accounts = "devnet/tests/gen-activity/accounts-devnet.json"
+
+[chains.testnet]
+rpc = "https://rpc.testnet.lumera.io:443"
+grpc = "grpc.testnet.lumera.io:443"
+chain-id = "lumera-testnet-1"
+accounts = "devnet/tests/gen-activity/accounts-testnet.json"
+
+[chains.mainnet]
+rpc = "https://rpc.lumera.io:443"
+grpc = "grpc.lumera.io:443"
+chain-id = "lumera-mainnet-1"
+accounts = "devnet/tests/gen-activity/accounts-mainnet.json"
+```
+
+Any key valid in `[common]` may be overridden inside a `[chains.X]` section.
+TOML keys mirror the existing CLI flag names (kebab-case) so config and flags map
+one-to-one.
+
+New flags:
+- `-config <path>` — config file path. Default `gen-activity-config.toml` in the
+  current working directory. A missing file is **not** an error: the tool then
+  behaves exactly as today (pure flag-driven).
+- `-chain <name>` — selects a `[chains.<name>]` section.
+
+**Precedence** (lowest to highest):
+
+1. Built-in flag defaults (as registered in `configureFlags`).
+2. `[common]` section.
+3. `[chains.<name>]` section (when `-chain` is set).
+4. Explicitly-set CLI flags.
+
+Implementation: after `flag.Parse()`, collect the set of explicitly-set flag
+names with `FlagSet.Visit`. Build the effective `Config` by starting from the
+parsed flags (which already hold defaults), then for every field whose flag was
+**not** explicitly set, overlay the config value if the config provides one
+(chain section overriding common section). Fields whose flag *was* set on the
+command line are left untouched. This is the linchpin that lets config files
+populate values without clobbering explicit CLI overrides, working around the
+fact that Go's `flag` cannot distinguish a default from an explicit value.
+
+`Config.Validate()` is unchanged and runs after layering.
+
+### 3.2 Mode selection + wizard
+
+**Mode rule** (in `main`/`parseFlags`):
+
+- `flag.NFlag() == 0` (no flags set) → **wizard mode** (new default).
+- Any flag set → **command-line mode** (current behavior; backward compatible).
+- `-w` / `-wizard` → force wizard even when other flags are present; those flags
+  pre-seed the wizard's defaults (e.g. `gen-activity -w -chain testnet`).
+
+New file `wizard.go` using `github.com/AlecAivazis/survey/v2`.
+
+A `prompter` interface decouples the wizard's control flow from survey so the
+menu state machine is unit-testable with scripted answers:
+
+```go
+type prompter interface {
+    SelectOne(label string, options []string, def string) (string, error)
+    Input(label, def string) (string, error)
+    Confirm(label string, def bool) (bool, error)
+}
+```
+
+The production implementation calls survey; tests inject a scripted fake.
+
+Flow:
+
+1. **Chain picker.** If a config file with `[chains.*]` exists, `SelectOne` over
+   the chain names. The chosen chain's effective config becomes the starting
+   defaults. If no config file exists, present a single "manual" entry that
+   prompts for rpc / grpc / chain-id by hand and offers to save them as a chain
+   section in a new config file.
+2. **Settings menu.** `SelectOne` over editable settings, each rendered with its
+   current value, plus `▶ Run now` and `Quit` entries. Selecting a setting
+   re-prompts (`Input` / `Confirm` / `SelectOne` as appropriate) and returns to
+   the menu. Editable settings: funding-key, mode (fresh / add-accounts /
+   activity-existing), num-accounts, num-multisig23-accounts,
+   num-multisig35-accounts, accounts path, parallelism, actions,
+   funding-batch-size, max-account-amount, dry-run.
+3. **Run.** `▶ Run now` validates (`Config.Validate`) and calls the same
+   `run(cfg)` entry point as command-line mode. `Quit` exits without changes.
+
+The wizard only assembles a `Config`; all execution stays in the existing
+`run(cfg)` path, so wizard and CLI modes share one code path.
+
+### 3.3 Multisig extraction → `common`
+
+New file `devnet/tests/common/multisig.go` (+ `multisig_test.go`) holding the
+generic ceremony, built on `ChainCLI`. To stay unit-testable without a live
+chain, the helpers depend on a minimal runner interface that `ChainCLI`
+satisfies (exposing the raw `Run`, tx submission, account number/sequence,
+tx-inclusion wait, key existence/address lookup, and the bin/home/chain-id/
+gas/gas-prices/keyring-backend it needs to build args). Exact interface shape is
+finalized during implementation via TDD; it must preserve the current CLI
+semantics: `--nosort` on `keys add --multisig`, `--multisig <addr>` +
+`--sign-mode amino-json` on `tx sign`, and `tx multisign` consuming the first K
+signature files.
+
+Exported helpers (names indicative):
+
+- `CreateMultisigKey(name string, members []string, threshold int) (addr string, err error)`
+  — rerun-safe `keys add --multisig --nosort`; reuses an existing composite.
+- `EnsureMultisigMembers(names []string, style KeyStyle) error`
+  — key-style-aware member key generation via the existing `AddKeyWithStyle`.
+- `RegisterMultisigPubKey(name, addr string, members []string, threshold int) error`
+  — the 1-ulume self-send ceremony that publishes the composite pubkey on-chain.
+- `BuildUnsignedTx(...)` — generate-only unsigned-tx helper.
+- `SignAndBroadcastMultisig(unsignedFile, name, addr string, members []string, threshold int) (txHash string, err error)`
+  — `sign×K → multisign → broadcast`, waits for inclusion.
+
+**evmigration refactor.** `ensureMultisigCompositeKey`, `ensureMultisigMembers`,
+`registerMultisigPubKey`, `signAndBroadcastMultisigTx`,
+`buildUnsignedMultisigBankSendTx`, and `buildUnsignedMultisigDelegateTx` become
+thin adapters that construct a `ChainCLI` from the existing `*flag*` globals and
+delegate to the common helpers. The proof flow
+(`runFourStepMigrationMultisig`, `runSignProofBoth`), the permanent-locked
+vesting fixture, and validator discovery stay in `evmigration`. The standalone
+`multisig` / `multisig-vesting` / `multisig-validator` modes keep working
+unchanged. Existing evmigration unit tests must stay green; the live multisig
+modes remain integration/devnet-exercised.
+
+### 3.4 Multisig accounts in gen-activity
+
+New flags / config keys: `-num-multisig23-accounts` (2-of-3),
+`-num-multisig35-accounts` (3-of-5), default 0 each.
+
+**Registry schema v2.** `AccountRecord` gains an optional field:
+
+```go
+type MultisigInfo struct {
+    MemberNames []string `json:"member_names"`
+    Threshold   int      `json:"threshold"`
+    Signers     int      `json:"signers"`
+}
+// AccountRecord gains: Multisig *MultisigInfo `json:"multisig,omitempty"`
+```
+
+`schemaVersion` bumps to 2. v1 files still load: a record with a nil `Multisig`
+is a regular account, so v1 and v2 files are forward/backward compatible without
+a migration step. The loader accepts schema_version 1 or 2.
+
+**Naming.** Composite keys: `<prefix>-msig23-NNNN` / `<prefix>-msig35-NNNN`;
+member keys `<composite>-signer-<i>`. `AllocateNames` is generalized to allocate
+per-kind names continuing past the highest existing index for that prefix.
+
+**Flow integration in `run()`:**
+
+1. Generate composites: create member keys (`EnsureMultisigMembers` with the
+   detected key style) and the composite (`CreateMultisigKey`). Upsert into the
+   registry and `Save` before funding (interrupt-safe, matching the existing
+   key-then-save ordering).
+2. Fund composites from the funder, alongside regular accounts (they are
+   `unfundedTargets`).
+3. `RegisterMultisigPubKey` for each funded composite so it can sign.
+4. **Exercise:** one multisign bank-send to a peer address
+   (`sign×K → multisign → broadcast`), recorded in the account's activity log.
+   Each composite's ceremony runs sequentially (single account sequence);
+   composites participate in the existing worker pool at the configured
+   parallelism.
+
+Multisig accounts honor `-add-accounts` and `-activity-existing` the same way
+regular accounts do. Multisig composites are funded from the funder (not by
+transfer from a generated account), and the exercise is a single multisign
+bank-send (not the full delegate/grant suite) to bound ceremony cost.
+
+## 4. Testing (TDD)
+
+Unit tests (no live chain, no TTY):
+
+- Config layering: precedence order and the `flag.Visit` "explicit beats config"
+  rule; TOML parse of `[common]` + `[chains.*]`; missing-file ⇒ pure-flag path.
+- Wizard: menu state machine driven by a scripted `prompter` fake — chain
+  selection, editing each setting type, Run vs Quit.
+- Common multisig helpers: argument construction and ceremony orchestration
+  against a fake runner (assert `--nosort`, `--multisig`, `amino-json`, first-K
+  signature files).
+- Registry: schema-v2 round-trip and v1 backward-compatible load; `MultisigInfo`
+  serialization; multisig name allocation continuing past existing indices.
+- evmigration: existing unit tests stay green after the refactor.
+
+Live/devnet exercise (manual or existing harness): a bare-config run that
+creates, funds, and exercises 2-of-3 and 3-of-5 accounts; the evmigration
+`multisig` modes still pass end-to-end.
+
+## 5. Dependencies, docs, build
+
+- `devnet/go.mod`: promote `github.com/pelletier/go-toml/v2` to a direct
+  dependency; add `github.com/AlecAivazis/survey/v2`; run `go mod tidy` in the
+  `devnet` module.
+- Commit a `gen-activity-config.toml.example` documenting the schema.
+- Update `docs/design/gen-activity-design.md` to describe config, wizard, and
+  multisig accounts.
+- `make lint` must pass cleanly (0 issues) after all changes.
+
+## 6. File-change summary
+
+New:
+- `devnet/tests/gen-activity/configfile.go` (+ `_test.go`)
+- `devnet/tests/gen-activity/wizard.go` (+ `_test.go`)
+- `devnet/tests/common/multisig.go` (+ `_test.go`)
+- `gen-activity-config.toml.example`
+
+Modified:
+- `devnet/tests/gen-activity/config.go` — new fields (`Config`-side of config
+  file, chain, multisig counts), validation for multisig counts.
+- `devnet/tests/gen-activity/main.go` — flag registration, mode selection,
+  config layering, multisig generation/funding/exercise in `run()`.
+- `devnet/tests/gen-activity/registry.go` — schema v2, `MultisigInfo`,
+  name allocation.
+- `devnet/tests/gen-activity/chain.go` / `funder.go` — multisig funding +
+  exercise plumbing as needed.
+- `devnet/tests/evmigration/multisig.go` — delegate generic ceremony to common.
+- `devnet/go.mod` / `devnet/go.sum` — deps.
+- `docs/design/gen-activity-design.md` — documentation.

--- a/docs/superpowers/specs/2026-06-12-gen-activity-wizard-config-multisig-design.md
+++ b/docs/superpowers/specs/2026-06-12-gen-activity-wizard-config-multisig-design.md
@@ -202,9 +202,9 @@ type MultisigInfo struct {
 // AccountRecord gains: Multisig *MultisigInfo `json:"multisig,omitempty"`
 ```
 
-`schemaVersion` bumps to 2. v1 files still load: a record with a nil `Multisig`
-is a regular account, so v1 and v2 files are forward/backward compatible without
-a migration step. The loader accepts schema_version 1 or 2.
+`schemaVersion` bumps to 2 and the loader expects 2 — no backward compatibility
+with v1 registry files is required (existing `accounts.json` files can be
+regenerated). A record with a nil `Multisig` is simply a regular account.
 
 **Naming.** Composite keys: `<prefix>-msig23-NNNN` / `<prefix>-msig35-NNNN`;
 member keys `<composite>-signer-<i>`. `AllocateNames` is generalized to allocate
@@ -241,13 +241,18 @@ Unit tests (no live chain, no TTY):
 - Common multisig helpers: argument construction and ceremony orchestration
   against a fake runner (assert `--nosort`, `--multisig`, `amino-json`, first-K
   signature files).
-- Registry: schema-v2 round-trip and v1 backward-compatible load; `MultisigInfo`
-  serialization; multisig name allocation continuing past existing indices.
+- Registry: schema-v2 round-trip (loader expects v2; no v1 compat required);
+  `MultisigInfo` serialization; multisig name allocation continuing past
+  existing indices.
 - evmigration: existing unit tests stay green after the refactor.
 
+Post-refactor verification of the evmigration tools: after delegating the
+generic ceremony to `common`, run the evmigration unit tests and exercise the
+`multisig` / `multisig-vesting` / `multisig-validator` modes (devnet/integration)
+to confirm nothing is broken.
+
 Live/devnet exercise (manual or existing harness): a bare-config run that
-creates, funds, and exercises 2-of-3 and 3-of-5 accounts; the evmigration
-`multisig` modes still pass end-to-end.
+creates, funds, and exercises 2-of-3 and 3-of-5 accounts.
 
 ## 5. Dependencies, docs, build
 

--- a/docs/superpowers/specs/2026-06-12-gen-activity-wizard-config-multisig-design.md
+++ b/docs/superpowers/specs/2026-06-12-gen-activity-wizard-config-multisig-design.md
@@ -1,4 +1,4 @@
-# gen-activity: config file, wizard mode, and multisig accounts
+# gen-activity: config file, wizard mode, multisig + vesting accounts
 
 **Date:** 2026-06-12
 **Status:** Approved (design)
@@ -7,7 +7,7 @@
 ## 1. Goal
 
 Make the `tests-gen-activity` utility easier to drive against multiple chains and
-exercise multisig accounts. Three capabilities:
+exercise multisig and vesting accounts. Four capabilities:
 
 1. A `gen-activity-config.toml` file predefining named chains (devnet, testnet,
    mainnet) plus a shared `[common]` section, selectable with `-chain`.
@@ -17,10 +17,17 @@ exercise multisig accounts. Three capabilities:
    `-num-multisig35-accounts` = 3-of-5) that are created, funded, and exercised.
    The generic multisig ceremony is extracted from `devnet/tests/evmigration`
    into the shared `devnet/tests/common` package and used by both tools.
+4. Generation of vesting accounts created **at funding time**: a random share of
+   regular accounts created as continuous/delayed vesting (`-vesting-percent`),
+   plus a dedicated set of PermanentLocked accounts
+   (`-num-permanent-locked-accounts`). Vesting-create helpers live in
+   `devnet/tests/common`.
 
 Non-goals: changing the existing activity mix for regular accounts; changing the
-evmigration proof flow (`generate/sign/combine/submit-proof`), its vesting
-fixtures, or its validator-discovery logic.
+evmigration proof flow (`generate/sign/combine/submit-proof`) or its
+validator-discovery logic. Converting an already-funded/active account into a
+vesting or locked account post-hoc is **out of scope and infeasible** on a stock
+Cosmos-SDK chain (see §3.5).
 
 ## 2. Background / current state
 
@@ -230,6 +237,59 @@ regular accounts do. Multisig composites are funded from the funder (not by
 transfer from a generated account), and the exercise is a single multisign
 bank-send (not the full delegate/grant suite) to bound ceremony cost.
 
+### 3.5 Vesting accounts
+
+**SDK constraint.** Cosmos-SDK `x/vesting` creates a vesting or permanent-locked
+account *as part of funding it*: `MsgCreateVestingAccount` /
+`MsgCreatePermanentLockedAccount` reject a destination that already exists
+on-chain. You therefore cannot convert a base account that has already received
+funds or done activity into a vesting/locked account. gen-activity creates all
+vesting/locked accounts at funding time, before any activity.
+
+**Account types created** (via the stock CLI):
+
+- **Continuous vesting** — `tx vesting create-vesting-account <to> <amount>
+  <end-unix>` (linear unlock from block time to end).
+- **Delayed (cliff) vesting** — same command with `--delayed` (all unlocks at
+  end).
+- **Permanent locked** — `tx vesting create-permanent-locked-account <to>
+  <amount>` (never unlocks).
+
+Periodic vesting is out of scope (requires a periods JSON file; YAGNI).
+
+**New flags / config keys:**
+
+- `-vesting-percent` (int 0–100, default 0): the percentage of the run's regular
+  generated accounts to randomly designate as vesting. Each selected account is
+  randomly assigned continuous or delayed, with an end time randomly chosen in a
+  fixed window (now + [1h, 30d]).
+- `-num-permanent-locked-accounts` (int, default 0): a dedicated count of
+  PermanentLocked accounts (named `<prefix>-plock-NNNN`), separate from the
+  regular pool.
+
+**Funding split.** Regular (non-vesting) accounts keep the existing batched
+bank-send funding path. Vesting and permanent-locked accounts are funded by the
+funder via the appropriate `create-*` tx for the locked amount, then topped up
+with a small liquid bank-send so they can pay gas (locked balances cannot cover
+fees). Both steps are funder-signed. An account is marked `Funded` only after
+both succeed.
+
+**Activity.** Vesting and locked accounts participate in the normal activity mix:
+delegation can use locked coins; bank sends/grants draw on the liquid top-up.
+They are added to the activity targets like regular funded accounts.
+
+**Registry (schema v2).** `AccountRecord` gains an optional
+`Vesting *VestingInfo { Type string; EndTime int64; LockedAmount string }`
+(`Type` ∈ `continuous` | `delayed` | `permanent_locked`). A nil `Vesting` is a
+plain account. This shares the v2 bump already introduced for multisig; an
+account is never both multisig and vesting.
+
+**Shared helpers.** The `create-vesting-account` / `create-permanent-locked-account`
+argument builders and funder-signed wrappers live in
+`devnet/tests/common/vesting.go`, mirroring the multisig extraction. Converging
+evmigration's existing permanent-locked fixture onto these helpers is an optional
+follow-up, not required by this design.
+
 ## 4. Testing (TDD)
 
 Unit tests (no live chain, no TTY):
@@ -242,8 +302,12 @@ Unit tests (no live chain, no TTY):
   against a fake runner (assert `--nosort`, `--multisig`, `amino-json`, first-K
   signature files).
 - Registry: schema-v2 round-trip (loader expects v2; no v1 compat required);
-  `MultisigInfo` serialization; multisig name allocation continuing past
-  existing indices.
+  `MultisigInfo` / `VestingInfo` serialization; multisig and `plock` name
+  allocation continuing past existing indices.
+- Common vesting helpers: argument construction (continuous vs `--delayed` vs
+  permanent-locked; end-time formatting) against a fake runner.
+- Vesting selection: with an injected RNG, `-vesting-percent` selects the right
+  count and assigns a continuous/delayed type + end-time deterministically.
 - evmigration: existing unit tests stay green after the refactor.
 
 Post-refactor verification of the evmigration tools: after delegating the
@@ -269,18 +333,25 @@ creates, funds, and exercises 2-of-3 and 3-of-5 accounts.
 New:
 - `devnet/tests/gen-activity/configfile.go` (+ `_test.go`)
 - `devnet/tests/gen-activity/wizard.go` (+ `_test.go`)
+- `devnet/tests/gen-activity/multisig.go` (+ `_test.go`)
+- `devnet/tests/gen-activity/vesting.go` (+ `_test.go`)
 - `devnet/tests/common/multisig.go` (+ `_test.go`)
+- `devnet/tests/common/vesting.go` (+ `_test.go`)
 - `gen-activity-config.toml.example`
 
 Modified:
-- `devnet/tests/gen-activity/config.go` — new fields (`Config`-side of config
-  file, chain, multisig counts), validation for multisig counts.
+- `devnet/tests/gen-activity/config.go` — new fields (config file, chain,
+  multisig counts, `-vesting-percent`, `-num-permanent-locked-accounts`) and
+  their validation.
 - `devnet/tests/gen-activity/main.go` — flag registration, mode selection,
-  config layering, multisig generation/funding/exercise in `run()`.
+  config layering, multisig + vesting generation/funding/exercise in `run()`.
 - `devnet/tests/gen-activity/registry.go` — schema v2, `MultisigInfo`,
-  name allocation.
-- `devnet/tests/gen-activity/chain.go` / `funder.go` — multisig funding +
-  exercise plumbing as needed.
+  `VestingInfo`, name allocation.
+- `devnet/tests/gen-activity/chain.go` / `funder.go` — multisig + vesting
+  funding/exercise plumbing as needed.
 - `devnet/tests/evmigration/multisig.go` — delegate generic ceremony to common.
 - `devnet/go.mod` / `devnet/go.sum` — deps.
 - `docs/design/gen-activity-design.md` — documentation.
+
+Plans (in `docs/design/`): `gen-activity-config-wizard-plan.md`,
+`gen-activity-multisig-plan.md`, `gen-activity-vesting-plan.md`.

--- a/docs/superpowers/specs/2026-06-16-gen-activity-migrate-mode-design.md
+++ b/docs/superpowers/specs/2026-06-16-gen-activity-migrate-mode-design.md
@@ -194,6 +194,25 @@ legacy and new sides with enough signers, combine, submit proof. The shared
 package should reuse the multisig extraction already planned for gen-activity
 and evmigration.
 
+**Member-key portability.** The proof flow signs with the legacy multisig member
+sub-keys, which (unlike a single-sig account's key) cannot be derived on the fly.
+Generation therefore persists each member's mnemonic in
+`MultisigInfo.Members[]` (alongside the existing `member_names`), so migrate mode
+can re-import any missing member key into a fresh keyring before the ceremony —
+giving multisig the same portability single-sig already has. Before creating any
+destination keys, migrate mode pre-flights member-key presence: it imports
+missing keys from their stored mnemonics, and if a key is missing with no
+recoverable mnemonic it fails that account fast with an actionable message
+(rather than the keeper's opaque "key not found"/signature errors) and creates no
+orphan destination keys. Registries generated before this change carry only
+`member_names`; those accounts must be migrated from the keyring that generated
+them.
+
+**Chain-id in the proof.** `generate-proof-payload` MUST be invoked with
+`--chain-id`: the chain id is part of the signed proof payload, and omitting it
+makes the CLI fall back to the bech32 prefix, so every signature fails on-chain
+verification.
+
 ## 8. Parallel Execution
 
 Use a worker pool:

--- a/docs/superpowers/specs/2026-06-16-gen-activity-migrate-mode-design.md
+++ b/docs/superpowers/specs/2026-06-16-gen-activity-migrate-mode-design.md
@@ -1,0 +1,242 @@
+# gen-activity: migrate mode for generated live-chain accounts
+
+**Date:** 2026-06-16
+**Status:** Approved (design)
+**Tools:** `devnet/tests/gen-activity`, `devnet/tests/evmigration`
+
+## 1. Goal
+
+Add an explicit migration mode to `tests-gen-activity` so accounts created by
+the live-chain activity generator can be migrated in parallel after the EVM
+cutover.
+
+The design follows option 1 from the discussion: `tests-gen-activity` owns the
+live-chain user experience and its registry, while reusable migration primitives
+are extracted from `devnet/tests/evmigration` into shared Go code. The existing
+`tests_evmigration` binary keeps its devnet scenario modes and reuses the same
+shared migration package.
+
+## 2. Background
+
+`tests_evmigration` is scenario-oriented. It assumes the devnet docker layout,
+predefined accounts, validator-local execution, and a migration-specific
+accounts file.
+
+`tests-gen-activity` is live-chain-oriented. It already has chain config,
+registry management, a wizard-style UI, funding/activity generation, and can be
+run against devnet, testnet, or mainnet-like environments. Its registry records
+the generated keys, mnemonics, key style, multisig metadata, vesting metadata,
+and activity log.
+
+The two tools already share identity/activity structs and some helpers. Migration
+logic should be shared too, but the tool-level orchestration should stay
+separate because the operating assumptions differ.
+
+## 3. Non-Goals
+
+- Do not fold `tests_evmigration` into `tests-gen-activity`.
+- Do not make normal account/activity generation implicitly migrate accounts.
+- Do not expose devnet validator migration through the gen-activity wizard.
+- Do not require a funder key for migration mode; ordinary account migration
+  signs with the legacy account and uses evmigration fee handling.
+- Do not support unsafe concurrent writes to the gen-activity registry.
+
+## 4. User Interface
+
+Add a first-class mode flag:
+
+```bash
+tests-gen-activity -mode=migrate \
+  -chain devnet \
+  -accounts devnet/tests/gen-activity/accounts.json \
+  -parallelism 10 \
+  -dry-run=false
+```
+
+The existing default wizard should include `migrate` in the run-mode selector.
+When `migrate` is selected, hide fields that are not relevant to migration:
+
+- funding key
+- number of accounts
+- account prefix
+- max account amount
+- multisig creation counts
+- vesting creation settings
+- add-accounts / activity-existing
+- action settings
+- funding batch size
+
+The migrate-mode wizard should keep only:
+
+- chain/config selection
+- RPC / gRPC / chain ID / home / keyring backend
+- accounts registry path
+- parallelism
+- dry-run
+
+`parallelism` controls concurrent migration workers. `dry-run=true` prints the
+planned migration set, already-migrated skips, and estimated tx types without
+creating keys, submitting txs, or mutating the registry.
+
+## 5. Shared Migration Package
+
+Create a reusable migration package under `devnet/tests`, for example
+`devnet/tests/migration`. It should depend on `devnet/tests/common` for
+`ChainCLI`, key style, account identity, activity structs, and JSON helpers.
+
+Shared package responsibilities:
+
+- query `evmigration params`
+- query `migration-record`
+- query `migration-estimate`
+- derive/import EVM destination keys from legacy mnemonics
+- create destination multisig keys and run the proof flow
+- submit single-sig claim migrations
+- submit multisig proof migrations
+- wait for tx inclusion
+- verify migration record and selected post-migration invariants
+- classify outcomes as migrated, already migrated, skipped, or failed
+
+`tests_evmigration` should call this package from its existing modes instead of
+owning all migration helpers locally. Devnet-specific behavior remains in
+`tests_evmigration`: prepare mode, validator-local discovery, validator
+migration, scenario reports, and devnet-only assertions.
+
+## 6. gen-activity Registry Changes
+
+Extend `AccountRecord` with migration metadata:
+
+```go
+type MigrationInfo struct {
+    NewName     string `json:"new_name,omitempty"`
+    NewAddress  string `json:"new_address,omitempty"`
+    TxHash      string `json:"tx_hash,omitempty"`
+    Height      int64  `json:"height,omitempty"`
+    MigratedAt  string `json:"migrated_at,omitempty"`
+    Status      string `json:"status,omitempty"` // migrated, already_migrated, skipped, failed
+    Error       string `json:"error,omitempty"`
+}
+```
+
+The existing top-level record can either embed these fields directly or place
+them under `migration`. Prefer `migration` to avoid mixing generation metadata
+with migration state:
+
+```go
+Migration *MigrationInfo `json:"migration,omitempty"`
+```
+
+A record is eligible when:
+
+- `KeyStyle == "legacy"` or the address resolves to a legacy account on-chain
+- a mnemonic or multisig signer metadata exists
+- there is no successful migration metadata, or the chain does not yet show the
+  matching migration record
+
+The mode must be rerunnable. If an account is already migrated on-chain, update
+the registry with `Status: "already_migrated"` and the observed new address.
+
+## 7. Account Types
+
+Migration mode should target all account types created by `tests-gen-activity`:
+
+- regular single-sig accounts
+- continuous/delayed vesting accounts
+- permanent-locked accounts
+- generated multisig accounts
+
+Single-sig, vesting, and permanent-locked accounts use the same mnemonic-based
+destination-key flow. The post-migration verifier should preserve auth account
+type expectations where the migration module exposes them.
+
+Multisig accounts use the existing four-step proof flow: generate payload, sign
+legacy and new sides with enough signers, combine, submit proof. The shared
+package should reuse the multisig extraction already planned for gen-activity
+and evmigration.
+
+## 8. Parallel Execution
+
+Use a worker pool:
+
+1. Coordinator loads the registry and builds an immutable work queue.
+2. Workers execute migrations and return result structs.
+3. A single coordinator goroutine applies results to the registry and writes the
+   file atomically.
+
+Workers must not write `accounts.json` directly.
+
+The migration module has `max_migrations_per_block`. The coordinator should
+query it and throttle submissions so `parallelism` does not exceed the chain's
+per-block migration capacity. A simple initial design:
+
+- allow up to `min(parallelism, max_migrations_per_block)` in-flight submissions
+- wait for tx inclusion before releasing a slot
+- keep the registry save cadence result-driven, not batch-driven
+
+This keeps parallel migration useful without turning the mempool into a source
+of noisy sequence or per-block-cap failures.
+
+## 9. Error Handling
+
+Each account migration result should be independent:
+
+- one failed account does not stop the run
+- the final process exits nonzero if any account failed
+- successful and already-migrated accounts remain recorded
+- failed records include a short error string and can be retried on the next run
+
+Fatal preflight errors stop before workers start:
+
+- chain ID missing
+- registry cannot be parsed
+- migration disabled
+- migration window closed
+- current runtime is pre-EVM
+
+## 10. Validation
+
+Post-migration validation should check:
+
+- migration record exists and maps old address to expected new address
+- new key address matches the derived/imported destination
+- old account is rejected by post-migration estimate as already migrated
+- balance transfer is consistent with migration module behavior
+- recorded delegations, authz, feegrant, claim, and action references are
+  re-keyed where those checks are available from shared activity records
+
+The shared package should expose validation helpers granularly so gen-activity
+can use live-chain-safe checks and tests_evmigration can keep deeper devnet
+scenario checks.
+
+## 11. Tests
+
+Add unit tests for:
+
+- config validation: `mode=migrate` does not require funding/generation fields
+- wizard visibility: migrate mode hides creation/activity prompts
+- dry-run migration planning does not mutate keyring or registry
+- registry eligibility selection
+- result application and atomic save path
+- worker pool uses a single writer
+- already-migrated chain state updates the registry and skips tx submission
+- throttling respects `max_migrations_per_block`
+- shared migration package derives deterministic EVM destinations
+- multisig migration work item construction
+
+Keep existing `tests_evmigration` tests green after extracting shared code.
+
+## 12. Rollout
+
+Implementation should land in small steps:
+
+1. Add `mode` to gen-activity config and wizard, with `fresh` as the default
+   existing behavior.
+2. Extract read-only migration queries and destination-key derivation.
+3. Add migrate dry-run planning.
+4. Add single-sig migration execution and registry updates.
+5. Add multisig migration support.
+6. Refactor `tests_evmigration` to use the shared package.
+7. Add deeper post-migration validation shared by both tools.
+
+This sequence gives a usable migrate mode early while keeping the risky
+multisig/proof and evmigration refactor steps isolated.

--- a/docs/superpowers/specs/2026-06-16-gen-activity-migrate-mode-design.md
+++ b/docs/superpowers/specs/2026-06-16-gen-activity-migrate-mode-design.md
@@ -1,8 +1,8 @@
 # gen-activity: migrate mode for generated live-chain accounts
 
 **Date:** 2026-06-16
-**Status:** Approved (design)
-**Tools:** `devnet/tests/gen-activity`, `devnet/tests/evmigration`
+**Status:** Approved (design); revised 2026-06-16 after codebase review
+**Tools:** `devnet/tests/gen-activity`, `devnet/tests/evmigration`, `devnet/tests/common`
 
 ## 1. Goal
 
@@ -12,9 +12,16 @@ cutover.
 
 The design follows option 1 from the discussion: `tests-gen-activity` owns the
 live-chain user experience and its registry, while reusable migration primitives
-are extracted from `devnet/tests/evmigration` into shared Go code. The existing
-`tests_evmigration` binary keeps its devnet scenario modes and reuses the same
-shared migration package.
+live in shared Go code. The existing `tests_evmigration` binary keeps its devnet
+scenario modes and reuses the same shared migration code.
+
+**Revision note (shared-code location):** rather than create a brand-new
+`devnet/tests/migration` package, the shared migration primitives are added to
+the existing `devnet/tests/common` package, which both tools already import
+(`ChainCLI`, `Multisig`, key style, `AccountIdentity`, activity structs, JSON
+helpers). This avoids a new package boundary and a large up-front import churn.
+`tests_evmigration` is then refactored to call these `common` helpers instead of
+its local copies.
 
 ## 2. Background
 
@@ -53,7 +60,19 @@ tests-gen-activity -mode=migrate \
   -dry-run=false
 ```
 
-The existing default wizard should include `migrate` in the run-mode selector.
+`-chain`, `-accounts`, `-parallelism`, and `-dry-run` already exist. The new
+piece is `-mode`. Today the "mode" concept is implicit: two mutually-exclusive
+booleans (`-add-accounts`, `-activity-existing`) with the unset state meaning
+"fresh". This design promotes mode to an explicit `-mode` flag with values
+`fresh | add-accounts | activity-existing | migrate`, backed by a `Mode` config
+field. For backward compatibility the existing booleans continue to set the
+equivalent mode and must not be combined with a conflicting `-mode` value;
+`Validate()` rejects contradictions. `migrate` is mutually exclusive with all
+generation/activity modes.
+
+The existing default wizard already has a run-mode selector
+(`wizard.go` `settingMode`, options `fresh`/`add-accounts`/`activity-existing`);
+add `migrate` to it.
 When `migrate` is selected, hide fields that are not relevant to migration:
 
 - funding key
@@ -78,29 +97,38 @@ The migrate-mode wizard should keep only:
 planned migration set, already-migrated skips, and estimated tx types without
 creating keys, submitting txs, or mutating the registry.
 
-## 5. Shared Migration Package
+## 5. Shared Migration Code (in `devnet/tests/common`)
 
-Create a reusable migration package under `devnet/tests`, for example
-`devnet/tests/migration`. It should depend on `devnet/tests/common` for
-`ChainCLI`, key style, account identity, activity structs, and JSON helpers.
+Add reusable migration primitives to the existing `devnet/tests/common`
+package (new files, e.g. `migration.go`, `migration_keys.go`,
+`migration_multisig.go`, `migration_verify.go`). They build on the package's
+existing `ChainCLI`, `Multisig`, `KeyStyle`, `AccountIdentity`, and JSON
+helpers.
 
-Shared package responsibilities:
+Shared responsibilities:
 
-- query `evmigration params`
-- query `migration-record`
+- query `evmigration params` (`enable_migration`, `migration_end_time`,
+  `max_migrations_per_block`, `max_validator_delegations`, `max_multisig_sub_keys`)
+- query `migration-record` (by legacy address and by new address)
 - query `migration-estimate`
-- derive/import EVM destination keys from legacy mnemonics
-- create destination multisig keys and run the proof flow
-- submit single-sig claim migrations
-- submit multisig proof migrations
+- derive/import EVM destination keys from legacy mnemonics (coin-type 60,
+  `eth_secp256k1`) — deterministic from the same mnemonic
+- create destination multisig keys and run the four-step proof flow
+- submit single-sig claim migrations (`tx evmigration claim-legacy-account`)
+- submit multisig proof migrations (generate-proof-payload → sign-proof ×K →
+  combine-proof → submit-proof)
 - wait for tx inclusion
 - verify migration record and selected post-migration invariants
 - classify outcomes as migrated, already migrated, skipped, or failed
 
-`tests_evmigration` should call this package from its existing modes instead of
-owning all migration helpers locally. Devnet-specific behavior remains in
+`tests_evmigration` is refactored to call these `common` helpers instead of its
+local copies (see §12 step 6). Devnet-specific behavior remains in
 `tests_evmigration`: prepare mode, validator-local discovery, validator
 migration, scenario reports, and devnet-only assertions.
+
+The migration helpers must take their chain seams through interfaces/`ChainCLI`
+so gen-activity can unit-test planning and result application with fakes, the
+same way it already fakes `activityChain`, `fundingChain`, and `multisigExerciser`.
 
 ## 6. gen-activity Registry Changes
 
@@ -118,13 +146,19 @@ type MigrationInfo struct {
 }
 ```
 
-The existing top-level record can either embed these fields directly or place
-them under `migration`. Prefer `migration` to avoid mixing generation metadata
-with migration state:
+The fields go under a nested `migration` object on `AccountRecord` to avoid
+mixing generation metadata with migration state:
 
 ```go
 Migration *MigrationInfo `json:"migration,omitempty"`
 ```
+
+Because the field is optional (`omitempty`) and additive, the registry
+`schemaVersion` stays at **2**; old registries load unchanged. Some live devnet
+registries carry ad-hoc top-level `migrated` / `new_address` keys that were added
+by hand during manual migration testing; these are not part of the struct and
+are ignored on load. Migrate mode supersedes them by writing the structured
+`migration` object, and may optionally backfill from them when present.
 
 A record is eligible when:
 
@@ -146,8 +180,14 @@ Migration mode should target all account types created by `tests-gen-activity`:
 - generated multisig accounts
 
 Single-sig, vesting, and permanent-locked accounts use the same mnemonic-based
-destination-key flow. The post-migration verifier should preserve auth account
-type expectations where the migration module exposes them.
+destination-key flow. The keeper (`x/evmigration/keeper/migrate_auth.go`)
+detects the legacy auth type (continuous/delayed/periodic vesting,
+permanent-locked), captures the original schedule, removes the legacy account,
+transfers the balance, and recreates the vesting account at the new address.
+The destination must be a fresh address or a plain `BaseAccount`
+(`ErrInvalidMigrationDestination` otherwise); the mnemonic-derived coin-type-60
+key is fresh, so this holds. The post-migration verifier should preserve auth
+account type expectations where the migration module exposes them.
 
 Multisig accounts use the existing four-step proof flow: generate payload, sign
 legacy and new sides with enough signers, combine, submit proof. The shared
@@ -175,6 +215,30 @@ per-block migration capacity. A simple initial design:
 
 This keeps parallel migration useful without turning the mempool into a source
 of noisy sequence or per-block-cap failures.
+
+### 8.1 Logging & observability (concurrent troubleshooting)
+
+Concurrency makes interleaved logs hard to read, so every migration log line must
+be self-identifying and correlatable:
+
+- Each work item gets a stable **correlation id** (the account name, plus a
+  monotonic work index) included in every line for that item, e.g.
+  `[migrate gen-0007 #12]`.
+- Log the **lifecycle** of each item at a consistent set of points: queued,
+  preflight/estimate result, destination key derived (with new address),
+  submit (with tx hash), inclusion (with height + wait duration), verify result,
+  and final outcome (migrated / already_migrated / skipped / failed + reason).
+- Worker pool events are logged: worker start/stop, in-flight slot
+  acquisition/release, and throttle waits caused by `max_migrations_per_block`
+  (so a stall is visibly attributed to throttling, not a hang).
+- The coordinator (single writer) logs each registry apply with the item id and
+  resulting status, plus periodic progress (`done N/total, in-flight M`).
+- Each line carries a wall-clock timestamp and is written through one
+  synchronized logger so concurrent lines never interleave mid-line.
+- A run summary at the end tallies counts per outcome and lists failed items with
+  their short error strings, so a run can be triaged without grepping.
+- `dry-run` uses the same correlation ids and lifecycle phrasing (minus the tx
+  lines) so dry-run output maps 1:1 onto a real run.
 
 ## 9. Error Handling
 
@@ -231,11 +295,13 @@ Implementation should land in small steps:
 
 1. Add `mode` to gen-activity config and wizard, with `fresh` as the default
    existing behavior.
-2. Extract read-only migration queries and destination-key derivation.
-3. Add migrate dry-run planning.
-4. Add single-sig migration execution and registry updates.
+2. Add read-only migration queries and destination-key derivation to
+   `devnet/tests/common`.
+3. Add migrate dry-run planning and the `MigrationInfo` registry field.
+4. Add single-sig migration execution (incl. vesting/permanent-locked) and
+   registry updates.
 5. Add multisig migration support.
-6. Refactor `tests_evmigration` to use the shared package.
+6. Refactor `tests_evmigration` to use the shared `common` migration code.
 7. Add deeper post-migration validation shared by both tools.
 
 This sequence gives a usable migrate mode early while keeping the risky

--- a/gen-activity-config.toml.example
+++ b/gen-activity-config.toml.example
@@ -16,6 +16,13 @@ parallelism = 5
 funding-batch-size = 10
 actions = true
 
+# Optional account-mix knobs (default 0 / off). Usually passed as CLI flags, but
+# can be predefined here or per-chain:
+# num-multisig23-accounts = 0        # number of 2-of-3 multisig accounts
+# num-multisig35-accounts = 0        # number of 3-of-5 multisig accounts
+# vesting-percent = 0                # % of regular accounts made continuous/delayed vesting (0-100)
+# num-permanent-locked-accounts = 0  # dedicated PermanentLocked accounts
+
 [chains.devnet]
 rpc = "tcp://localhost:26657"
 grpc = "localhost:9090"

--- a/gen-activity-config.toml.example
+++ b/gen-activity-config.toml.example
@@ -15,6 +15,13 @@ max-account-amount = "10000000ulume"
 parallelism = 5
 funding-batch-size = 10
 actions = true
+require-actions = false
+max-actions-per-run = 3
+action-states = "pending,done,approved"
+action-readiness-timeout = "180s"
+add-accounts = false
+activity-existing = false
+dry-run = false
 
 # Optional account-mix knobs (default 0 / off). Usually passed as CLI flags, but
 # can be predefined here or per-chain:

--- a/gen-activity-config.toml.example
+++ b/gen-activity-config.toml.example
@@ -1,0 +1,35 @@
+# gen-activity-config.toml — copy to gen-activity-config.toml and edit.
+#
+# Precedence (low -> high): built-in defaults < [common] < [chains.<name>] <
+# explicit CLI flags. Select a chain with `-chain <name>`. Keys mirror the CLI
+# flag names. Running with NO flags launches the interactive wizard.
+
+[common]
+bin = "lumerad"
+home = "~/.lumera"
+keyring-backend = "test"
+funding-key = "faucet"
+evm-cutover-version = "v1.20.0"
+account-prefix = "gen"
+max-account-amount = "10000000ulume"
+parallelism = 5
+funding-batch-size = 10
+actions = true
+
+[chains.devnet]
+rpc = "tcp://localhost:26657"
+grpc = "localhost:9090"
+chain-id = "lumera-devnet-1"
+accounts = "devnet/tests/gen-activity/accounts-devnet.json"
+
+[chains.testnet]
+rpc = "https://rpc.testnet.lumera.io:443"
+grpc = "grpc.testnet.lumera.io:443"
+chain-id = "lumera-testnet-1"
+accounts = "devnet/tests/gen-activity/accounts-testnet.json"
+
+[chains.mainnet]
+rpc = "https://rpc.lumera.io:443"
+grpc = "grpc.lumera.io:443"
+chain-id = "lumera-mainnet-1"
+accounts = "devnet/tests/gen-activity/accounts-mainnet.json"

--- a/gen-activity-config.toml.example
+++ b/gen-activity-config.toml.example
@@ -8,12 +8,12 @@
 bin = "lumerad"
 home = "~/.lumera"
 keyring-backend = "test"
-funding-key = "faucet"
+funding-key = "governance_key"
 evm-cutover-version = "v1.20.0"
 account-prefix = "gen"
 max-account-amount = "10000000ulume"
 parallelism = 5
-funding-batch-size = 10
+funding-batch-size = 1
 actions = true
 require-actions = false
 max-actions-per-run = 3
@@ -21,7 +21,7 @@ action-states = "pending,done,approved"
 action-readiness-timeout = "180s"
 add-accounts = false
 activity-existing = false
-dry-run = false
+dry-run = true
 
 # Optional account-mix knobs (default 0 / off). Usually passed as CLI flags, but
 # can be predefined here or per-chain:
@@ -34,16 +34,16 @@ dry-run = false
 rpc = "tcp://localhost:26657"
 grpc = "localhost:9090"
 chain-id = "lumera-devnet-1"
-accounts = "devnet/tests/gen-activity/accounts-devnet.json"
+accounts = "accounts-devnet.json"
 
 [chains.testnet]
 rpc = "https://rpc.testnet.lumera.io:443"
 grpc = "grpc.testnet.lumera.io:443"
 chain-id = "lumera-testnet-1"
-accounts = "devnet/tests/gen-activity/accounts-testnet.json"
+accounts = "accounts-testnet.json"
 
 [chains.mainnet]
 rpc = "https://rpc.lumera.io:443"
 grpc = "grpc.lumera.io:443"
 chain-id = "lumera-mainnet-1"
-accounts = "devnet/tests/gen-activity/accounts-mainnet.json"
+accounts = "accounts-mainnet.json"

--- a/tests/scripts/devnet-common.bats
+++ b/tests/scripts/devnet-common.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  WORKDIR="$(mktemp -d)"
+  mkdir -p "$WORKDIR"
+  CLAIMS_FILE="$WORKDIR/claims.csv"
+  printf 'address,balance\n' > "$CLAIMS_FILE"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+}
+
+write_lumerad_shim() {
+  local help_text="$1"
+  SHIM="$WORKDIR/lumerad"
+  cat > "$SHIM" <<EOF
+#!/usr/bin/env bash
+if [ "\$1" = "start" ] && [ "\$2" = "--help" ]; then
+  cat <<'HELP'
+$help_text
+HELP
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$SHIM"
+}
+
+@test "claims start flags use only claims-path for older binaries" {
+  write_lumerad_shim "      --claims-path string   Path to claims.csv file"
+
+  run bash -c 'source "$1"; lumerad_claims_start_flags "$2" "$3"' _ \
+    "$REPO_ROOT/devnet/scripts/common.sh" "$SHIM" "$CLAIMS_FILE"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "--claims-path=$CLAIMS_FILE" ]
+}
+
+@test "claims start flags force claim loading for newer binaries" {
+  write_lumerad_shim "      --skip-claims-check
+      --claims-path string   Path to claims.csv file"
+
+  run bash -c 'source "$1"; lumerad_claims_start_flags "$2" "$3"' _ \
+    "$REPO_ROOT/devnet/scripts/common.sh" "$SHIM" "$CLAIMS_FILE"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "--skip-claims-check=false --claims-path=$CLAIMS_FILE" ]
+}
+
+@test "claims start flags are empty when claims file is absent" {
+  write_lumerad_shim "      --claims-path string   Path to claims.csv file"
+
+  run bash -c 'source "$1"; lumerad_claims_start_flags "$2" "$3"' _ \
+    "$REPO_ROOT/devnet/scripts/common.sh" "$SHIM" "$WORKDIR/missing.csv"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}

--- a/tests/scripts/devnet-makefile.bats
+++ b/tests/scripts/devnet-makefile.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  WORKDIR="$(mktemp -d)"
+  EXTERNAL_GENESIS="$WORKDIR/genesis.json"
+  jq '.app_state.claim.total_claimable_amount = "0" | .app_state.claim.params.enable_claims = false' \
+    "$REPO_ROOT/devnet/default-config/devnet-genesis.json" > "$EXTERNAL_GENESIS"
+  REMOTE_STAGE_DIR="$REPO_ROOT/build/devnet-remote-stage/lumera-devnet-1"
+  REMOTE_CONFIG="$REMOTE_STAGE_DIR/config-no-hermes.json"
+  mkdir -p "$REMOTE_STAGE_DIR"
+  jq '.hermes.enabled = false' "$REPO_ROOT/devnet/config/config.json" > "$REMOTE_CONFIG"
+}
+
+teardown() {
+  rm -rf "$WORKDIR"
+}
+
+@test "external version staging uses downloaded binaries without requiring claims" {
+  run make -C "$REPO_ROOT" -n devnet-stage-external-version \
+    VERSION=v1.12.0 \
+    EXTERNAL_GENESIS_FILE="$EXTERNAL_GENESIS"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"devnet-build"* ]]
+  [[ "$output" == *"rm -rf \"$REMOTE_STAGE_DIR\""* ]]
+  [[ "$output" == *"DEVNET_DIR=\"$REMOTE_STAGE_DIR\""* ]]
+  [[ "$output" == *"DEVNET_BUILD_LUMERA=0"* ]]
+  [[ "$output" == *"DEVNET_BUILD_TESTS=0"* ]]
+  [[ "$output" == *"DEVNET_BIN_DIR=devnet/bin-v1.12.0"* ]]
+  [[ "$output" == *"jq '.hermes.enabled = false'"* ]]
+  [[ "$output" == *"CONFIG_JSON=\"$REMOTE_CONFIG\""* ]]
+  [[ "$output" == *"EXTERNAL_GENESIS_FILE="* ]]
+  [[ "$output" != *"EXTERNAL_CLAIMS_FILE="* ]]
+}
+
+@test "remote version target syncs staged runtime and runs docker remotely" {
+  run make -C "$REPO_ROOT" -n devnet-new-remote-version \
+    VERSION=v1.12.0 \
+    EXTERNAL_GENESIS_FILE="$EXTERNAL_GENESIS" \
+    REMOTE_DEVNET_HOST=example-devnet \
+    REMOTE_DEVNET_DIR=/tmp/lumera-remote
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DEVNET_DOCKER_BUILD=0"* ]]
+  [[ "$output" == *"rsync"* ]]
+  [[ "$output" == *"$REMOTE_STAGE_DIR/shared/"* ]]
+  [[ "$output" == *"example-devnet:/tmp/lumera-remote/devnet/"* ]]
+  [[ "$output" == *"ssh example-devnet"* ]]
+  [[ "$output" == *"docker compose version"* ]]
+  [[ "$output" == *"START_MODE=auto docker compose up -d"* ]]
+  [[ "$output" == *"--remove-orphans"* ]]
+  [[ "$output" != *"ssh example-devnet"*"go "* ]]
+}

--- a/tests/scripts/supernode-setup.bats
+++ b/tests/scripts/supernode-setup.bats
@@ -177,3 +177,134 @@ teardown() {
   [[ "$(cat "$CMD_LOG")" == *"tx feegrant grant prepare-funder-supernova_validator_2 lumera1locked"* ]]
   [[ "$(cat "$CMD_LOG")" == *"--fee-granter lumera1liquid"* ]]
 }
+
+@test "validator setup selects migrated evm validator key when it is active on chain" {
+  run env \
+    MONIKER=supernova_validator_2 \
+    SUPERNODE_SETUP_LIB_ONLY=1 \
+    SUPERNODE_SHARED_DIR="$SHARED_DIR" \
+    bash -c '
+      source "$1"
+      DAEMON=lumerad
+      KEY_NAME=supernova_validator_2_key
+      VALIDATOR_BASE_KEY_NAME=supernova_validator_2_key
+      lumerad() {
+        case "$*" in
+          "keys show supernova_validator_2_key -a --keyring-backend test") printf "%s\n" "lumera1legacy" ;;
+          "keys show supernova_validator_2_key --bech val -a --keyring-backend test") printf "%s\n" "lumeravaloper1legacy" ;;
+          "q staking validator lumeravaloper1legacy --output json") return 1 ;;
+          "keys show supernova_validator_2_key_evm -a --keyring-backend test") printf "%s\n" "lumera1migrated" ;;
+          "keys show supernova_validator_2_key_evm --bech val -a --keyring-backend test") printf "%s\n" "lumeravaloper1migrated" ;;
+          "q staking validator lumeravaloper1migrated --output json") printf "%s\n" "{\"validator\":{\"operator_address\":\"lumeravaloper1migrated\"}}" ;;
+          *) return 1 ;;
+        esac
+      }
+      select_active_validator_key
+      printf "%s\n%s\n%s\n" "$KEY_NAME" "$VAL_ADDR" "$VALOPER_ADDR"
+    ' bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == $'supernova_validator_2_key_evm\nlumera1migrated\nlumeravaloper1migrated' ]]
+}
+
+@test "migrated validator multisig signing uses discovered evm signer keys" {
+  run env \
+    MONIKER=supernova_validator_2 \
+    SUPERNODE_SETUP_LIB_ONLY=1 \
+    SUPERNODE_SHARED_DIR="$SHARED_DIR" \
+    bash -c '
+      source "$1"
+      DAEMON=lumerad
+      KEY_NAME=supernova_validator_2_key_evm
+      VALIDATOR_BASE_KEY_NAME=supernova_validator_2_key
+      lumerad() {
+        case "$*" in
+          "keys show val2-evm-signer-1 -a --keyring-backend test") printf "%s\n" "lumera1evmsigner1" ;;
+          "keys show val2-evm-signer-2 -a --keyring-backend test") printf "%s\n" "lumera1evmsigner2" ;;
+          *) return 1 ;;
+        esac
+      }
+      validator_multisig_signer_key 1
+      validator_multisig_signer_key 2
+    ' bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == $'val2-evm-signer-1\nval2-evm-signer-2' ]]
+}
+
+@test "supernode evm key recovery uses supernode keyring writer" {
+  CMD_LOG="$SHARED_DIR/commands.log"
+  mkdir -p "$SHARED_DIR/supernode"
+  cat >"$SHARED_DIR/supernode/config.yml" <<'YAML'
+supernode:
+    key_name: "supernova_supernode_2_key_evm"
+keyring:
+    backend: "test"
+    dir: "keys"
+YAML
+
+  run env \
+    MONIKER=supernova_validator_2 \
+    SUPERNODE_SETUP_LIB_ONLY=1 \
+    SUPERNODE_SHARED_DIR="$SHARED_DIR" \
+    CMD_LOG="$CMD_LOG" \
+    bash -c '
+      source "$1"
+      SN_BASEDIR="$SHARED_DIR/supernode"
+      SN_CONFIG="$SN_BASEDIR/config.yml"
+      SN_KEYRING_HOME="$SN_BASEDIR/keys"
+      SN=supernode-linux-amd64
+      mkdir -p "$SN_KEYRING_HOME/keyring-test"
+      touch "$SN_KEYRING_HOME/keyring-test/supernova_supernode_2_key_evm.info"
+      supernode-linux-amd64() {
+        printf "%s\n" "$*" >>"$CMD_LOG"
+        case "$*" in
+          "keys list -d "*)
+            return 1
+            ;;
+          "keys recover supernova_supernode_2_key_evm -d "*)
+            return 0
+            ;;
+        esac
+      }
+      ensure_supernode_evm_key_from_mnemonic supernova_supernode_2_key_evm "test test test test test test test test test test test junk"
+    ' bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$CMD_LOG")" == *"keys list -d $SHARED_DIR/supernode"* ]]
+  [[ "$(cat "$CMD_LOG")" == *"keys recover supernova_supernode_2_key_evm -d $SHARED_DIR/supernode"* ]]
+  compgen -G "$SHARED_DIR/supernode/keys/keyring-test/supernova_supernode_2_key_evm.info.bak-"* >/dev/null
+}
+
+@test "supernode binary install does not downgrade newer installed version" {
+  RELEASE_DIR="$SHARED_DIR/release"
+  mkdir -p "$RELEASE_DIR" "$SHARED_DIR/bin"
+  cat >"$RELEASE_DIR/supernode-linux-amd64" <<'SH'
+#!/bin/sh
+case "$1" in
+  version) printf '%s\n' 'Version: v2.5.2' ;;
+esac
+SH
+  cat >"$SHARED_DIR/bin/supernode-linux-amd64" <<'SH'
+#!/bin/sh
+case "$1" in
+  version) printf '%s\n' 'Version: v2.6.0-rc1' ;;
+esac
+SH
+  chmod +x "$RELEASE_DIR/supernode-linux-amd64" "$SHARED_DIR/bin/supernode-linux-amd64"
+
+  run env \
+    MONIKER=supernova_validator_2 \
+    SUPERNODE_SETUP_LIB_ONLY=1 \
+    SUPERNODE_SHARED_DIR="$SHARED_DIR" \
+    bash -c '
+      source "$1"
+      SN_BIN_DST="$SHARED_DIR/bin/supernode-linux-amd64"
+      install_supernode_binary
+      "$SN_BIN_DST" version
+    ' bash "$SCRIPT"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"newer than shared release"* ]]
+  [[ "$output" == *"Version: v2.6.0-rc1"* ]]
+}


### PR DESCRIPTION
## Summary

Extends the local devnet tooling and the `tests-gen-activity` account-activity generator with four feature areas, plus supporting design docs. The `x/evmigration` multisig signer-index guard that originally rode on this branch has been split into its own PR (#153); this branch is now devnet/gen-activity only.

All work lives under `devnet/` (a separate Go module), `Makefile.devnet`, `tests/scripts/`, `docs/`, and a CLAUDE.md note — **no changes to chain code under `x/` or `app/`**.

## What's included

### 1. Remote devnet deployment
- New remote-deployment target and supporting `Makefile.devnet` plumbing (+177 lines) to stand up / drive the 5-validator + Hermes devnet on a shared remote host.
- Devnet script updates: `common.sh`, `configure.sh`, `lumera-helper.sh`, `restart.sh`, `start.sh`.
- `bats` coverage for the script/Makefile surface: `tests/scripts/devnet-common.bats`, `tests/scripts/devnet-makefile.bats`.
- CLAUDE.md: shared devnet host notes (SSH alias, container names, bind-mount paths, accounts file location, migration-transcript convention).

### 2. gen-activity: config file + interactive wizard
- Parse `gen-activity-config.toml` (`chains` / `common` sections) with layered precedence **flag > chain > common > default**.
- New flags: `-config`, `-chain`, `-wizard`, multisig/vesting counts.
- Interactive `survey`-based wizard (menu rendering + per-setting editing) as the default mode when no command-line driver is given; includes a chain summary and safer defaults.
- `gen-activity-config.toml.example` documents every key.

### 3. gen-activity: multisig accounts
- Generic K-of-N multisig ceremony extracted into `devnet/tests/common` (`Multisig`): CLI arg builders for `keys add`/`sign`/`multisign`/`broadcast`, composite-create, and the full sign→multisign→broadcast flow (uses `--nosort` + amino-json so legacy/new sides agree on signer index).
- `devnet/tests/evmigration/multisig.go` refactored to delegate to the shared ceremony (−331 of duplicated logic).
- gen-activity plans, creates, funds, and exercises multisig accounts in `run()`; registry schema v2 records the composite + member key names.

### 4. gen-activity: vesting + permanent-locked accounts
- Shared create helpers in `devnet/tests/common/vesting.go`.
- `-vesting-percent` and `-num-permanent-locked-accounts` flags; vesting account selection + permanent-locked generation, created and funded at funding time.
- Registry `VestingInfo` captures vesting/locked metadata.

### 5. Design / plan docs
- `docs/design/gen-activity-{design,config-wizard-plan,multisig-plan,vesting-plan}.md` and the wizard/config/multisig design spec.

## Verification
The devnet module is separate (`devnet/go.mod`). Branch-touched packages build, vet, and test clean:
```
cd devnet
go build ./tests/gen-activity/... ./tests/common/... ./tests/evmigration/... .   # OK
go vet   ./tests/gen-activity/... ./tests/common/...                              # OK
go test  ./tests/gen-activity/... ./tests/common/... -count=1                     # ok  (PASS)
```
Note: `go build ./...` from `devnet/` reports `undefined: lumeraHermesSuite` in `tests/hermes/` — that is a pre-existing, build-tag-gated artifact unrelated to this branch (`devnet/tests/hermes/` is untouched here).

## Notes for reviewers
- The shared `common.Multisig` ceremony is the same code path the evmigration devnet tests now use, so multisig key ordering is consistent across gen-activity and migration testing.
- gen-activity remains a devnet-only test/utility binary; it does not ship in `lumerad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)