### PR TITLE
evmigration(batch): classify vesting-locked targets as needs-funding

### DIFF
--- a/docs/evm-integration/user-guides/migration-scripts.md
+++ b/docs/evm-integration/user-guides/migration-scripts.md
@@ -14,6 +14,7 @@ Use the script that matches the account you are migrating:
 | Regular single-key account                      | `scripts/migrate-account.sh`   | Migrates a legacy coin-type 118 `secp256k1` account to a coin-type 60 `eth_secp256k1` account.                                |
 | Single-key validator operator                   | `scripts/migrate-validator.sh` | Migrates the validator operator account and re-keys validator-related state. The validator node must be stopped before broadcast. |
 | Multisig account or multisig validator operator | `scripts/migrate-multisig.sh`  | Runs a 4-step coordinator/co-signer ceremony:`generate`, `sign`, `combine`, `submit`.                                     |
+| **Many accounts** (single-key or multisig) you hold all mnemonics for | `scripts/migrate-batch.sh`     | Drives the migration of N accounts in one process: classifies each one off-chain state, sets up an ephemeral keyring, funds vesting-locked / zero-balance targets from an operator funder, self-sends to publish each multisig pubkey, and delegates the migration ceremony to the scripts above. See [scripts/migrate-batch.md](../../../scripts/migrate-batch.md) for the operator playbook. |
 
 Most users should do this first:
 

--- a/docs/evm-integration/user-guides/migration-scripts.md
+++ b/docs/evm-integration/user-guides/migration-scripts.md
@@ -14,7 +14,6 @@ Use the script that matches the account you are migrating:
 | Regular single-key account                      | `scripts/migrate-account.sh`   | Migrates a legacy coin-type 118 `secp256k1` account to a coin-type 60 `eth_secp256k1` account.                                |
 | Single-key validator operator                   | `scripts/migrate-validator.sh` | Migrates the validator operator account and re-keys validator-related state. The validator node must be stopped before broadcast. |
 | Multisig account or multisig validator operator | `scripts/migrate-multisig.sh`  | Runs a 4-step coordinator/co-signer ceremony:`generate`, `sign`, `combine`, `submit`.                                     |
-| **Many accounts** (single-key or multisig) you hold all mnemonics for | `scripts/migrate-batch.sh`     | Drives the migration of N accounts in one process: classifies each one off-chain state, sets up an ephemeral keyring, funds vesting-locked / zero-balance targets from an operator funder, self-sends to publish each multisig pubkey, and delegates the migration ceremony to the scripts above. See [scripts/migrate-batch.md](../../../scripts/migrate-batch.md) for the operator playbook. |
 
 Most users should do this first:
 

--- a/scripts/migrate-batch.md
+++ b/scripts/migrate-batch.md
@@ -92,7 +92,7 @@ For each target, runs:
 - `evmigration migration-record` (already migrated?)
 - `auth account` (does the pubkey exist on chain?)
 - `bank balances` and `bank spendable-balances` (does the account hold ulume
-  it can actually spend on fees?)
+  it can actually spend on the pubkey-publishing self-send amount plus fees?)
 
 and prints one of:
 
@@ -101,11 +101,12 @@ and prints one of:
 - `needs-pubkey`  — has **spendable** balance but no pubkey on chain. Will
                     self-send to publish the pubkey, then migrate.
 - `needs-funding` — pubkey missing AND spendable balance is below the
-                    self-send fee threshold. Covers **two** real cases:
+                    self-send amount plus fee threshold. Covers **two** real cases:
                     (a) zero total balance (classic fresh foundation
                     account), and (b) non-zero total balance but
-                    **vesting-locked** so spendable < fee. Both require
-                    `--funder` during `execute`.
+                    **vesting-locked** so spendable cannot cover the
+                    self-send amount plus fee. Both require `--funder`
+                    during `execute`.
 - `unknown`       — RPC failure (re-check connectivity / endpoint).
 
 `status` surfaces both `balance` and `spendable` per target so an operator
@@ -123,7 +124,7 @@ Common flags:
 |---|---|
 | `--target <name>` | Process only the named target. Use this for the first run. |
 | `--funder <key>` | Operator-keyring key that pays fees for **any** target classified `needs-funding`, including vesting-locked accounts whose total balance is large but spendable is zero. Must have spendable balance ≥ `N_needs_funding × (--top-up-amount + broadcast-fee)`. Required whenever any target is `needs-funding`; the script aborts that target otherwise. |
-| `--top-up-amount <coins>` | How much the funder sends to each `needs-funding` target. Default `200000ulume`. Sizing rule: must cover the downstream self-send (`100000ulume`) + its broadcast fee (`5000ulume`) with comfortable headroom (default leaves ~95000ulume slack). If you've overridden fees in the multisig scripts, set this to at least `2 × (self_send_amount + multisig_self_send_fee)` and never less than `200000ulume`. |
+| `--top-up-amount <coins>` | How much the funder sends to each `needs-funding` target. Default `200000ulume`. Sizing rule: must cover the downstream self-send (`100000ulume`) + its broadcast fee (`5000ulume`) with comfortable headroom (default leaves ~95000ulume slack). If you've overridden the self-send amount or fees in the script, set this to at least `2 × (self_send_amount + self_send_fee)` and never less than `200000ulume`. |
 | `--funder-keyring-{backend,dir,home}` | How to reach the funder key. Defaults: `test` backend, `lumerad`'s default home / keyring dir. Example: `--funder-keyring-backend file --funder-keyring-home /etc/lumerad`. |
 | `--log-file <path>` | Append one JSONL audit record per lifecycle milestone (batch_start, target_start, classify, keyring_setup, reconstructed, funding_*, self_send_*, ceremony_start, target_done, batch_done). `classify` events include both `balance` and `spendable`. Mode 0600 on create, append-only, correlated by per-run `batch_id`. Operator handles rotation. |
 | `--dry-run` | Stop after read-only steps + address reconstruction; no broadcasts. |

--- a/scripts/migrate-batch.md
+++ b/scripts/migrate-batch.md
@@ -28,6 +28,43 @@ triggered failures).
 - You want idempotency: re-running the script skips already-migrated targets
   and re-classifies the rest from chain state, so partial runs are safe.
 
+## Prerequisites
+
+On the machine where you run the script:
+
+- `lumerad` built from a **post-EVM-upgrade** commit. Verify with
+  `lumerad query evmigration --help` — it must list `migration-record`,
+  `migration-estimate`, etc.
+- `bash` 4.4 or newer.
+- `jq` on `PATH`.
+- Access to a Lumera RPC endpoint. Default is `tcp://localhost:26657`.
+  Pass `--node <url>` to point elsewhere.
+- An **operator keyring** containing the `--funder` key (see below). This
+  is your main `lumerad` keyring — `--keyring-backend test|file|os` are all
+  supported via the `--funder-keyring-{backend,dir,home}` flags. Default
+  backend is `test` and default location is `lumerad`'s default home.
+
+You can run the script from any host that satisfies the above. There is no
+requirement that it run on a validator node; running on a dedicated ops box
+with read-only RPC access to a full node is the recommended pattern.
+
+## Picking and preparing the funder
+
+`--funder <key>` is the operator-keyring key that pays fees for every target
+classified `needs-funding` (see § Subcommands → status below for what that
+means). Three things to verify before kicking off `execute`:
+
+1. **Key is in the operator keyring**, not the ephemeral one. Confirm with
+   `lumerad keys show <funder-key> --keyring-backend <backend>`.
+2. **Spendable balance is sufficient.** The funder needs roughly
+   `N_needs_funding × top_up_amount + N_needs_funding × broadcast_fee`.
+   For the mainnet foundation bundle (~24 vesting-locked multisigs) at the
+   default `200000ulume` top-up that's < 0.01 LUME total, but check anyway.
+   A vesting-locked key **cannot** be used as a funder — it has spendable=0.
+3. **Key type is supported.** Both legacy `secp256k1` and EVM
+   `eth_secp256k1` funder keys work; the script broadcasts a plain `MsgSend`
+   from it.
+
 ## Subcommands
 
 ```
@@ -54,9 +91,26 @@ For each target, runs:
 
 - `evmigration migration-record` (already migrated?)
 - `auth account` (does the pubkey exist on chain?)
-- `bank balances` (does the account hold ulume to pay fees?)
+- `bank balances` and `bank spendable-balances` (does the account hold ulume
+  it can actually spend on fees?)
 
-and prints one of: `migrated`, `ready`, `needs-pubkey`, `needs-funding`, `unknown`.
+and prints one of:
+
+- `migrated`      — already migrated, will be skipped by `execute`.
+- `ready`         — pubkey on chain, ready to migrate. No self-send needed.
+- `needs-pubkey`  — has **spendable** balance but no pubkey on chain. Will
+                    self-send to publish the pubkey, then migrate.
+- `needs-funding` — pubkey missing AND spendable balance is below the
+                    self-send fee threshold. Covers **two** real cases:
+                    (a) zero total balance (classic fresh foundation
+                    account), and (b) non-zero total balance but
+                    **vesting-locked** so spendable < fee. Both require
+                    `--funder` during `execute`.
+- `unknown`       — RPC failure (re-check connectivity / endpoint).
+
+`status` surfaces both `balance` and `spendable` per target so an operator
+can verify the classification at a glance: a multisig holding 5T LUME but
+classified `needs-funding` will show `spendable=0` next to it.
 
 ### `execute`  (the real thing)
 
@@ -68,10 +122,10 @@ Common flags:
 | flag | meaning |
 |---|---|
 | `--target <name>` | Process only the named target. Use this for the first run. |
-| `--funder <key>` | Operator-keyring key that pays fees for zero-balance targets. |
-| `--top-up-amount <coins>` | How much to send to a zero-balance target. Default `200000ulume` (covers the 100000ulume self-send + 5000ulume fee + headroom). |
-| `--funder-keyring-{backend,dir,home}` | How to reach the funder key. Defaults: `test` backend, lumerad's default home / keyring dir. |
-| `--log-file <path>` | Append one JSONL audit record per lifecycle milestone (batch_start, target_start, classify, keyring_setup, reconstructed, funding_*, self_send_*, ceremony_start, target_done, batch_done). Mode 0600 on create, append-only, correlated by per-run `batch_id`. Operator handles rotation. |
+| `--funder <key>` | Operator-keyring key that pays fees for **any** target classified `needs-funding`, including vesting-locked accounts whose total balance is large but spendable is zero. Must have spendable balance ≥ `N_needs_funding × (--top-up-amount + broadcast-fee)`. Required whenever any target is `needs-funding`; the script aborts that target otherwise. |
+| `--top-up-amount <coins>` | How much the funder sends to each `needs-funding` target. Default `200000ulume`. Sizing rule: must cover the downstream self-send (`100000ulume`) + its broadcast fee (`5000ulume`) with comfortable headroom (default leaves ~95000ulume slack). If you've overridden fees in the multisig scripts, set this to at least `2 × (self_send_amount + multisig_self_send_fee)` and never less than `200000ulume`. |
+| `--funder-keyring-{backend,dir,home}` | How to reach the funder key. Defaults: `test` backend, `lumerad`'s default home / keyring dir. Example: `--funder-keyring-backend file --funder-keyring-home /etc/lumerad`. |
+| `--log-file <path>` | Append one JSONL audit record per lifecycle milestone (batch_start, target_start, classify, keyring_setup, reconstructed, funding_*, self_send_*, ceremony_start, target_done, batch_done). `classify` events include both `balance` and `spendable`. Mode 0600 on create, append-only, correlated by per-run `batch_id`. Operator handles rotation. |
 | `--dry-run` | Stop after read-only steps + address reconstruction; no broadcasts. |
 | `--yes` | Skip the interactive confirmation. |
 | `--continue-on-error` | Don't stop the batch on the first failed target. |
@@ -89,6 +143,11 @@ never by name suffix.
 
 ## Suggested workflow for a fresh deployment
 
+The first four steps are warm-ups; only step 5 broadcasts at scale. Pick
+**two** dry-run targets in step 3 — one vested (likely `needs-pubkey`) and
+one vesting-locked (likely `needs-funding`) — so you exercise both code
+paths before the full batch.
+
 ```bash
 # 1. Offline: confirm the file parses and classifies cleanly.
 ./scripts/migrate-batch.sh report \
@@ -96,16 +155,31 @@ never by name suffix.
   --plan-out plan.json
 
 # 2. Read-only: see what each target's on-chain state is.
+#    The output table shows balance AND spendable. Eyeball the summary
+#    counts and confirm needs-funding count matches your expectation
+#    (typically: every still-vesting multisig + every fresh zero-balance
+#    account).
 ./scripts/migrate-batch.sh status \
   --mnemonics output.json \
-  --chain-id lumera-testnet-2 \
+  --chain-id lumera-mainnet-1 \
   --node tcp://localhost:26657
 
-# 3. Dry-run one target end-to-end (no broadcasts).
+# 3a. Dry-run a VESTED target end-to-end (no broadcasts).
+#     Exercises the no-funder self-send path.
 ./scripts/migrate-batch.sh execute \
   --mnemonics output.json \
   --target seed_sale_1 \
-  --chain-id lumera-testnet-2 \
+  --chain-id lumera-mainnet-1 \
+  --funder ops-funder --top-up-amount 200000ulume \
+  --dry-run
+
+# 3b. Dry-run a VESTING-LOCKED target end-to-end (no broadcasts).
+#     Exercises the --funder + self-send path. Pick any target the status
+#     output showed as needs-funding with balance>0 (e.g. team_3, advisors_1).
+./scripts/migrate-batch.sh execute \
+  --mnemonics output.json \
+  --target team_3 \
+  --chain-id lumera-mainnet-1 \
   --funder ops-funder --top-up-amount 200000ulume \
   --dry-run
 
@@ -113,14 +187,16 @@ never by name suffix.
 ./scripts/migrate-batch.sh execute \
   --mnemonics output.json \
   --target seed_sale_1 \
-  --chain-id lumera-testnet-2 \
+  --chain-id lumera-mainnet-1 \
   --funder ops-funder --top-up-amount 200000ulume
 
-# 5. Full batch (with confirmation prompt).
+# 5. Full batch (with confirmation prompt; --log-file is strongly recommended).
 ./scripts/migrate-batch.sh execute \
   --mnemonics output.json \
-  --chain-id lumera-testnet-2 \
-  --funder ops-funder --top-up-amount 200000ulume
+  --chain-id lumera-mainnet-1 \
+  --funder ops-funder --top-up-amount 200000ulume \
+  --log-file ./batch-$(date -u +%Y%m%dT%H%M%SZ).jsonl \
+  --continue-on-error
 ```
 
 ## Safety properties

--- a/scripts/migrate-batch.sh
+++ b/scripts/migrate-batch.sh
@@ -17,7 +17,8 @@
 #   - For multisigs, reconstructs both legacy and new multisigs by pubkey-
 #     matched signer order, and asserts the reconstructed legacy address
 #     equals the address in the mnemonics file.
-#   - Optionally tops up the legacy address from --funder, if balance is 0.
+#   - Optionally tops up the legacy address from --funder, if the target cannot
+#     pay for its own pubkey-publishing self-send from spendable balance.
 #   - If on-chain pubkey is missing, performs a self-send to publish it
 #     (multisig variant: --generate-only + sign×K + multisign + broadcast).
 #   - Delegates the migration ceremony itself to:
@@ -200,11 +201,16 @@ _mb_filter_targets() {
   printf '%s' "$out"
 }
 
+# Self-send amount and fee used to publish a missing legacy pubkey.
+# Keep these as the single source of truth for both the classifier threshold and
+# the actual single-sig/multisig self-send broadcasts.
+_MB_SELF_SEND_AMOUNT_ULUME=100000
+_MB_SELF_SEND_FEE_ULUME=5000
+
 # Minimum spendable ulume required for the target to broadcast its own
-# self-send (publishes pubkey). Sized to cover the multisig self-send fee
-# (5000ulume) with headroom. Targets below this threshold MUST be funded by
+# self-send (publishes pubkey). Targets below this threshold MUST be funded by
 # --funder even if their TOTAL balance is large (the vesting-locked case).
-_MB_MIN_SELF_SEND_SPENDABLE_ULUME=10000
+_MB_MIN_SELF_SEND_SPENDABLE_ULUME=$((_MB_SELF_SEND_AMOUNT_ULUME + _MB_SELF_SEND_FEE_ULUME))
 
 # _mb_classify_target <legacy_addr>
 # Probes chain and prints one of:
@@ -212,13 +218,14 @@ _MB_MIN_SELF_SEND_SPENDABLE_ULUME=10000
 #   ready          — auth pubkey present, no migration record
 #   needs-pubkey   — auth account exists (or has balance) but no pubkey
 #                    AND has enough SPENDABLE balance to self-fund the
-#                    self-send fee
+#                    self-send amount plus fee
 #   needs-funding  — pubkey missing AND spendable balance is insufficient
-#                    for the self-send fee. This covers two cases:
+#                    for the self-send amount plus fee. This covers two cases:
 #                      a) account does not exist on auth and balance==0
 #                         (classic fresh foundation account)
 #                      b) account exists with non-zero TOTAL balance but
-#                         that balance is vesting-locked → spendable < fee
+#                         that balance is vesting-locked → spendable below
+#                         the self-send amount plus fee
 #   unknown        — RPC failure (cannot even read bank balances)
 # Plus prints `balance=<ulume>` and `spendable=<ulume>` on subsequent lines.
 #
@@ -288,7 +295,7 @@ _mb_classify_target() {
     *)
       # No pubkey on chain. Decide between needs-pubkey (self-fund) and
       # needs-funding (caller must provide --funder) based on whether the
-      # target can pay its own self-send fee from SPENDABLE balance.
+      # target can pay its own self-send amount plus fee from SPENDABLE balance.
       #
       # An account is self-fundable iff:
       #   - auth knows it OR total balance > 0  (so it can plausibly broadcast)
@@ -416,8 +423,9 @@ Phase B — per-target chain-state probe. READ-ONLY. No signing, no broadcast.
 Per target, classifies into one of:
   migrated       — already migrated, will be skipped by `execute`
   ready          — pubkey on chain, ready to migrate
-  needs-pubkey   — has spendable balance but no pubkey on chain (will self-send)
-  needs-funding  — pubkey missing and spendable balance < self-send fee
+  needs-pubkey   — has enough spendable balance for self-send amount + fee
+                   but no pubkey on chain (will self-send)
+  needs-funding  — pubkey missing and spendable balance < self-send amount + fee
                    (zero-balance OR vesting-locked; will need --funder during execute)
   unknown        — RPC failure (re-check)
 
@@ -666,22 +674,22 @@ _mb_send_with_funder() {
 }
 
 # _mb_multisig_self_send <multisig_name> <multisig_addr> <signers_csv> <threshold>
-# Performs a multisig self-send (multisig -> multisig) of 100000ulume to publish
-# the multisig's pubkey on chain. All signer keys must already be present in
-# the ephemeral keyring under legacy-* names.
+# Performs a multisig self-send (multisig -> multisig) to publish the multisig's
+# pubkey on chain. All signer keys must already be present in the ephemeral
+# keyring under legacy-* names.
 _mb_multisig_self_send() {
   local multi_name="$1" multi_addr="$2" signers_csv="$3" threshold="$4"
   local workdir
   workdir=$(mktemp -d "${_MB_EPHEMERAL_DIR}/selfsend-XXXXXX")
   local unsigned="${workdir}/unsigned.json"
 
-  # 1. Unsigned tx (self-send 100000ulume to publish pubkey). The first
+  # 1. Unsigned tx (self-send to publish pubkey). The first
   # positional argument is the FROM key NAME (looked up in the keyring), not
   # an address. lumerad rejects an address here as "no key name or address
   # provided; have you forgotten the --from flag?".
-  "$BIN" tx bank send "$multi_name" "$multi_addr" 100000ulume \
+  "$BIN" tx bank send "$multi_name" "$multi_addr" "${_MB_SELF_SEND_AMOUNT_ULUME}ulume" \
     --node "$NODE" --chain-id "$CHAIN_ID" \
-    --fees 5000ulume --gas auto --gas-adjustment 1.3 \
+    --fees "${_MB_SELF_SEND_FEE_ULUME}ulume" --gas auto --gas-adjustment 1.3 \
     --keyring-backend test --keyring-dir "$_MB_EPHEMERAL_DIR" \
     --generate-only --output json >"$unsigned"
 
@@ -882,9 +890,9 @@ _mb_execute_one() {
     else
       log_info "  publishing single-sig pubkey via self-send"
       local out tx_hash
-      if ! out=$("$BIN" tx bank send "$legacy_key_name" "$addr" 100000ulume \
+      if ! out=$("$BIN" tx bank send "$legacy_key_name" "$addr" "${_MB_SELF_SEND_AMOUNT_ULUME}ulume" \
                    --node "$NODE" --chain-id "$CHAIN_ID" \
-                   --fees 5000ulume --gas auto --gas-adjustment 1.3 \
+                   --fees "${_MB_SELF_SEND_FEE_ULUME}ulume" --gas auto --gas-adjustment 1.3 \
                    --keyring-backend test --keyring-dir "$_MB_EPHEMERAL_DIR" \
                    --output json -y); then
         log_error "  single-sig self-send broadcast exited non-zero"
@@ -1010,7 +1018,7 @@ _mb_execute() {
   _MB_DRY_RUN=0
   local yes=0
   _MB_FUNDER=""
-  # Must cover the self-send (100000ulume) + its fee (5000ulume) with headroom.
+  # Must cover the self-send amount + its fee with headroom.
   # 200000ulume = self-send + fee + ~2x headroom. Lower defaults will make the
   # downstream self-send fail with insufficient funds on a freshly-funded target.
   _MB_TOP_UP_AMOUNT="200000ulume"
@@ -1054,7 +1062,7 @@ Per target:
   2) set up an ephemeral mode-0700 keyring (wiped on exit)
   3) import each signer's mnemonic as legacy (118/secp256k1) + new (60/eth_secp256k1)
   4) reconstruct legacy multisig; assert address matches file (multisig targets)
-  5) fund if balance==0 (requires --funder)
+  5) fund if spendable balance is below self-send amount + fee (requires --funder)
   6) self-send to publish multisig pubkey on chain (if missing)
   7) delegate to migrate-multisig.sh / migrate-account.sh
   8) verify via evmigration migration-record
@@ -1066,11 +1074,11 @@ Optional:
   --target <name>            Process ONLY the named target. Highly recommended
                              for the first run.
   --funder <key>             Operator keyring key that pays fees for targets
-                             with zero balance. Lives in the OPERATOR's main
-                             keyring (NOT the ephemeral one).
-  --top-up-amount <coins>    Amount to send to a zero-balance target before
+                             classified needs-funding. Lives in the OPERATOR's
+                             main keyring (NOT the ephemeral one).
+  --top-up-amount <coins>    Amount to send to a needs-funding target before
                              self-send. Default: 200000ulume (covers the
-                             100000ulume self-send + 5000ulume fee + headroom).
+                             self-send amount + fee + headroom).
   --funder-keyring-*         How to reach the funder key (defaults: backend=test,
                              dir=$HOME default).
   --log-file <path>          Append JSONL audit records (one event per line)

--- a/scripts/migrate-batch.sh
+++ b/scripts/migrate-batch.sh
@@ -200,14 +200,27 @@ _mb_filter_targets() {
   printf '%s' "$out"
 }
 
+# Minimum spendable ulume required for the target to broadcast its own
+# self-send (publishes pubkey). Sized to cover the multisig self-send fee
+# (5000ulume) with headroom. Targets below this threshold MUST be funded by
+# --funder even if their TOTAL balance is large (the vesting-locked case).
+_MB_MIN_SELF_SEND_SPENDABLE_ULUME=10000
+
 # _mb_classify_target <legacy_addr>
 # Probes chain and prints one of:
 #   migrated       — migration-record exists
 #   ready          — auth pubkey present, no migration record
 #   needs-pubkey   — auth account exists (or has balance) but no pubkey
-#   needs-funding  — account not found on auth AND balance==0
+#                    AND has enough SPENDABLE balance to self-fund the
+#                    self-send fee
+#   needs-funding  — pubkey missing AND spendable balance is insufficient
+#                    for the self-send fee. This covers two cases:
+#                      a) account does not exist on auth and balance==0
+#                         (classic fresh foundation account)
+#                      b) account exists with non-zero TOTAL balance but
+#                         that balance is vesting-locked → spendable < fee
 #   unknown        — RPC failure (cannot even read bank balances)
-# Plus prints `balance=<ulume>` on second line.
+# Plus prints `balance=<ulume>` and `spendable=<ulume>` on subsequent lines.
 #
 # NOTE: the existing auth_pubkey_type helper hard-exits (exit 2) when the
 # account does not exist on auth, which is a LEGITIMATE state for fresh
@@ -215,9 +228,18 @@ _mb_filter_targets() {
 # ourselves and disambiguate "account not found" from "RPC down" by using
 # `bank balances` as the RPC-liveness probe (which succeeds with an empty
 # balances array for unknown addresses).
+#
+# WHY we look at SPENDABLE, not TOTAL: foundation multisigs on the mainnet
+# launch bundle are continuous-vesting accounts. Until their end_time they
+# carry a large TOTAL balance but spendable=0, so any tx they sign — even a
+# self-send to themselves — is rejected at the ante handler with
+# "insufficient funds" against the fee. A classifier that only looks at
+# TOTAL balance silently routes those targets onto the no-funder code path,
+# which then fails at broadcast. Looking at spendable lets the funder bail
+# them out instead.
 _mb_classify_target() {
   local addr="$1"
-  local rec_json balance_json balance auth_json pk_type_str
+  local rec_json balance_json balance spendable_json spendable auth_json pk_type_str
 
   # 1) already migrated?
   if rec_json=$(lumerad_q_capture evmigration migration-record "$addr" 2>/dev/null); then
@@ -232,9 +254,19 @@ _mb_classify_target() {
   if ! balance_json=$(lumerad_q_capture bank balances "$addr" 2>/dev/null); then
     printf 'unknown\n'
     printf 'balance=0\n'
+    printf 'spendable=0\n'
     return 0
   fi
   balance=$(jq -r '[.balances[]? | select(.denom == "ulume").amount | tonumber] | add // 0' <<<"$balance_json")
+
+  # 2b) spendable balance — same denom. For vesting-locked accounts this is
+  # strictly less than balance until end_time. We tolerate RPC failure here
+  # (treat as spendable=0 so we route to needs-funding, which is the safe
+  # default — the funder will top up).
+  spendable=0
+  if spendable_json=$(lumerad_q_capture bank spendable-balances "$addr" 2>/dev/null); then
+    spendable=$(jq -r '[.balances[]? | select(.denom == "ulume").amount | tonumber] | add // 0' <<<"$spendable_json")
+  fi
 
   # 3) auth account — may legitimately be absent for a fresh foundation
   # account. We treat that as "not on auth" (acct_known=0), NOT as RPC failure.
@@ -254,12 +286,16 @@ _mb_classify_target() {
       printf 'ready\n'
       ;;
     *)
-      # No pubkey on chain. Two sub-cases:
-      #   - account exists on auth but no pubkey (genesis / received-only) → needs-pubkey
-      #   - account does NOT exist on auth at all → needs-funding to create it,
-      #     unless someone has already sent to it (balance > 0), in which case
-      #     it's effectively needs-pubkey.
-      if (( acct_known == 1 )) || [[ "$balance" != "0" ]]; then
+      # No pubkey on chain. Decide between needs-pubkey (self-fund) and
+      # needs-funding (caller must provide --funder) based on whether the
+      # target can pay its own self-send fee from SPENDABLE balance.
+      #
+      # An account is self-fundable iff:
+      #   - auth knows it OR total balance > 0  (so it can plausibly broadcast)
+      #   - AND spendable >= _MB_MIN_SELF_SEND_SPENDABLE_ULUME
+      # Otherwise we hand it to the funder path.
+      if { (( acct_known == 1 )) || [[ "$balance" != "0" ]]; } \
+         && (( spendable >= _MB_MIN_SELF_SEND_SPENDABLE_ULUME )); then
         printf 'needs-pubkey\n'
       else
         printf 'needs-funding\n'
@@ -267,6 +303,7 @@ _mb_classify_target() {
       ;;
   esac
   printf 'balance=%s\n' "$balance"
+  printf 'spendable=%s\n' "$spendable"
 }
 
 ###############################################################################
@@ -379,8 +416,9 @@ Phase B — per-target chain-state probe. READ-ONLY. No signing, no broadcast.
 Per target, classifies into one of:
   migrated       — already migrated, will be skipped by `execute`
   ready          — pubkey on chain, ready to migrate
-  needs-pubkey   — has balance but no pubkey on chain (will self-send)
-  needs-funding  — zero balance, no pubkey (will need --funder during execute)
+  needs-pubkey   — has spendable balance but no pubkey on chain (will self-send)
+  needs-funding  — pubkey missing and spendable balance < self-send fee
+                   (zero-balance OR vesting-locked; will need --funder during execute)
   unknown        — RPC failure (re-check)
 
 Required:
@@ -699,10 +737,11 @@ _mb_execute_one() {
   # lines. For status=migrated the extra line is `new_address=...` (no balance).
   # For other statuses the extra line is `balance=...`. Parse by key so we
   # don't mis-label new_address as balance in the operator log + JSONL audit.
-  local cls cls_status balance new_addr_cls
+  local cls cls_status balance spendable new_addr_cls
   cls=$(_mb_classify_target "$addr")
   cls_status=$(awk 'NR==1' <<<"$cls")
   balance=$(awk -F= 'NR>1 && $1=="balance" {print $2}' <<<"$cls")
+  spendable=$(awk -F= 'NR>1 && $1=="spendable" {print $2}' <<<"$cls")
   new_addr_cls=$(awk -F= 'NR>1 && $1=="new_address" {print $2}' <<<"$cls")
 
   if [[ "$cls_status" == "migrated" ]]; then
@@ -712,8 +751,8 @@ _mb_execute_one() {
     _mb_log_event target_done target "$name" outcome skipped_already_migrated
     return 0
   fi
-  log_info "  on-chain status: $cls_status  (balance=${balance}ulume)"
-  _mb_log_event classify target "$name" status "$cls_status" balance "$balance"
+  log_info "  on-chain status: $cls_status  (balance=${balance}ulume spendable=${spendable:-0}ulume)"
+  _mb_log_event classify target "$name" status "$cls_status" balance "$balance" spendable "${spendable:-0}"
 
   if [[ "$cls_status" == "unknown" ]]; then
     log_error "  could not classify on-chain state; check RPC and re-run"

--- a/scripts/migrate-batch.sh
+++ b/scripts/migrate-batch.sh
@@ -461,7 +461,7 @@ S_USAGE
 
   local count_migrated=0 count_ready=0 count_needs_pubkey=0 count_needs_funding=0 count_unknown=0
   log_info "=== Status (chain: $CHAIN_ID, node: $NODE) ==="
-  local row name addr kind status_lines status balance extra
+  local row name addr kind status_lines status balance spendable extra
   local n_rows
   n_rows=$(jq -r 'length' <<<"$targets")
   local i=0
@@ -473,13 +473,15 @@ S_USAGE
     status_lines=$(_mb_classify_target "$addr")
     status=$(awk 'NR==1' <<<"$status_lines")
     # Parse extras by key, not by line number — _mb_classify_target emits
-    # `balance=...` for non-migrated statuses and `new_address=...` when
-    # migrated. Positional parsing would mis-label one as the other.
+    # `balance=...` and `spendable=...` for non-migrated statuses and
+    # `new_address=...` when migrated. Positional parsing would mis-label.
     balance=$(awk -F= 'NR>1 && $1=="balance" {print $2}' <<<"$status_lines")
+    spendable=$(awk -F= 'NR>1 && $1=="spendable" {print $2}' <<<"$status_lines")
     extra=""
     if [[ "$status" == "migrated" ]]; then
       extra=" -> $(awk -F= 'NR>1 && $1=="new_address" {print $2}' <<<"$status_lines")"
       balance=""
+      spendable=""
     fi
     case "$status" in
       migrated)       count_migrated=$((count_migrated+1)) ;;
@@ -488,13 +490,18 @@ S_USAGE
       needs-funding)  count_needs_funding=$((count_needs_funding+1)) ;;
       *)              count_unknown=$((count_unknown+1)) ;;
     esac
-    printf '  %-12s [%-10s] %-30s %s%s%s\n' \
+    # Surface spendable alongside balance so operators understand why a
+    # vesting-locked account (balance>0, spendable=0) is needs-funding.
+    printf '  %-12s [%-10s] %-30s %s%s%s%s\n' \
       "$status" "$kind" "$name" "$addr" \
-      "${balance:+  balance=${balance}ulume}" "$extra"
+      "${balance:+  balance=${balance}ulume}" \
+      "${spendable:+  spendable=${spendable}ulume}" \
+      "$extra"
     i=$((i+1))
   done
   printf '\nSummary: migrated=%s ready=%s needs-pubkey=%s needs-funding=%s unknown=%s\n' \
     "$count_migrated" "$count_ready" "$count_needs_pubkey" "$count_needs_funding" "$count_unknown"
+  printf 'Note: needs-funding includes targets where spendable=0 even when balance>0 (vesting-locked).\n'
 }
 
 ###############################################################################

--- a/tests/scripts/migrate-batch.bats
+++ b/tests/scripts/migrate-batch.bats
@@ -95,6 +95,55 @@ write_fixture_mixed() {
 JSON
 }
 
+write_fixture_standalone() {
+  local out="$1"
+  cat >"$out" <<'JSON'
+{
+  "standalone": {
+    "address": "lumera1standalone",
+    "mnemonic": "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art",
+    "pubkey": "{\"@type\":\"/cosmos.crypto.secp256k1.PubKey\",\"key\":\"STANDALONE\"}",
+    "type": "local"
+  }
+}
+JSON
+}
+
+write_lumerad_status_shim() {
+  local out="$1"
+  cat >"$out" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$*" == *"--help"* ]]; then
+  exit 0
+fi
+
+if [[ "${1-}" == "query" && "${2-}" == "evmigration" && "${3-}" == "migration-record" ]]; then
+  exit 1
+fi
+
+if [[ "${1-}" == "query" && "${2-}" == "bank" && "${3-}" == "balances" ]]; then
+  printf '{"balances":[{"denom":"ulume","amount":"%s"}]}\n' "${FAKE_BALANCE_ULUME:-500000}"
+  exit 0
+fi
+
+if [[ "${1-}" == "query" && "${2-}" == "bank" && "${3-}" == "spendable-balances" ]]; then
+  printf '{"balances":[{"denom":"ulume","amount":"%s"}]}\n' "${FAKE_SPENDABLE_ULUME:-0}"
+  exit 0
+fi
+
+if [[ "${1-}" == "query" && "${2-}" == "auth" && "${3-}" == "account" ]]; then
+  printf '{"account":{"@type":"/cosmos.auth.v1beta1.BaseAccount","address":"%s"}}\n' "${4-}"
+  exit 0
+fi
+
+printf 'unexpected lumerad shim args: %s\n' "$*" >&2
+exit 1
+SH
+  chmod +x "$out"
+}
+
 ###############################################################################
 # Tests
 ###############################################################################
@@ -271,4 +320,34 @@ JSON
   [ -s "$plan" ]
   run jq -e 'type == "object" and (.targets | type == "array")' "$plan"
   [ "$status" -eq 0 ]
+}
+
+@test "status: spendable below self-send amount plus fee requires funding" {
+  local fix="$TMPDIR/fix.json"
+  local shim="$TMPDIR/lumerad-shim"
+  write_fixture_standalone "$fix"
+  write_lumerad_status_shim "$shim"
+
+  run env FAKE_SPENDABLE_ULUME=104999 "$MIGRATE_BATCH" status \
+    --mnemonics "$fix" \
+    --chain-id lumera-test \
+    --binary "$shim"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"needs-funding"* ]]
+  [[ "$output" == *"spendable=104999ulume"* ]]
+}
+
+@test "status: spendable equal to self-send amount plus fee can self-send" {
+  local fix="$TMPDIR/fix.json"
+  local shim="$TMPDIR/lumerad-shim"
+  write_fixture_standalone "$fix"
+  write_lumerad_status_shim "$shim"
+
+  run env FAKE_SPENDABLE_ULUME=105000 "$MIGRATE_BATCH" status \
+    --mnemonics "$fix" \
+    --chain-id lumera-test \
+    --binary "$shim"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"needs-pubkey"* ]]
+  [[ "$output" == *"spendable=105000ulume"* ]]
 }


### PR DESCRIPTION
## Summary

`migrate-batch.sh` classifier silently routed **vesting-locked** multisigs onto the no-funder code path, where they failed at broadcast.

On a fresh `v1.20.0-rc5` local devnet booted with mainnet-shape genesis (testnet-2 bundle, voting=15m, expedited=5m, `max-txs=10000`), running `migrate-batch.sh execute` over the 31 foundation accounts produced:

| | Before | After |
|---|---|---|
| ✅ Migrated | 12/31 | **31/31** |
| ❌ Failed | 19/31 | 0/31 |

Every one of the 19 failures was a continuous-vesting multisig with `balance > 0` but `spendable = 0`. The chain-side error was always:

```
spendable balance 0ulume is smaller than 5000ulume: insufficient funds
```

## Root cause

`_mb_classify_target` only queried `bank balances` (TOTAL). For vesting accounts that's misleading — the ante handler charges fees against **spendable**, not total. The decision was:

```bash
if (( acct_known == 1 )) || [[ "$balance" != "0" ]]; then
  printf 'needs-pubkey\n'    # ← funder NEVER fires for vesting-locked
else
  printf 'needs-funding\n'
fi
```

So a vesting multisig with `balance=5T, spendable=0` got `needs-pubkey`, the script tried `_mb_multisig_self_send` with no funding, ante rejected, target failed.

This is the dominant shape on mainnet — foundation multisigs are continuous-vesting and remain locked for years (`advisors_*`, `seed_sale_2-5`, `private_sale_3-6`, `team_2-6`, `eco_dev_7`, …). An operator running the batch driver on launch day would have hit silent failures on all of them.

## Fix

1. Also query `bank spendable-balances` in `_mb_classify_target`.
2. New constant `_MB_MIN_SELF_SEND_SPENDABLE_ULUME=10000` (self-send fee 5000 + headroom).
3. Classifier emits `needs-funding` whenever `spendable < threshold`, even if total balance is large → funder path tops the target up before the self-send.
4. Surface `spendable=<ulume>` in:
   - operator log line
   - JSONL audit `classify` event
   - docstring + `report` subcommand `--help`

If the `spendable-balances` query fails (older binary, transient RPC), treat as `spendable=0` → safer to over-fund than to silently broadcast a doomed tx.

## Verification

Two end-to-end runs on the same rc5 devnet, same mnemonics, same `--funder`:

### Before (PR #163 head)
```
INFO  === Batch summary ===
INFO    succeeded : 12
INFO    failed    : 19
```
Failure signature on every locked target: `multisig_self_send_failed` → `insufficient funds`.

### After (this PR)
```
INFO  === Batch summary ===
INFO    succeeded : 31
INFO    failed    : 0
INFO    remaining : 0
```
Chain confirms:
```json
{ "total_migrated": "31", "total_legacy": "21" }
```

Audit-log evidence for a vesting-locked target:
```json
{"event":"classify","target":"ecosystem_development_7","status":"needs-funding","balance":"11250000000000","spendable":"0"}
```

Includes the non-sequential signer-order multisigs that prompted PR #176 (`team_3` [s3,s2,s1], `seed_sale_2` [s1,s3,s2], `team_6` [vesting til 2028], etc.) — all addresses reconstructed byte-for-byte and migrated.

### Static checks
- `shellcheck -x -e SC1091,SC2034 scripts/migrate-batch.sh` → clean
- `bats tests/scripts/migrate-batch.bats` → 11/11 pass (report-mode tests unaffected)

## Operator impact

- Behavior strictly safer: a class of targets that previously **silently broke** now go through the funder path that already exists. No new flags. No flag-default changes.
- Operators must still pass `--funder` (with enough balance) when any target needs funding. This was already documented and required for the zero-balance case.
- `--top-up-amount` default (200000ulume) is already sized for both cases.

## Risk

- **Determinism**: pure classifier change; no state mutation.
- **Migration semantics**: unchanged — the actual `claim-multisig` ceremony is identical, only the pre-step (self-send vs. funder-then-self-send) differs.
- **Failure mode if `bank spendable-balances` is unavailable**: we treat as `spendable=0` → routes to funder. Funder path requires `--funder`; absent funder, the target errors out cleanly with the existing `needs_funder_not_provided` reason (same as the zero-balance path).
- **Backwards compat**: report-subcommand text in `report`/`--help` updated; JSONL audit adds a new `spendable` field — additive only.

## Rollback

Revert the single commit. No state migration. No state on chain depends on this script.

## Related

- Depends on chain fix in #167 (zero-signer multisig tx mempool path).
- Complements #176 (multisig `--nosort` sign-time guard).
- Builds on #163 (batch driver landed in master).
