### PR TITLE
evmigration: optimize validator migration for large delegator sets

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -54,6 +54,7 @@ import (
 	consensuskeeper "github.com/cosmos/cosmos-sdk/x/consensus/keeper"
 	_ "github.com/cosmos/cosmos-sdk/x/distribution" // import for side-effects
 	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
@@ -365,6 +366,9 @@ func New(
 	// DeleteValidatorRecordNoHooks). Unsafe / migration-only.
 	app.EvmigrationKeeper.SetStakingStoreService(
 		runtime.NewKVStoreService(app.GetKey(stakingtypes.StoreKey)),
+	)
+	app.EvmigrationKeeper.SetDistributionStoreService(
+		runtime.NewKVStoreService(app.GetKey(distrtypes.StoreKey)),
 	)
 
 	// configure EVM coin info (must happen before EVM module keepers are created)

--- a/x/evmigration/keeper/keeper.go
+++ b/x/evmigration/keeper/keeper.go
@@ -20,6 +20,13 @@ type stakingStoreHandle struct {
 	svc corestore.KVStoreService
 }
 
+// distributionStoreHandle holds a mutable reference to distribution's
+// KVStoreService. It is wired post-depinject via SetDistributionStoreService and
+// used only by migration code that must range over validator-scoped prefixes.
+type distributionStoreHandle struct {
+	svc corestore.KVStoreService
+}
+
 type Keeper struct {
 	storeService corestore.KVStoreService
 	cdc          codec.Codec
@@ -33,6 +40,9 @@ type Keeper struct {
 	// x/staking's KV namespace. Wired post-build in app.go via
 	// SetStakingStoreService; used exclusively by DeleteValidatorRecordNoHooks.
 	stakingStoreHandle *stakingStoreHandle
+	// distributionStoreHandle grants this keeper migration-only raw read access
+	// to x/distribution's KV namespace for validator-scoped iteration.
+	distributionStoreHandle *distributionStoreHandle
 
 	// MigrationRecords stores completed migration records keyed by legacy address.
 	MigrationRecords collections.Map[string, types.MigrationRecord]
@@ -107,7 +117,8 @@ func NewKeeper(
 		// Allocate once so value-copies of Keeper (e.g. app.EvmigrationKeeper
 		// and AppModule.keeper) share the same mutable handle. app.go writes
 		// the staking store service into it post-build.
-		stakingStoreHandle: &stakingStoreHandle{},
+		stakingStoreHandle:      &stakingStoreHandle{},
+		distributionStoreHandle: &distributionStoreHandle{},
 	}
 
 	schema, err := sb.Build()
@@ -134,4 +145,14 @@ func (k Keeper) GetAuthority() []byte {
 // for any other purpose.
 func (k *Keeper) SetStakingStoreService(svc corestore.KVStoreService) {
 	k.stakingStoreHandle.svc = svc
+}
+
+// SetDistributionStoreService wires the distribution module's KVStoreService
+// into this keeper. Required for production validator migration to iterate only
+// validator-scoped distribution prefixes instead of chain-wide stores.
+//
+// UNSAFE / MIGRATION-ONLY: this grants raw read access to x/distribution's KV
+// namespace. Do NOT use for unrelated keeper logic.
+func (k *Keeper) SetDistributionStoreService(svc corestore.KVStoreService) {
+	k.distributionStoreHandle.svc = svc
 }

--- a/x/evmigration/keeper/migrate_distribution.go
+++ b/x/evmigration/keeper/migrate_distribution.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
 // MigrateDistribution withdraws all pending delegation rewards for legacyAddr,
@@ -109,46 +108,28 @@ func (k Keeper) incrementHistoricalRewardsReferenceCount(ctx sdk.Context, valAdd
 	return k.adjustHistoricalRewardsReferenceCount(ctx, valAddr, period, 1, false)
 }
 
-// resetHistoricalRewardsReferenceCount sets the reference count to 1 (base only),
-// clearing stale delegator references before re-creating delegations.
-func (k Keeper) resetHistoricalRewardsReferenceCount(ctx sdk.Context, valAddr sdk.ValAddress, period uint64) error {
-	var (
-		found      bool
-		historical distrtypes.ValidatorHistoricalRewards
-	)
-
-	k.distributionKeeper.IterateValidatorHistoricalRewards(ctx, func(val sdk.ValAddress, p uint64, rewards distrtypes.ValidatorHistoricalRewards) (stop bool) {
-		if val.Equals(valAddr) && p == period {
-			found = true
-			historical = rewards
-			return true
-		}
-		return false
-	})
-
+// setHistoricalRewardsReferenceCount overwrites the reference count of a single
+// (valAddr, period) historical rewards row. Used to set the count in one write
+// instead of a reset-then-increment-per-delegation loop, clearing stale
+// delegator references in the process.
+func (k Keeper) setHistoricalRewardsReferenceCount(ctx sdk.Context, valAddr sdk.ValAddress, period uint64, count uint32) error {
+	historical, found, err := k.validatorHistoricalReward(ctx, valAddr, period)
+	if err != nil {
+		return err
+	}
 	if !found {
 		return fmt.Errorf("validator historical rewards not found for %s period %d", valAddr.String(), period)
 	}
 
-	historical.ReferenceCount = 1
+	historical.ReferenceCount = count
 	return k.distributionKeeper.SetValidatorHistoricalRewards(ctx, valAddr, period, historical)
 }
 
 func (k Keeper) adjustHistoricalRewardsReferenceCount(ctx sdk.Context, valAddr sdk.ValAddress, period uint64, delta int64, repairZero bool) error {
-	var (
-		found      bool
-		historical distrtypes.ValidatorHistoricalRewards
-	)
-
-	k.distributionKeeper.IterateValidatorHistoricalRewards(ctx, func(val sdk.ValAddress, p uint64, rewards distrtypes.ValidatorHistoricalRewards) (stop bool) {
-		if val.Equals(valAddr) && p == period {
-			found = true
-			historical = rewards
-			return true
-		}
-		return false
-	})
-
+	historical, found, err := k.validatorHistoricalReward(ctx, valAddr, period)
+	if err != nil {
+		return err
+	}
 	if !found {
 		return fmt.Errorf("validator historical rewards not found for %s period %d", valAddr.String(), period)
 	}

--- a/x/evmigration/keeper/migrate_test.go
+++ b/x/evmigration/keeper/migrate_test.go
@@ -1,12 +1,15 @@
 package keeper_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	"cosmossdk.io/x/feegrant"
+	"github.com/cosmos/cosmos-sdk/codec"
 	addresscodec "github.com/cosmos/cosmos-sdk/codec/address"
 	kmultisig "github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -37,6 +40,9 @@ import (
 type mockFixture struct {
 	ctx                sdk.Context
 	keeper             keeper.Keeper
+	cdc                codec.Codec
+	stakingStore       corestore.KVStoreService
+	distributionStore  corestore.KVStoreService
 	accountKeeper      *evmigrationmocks.MockAccountKeeper
 	bankKeeper         *evmigrationmocks.MockBankKeeper
 	stakingKeeper      *evmigrationmocks.MockStakingKeeper
@@ -66,8 +72,20 @@ func initMockFixture(t *testing.T) *mockFixture {
 	encCfg := moduletestutil.MakeTestEncodingConfig(module.AppModule{})
 	addrCodec := addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+	stakingStoreKey := storetypes.NewKVStoreKey(stakingtypes.StoreKey)
+	distributionStoreKey := storetypes.NewKVStoreKey(distrtypes.StoreKey)
 	storeService := runtime.NewKVStoreService(storeKey)
-	ctx := testutil.DefaultContextWithDB(t, storeKey, storetypes.NewTransientStoreKey("transient_test")).Ctx
+	stakingStoreService := runtime.NewKVStoreService(stakingStoreKey)
+	distributionStoreService := runtime.NewKVStoreService(distributionStoreKey)
+	ctx := testutil.DefaultContextWithKeys(
+		map[string]*storetypes.KVStoreKey{
+			types.StoreKey:        storeKey,
+			stakingtypes.StoreKey: stakingStoreKey,
+			distrtypes.StoreKey:   distributionStoreKey,
+		},
+		map[string]*storetypes.TransientStoreKey{"transient_test": storetypes.NewTransientStoreKey("transient_test")},
+		nil,
+	)
 
 	authority := authtypes.NewModuleAddress(types.GovModuleName)
 
@@ -96,6 +114,9 @@ func initMockFixture(t *testing.T) *mockFixture {
 	return &mockFixture{
 		ctx:                ctx,
 		keeper:             k,
+		cdc:                encCfg.Codec,
+		stakingStore:       stakingStoreService,
+		distributionStore:  distributionStoreService,
 		accountKeeper:      accountKeeper,
 		bankKeeper:         bankKeeper,
 		stakingKeeper:      stakingKeeper,
@@ -105,6 +126,70 @@ func initMockFixture(t *testing.T) *mockFixture {
 		supernodeKeeper:    supernodeKeeper,
 		actionKeeper:       actionKeeper,
 		claimKeeper:        claimKeeper,
+	}
+}
+
+func (f *mockFixture) wireScopedMigrationStores() {
+	f.keeper.SetStakingStoreService(f.stakingStore)
+	f.keeper.SetDistributionStoreService(f.distributionStore)
+}
+
+func (f *mockFixture) writeRedelegation(red stakingtypes.Redelegation) {
+	delegator, err := sdk.AccAddressFromBech32(red.DelegatorAddress)
+	if err != nil {
+		panic(err)
+	}
+	src, err := sdk.ValAddressFromBech32(red.ValidatorSrcAddress)
+	if err != nil {
+		panic(err)
+	}
+	dst, err := sdk.ValAddressFromBech32(red.ValidatorDstAddress)
+	if err != nil {
+		panic(err)
+	}
+
+	store := f.stakingStore.OpenKVStore(f.ctx)
+	bz := stakingtypes.MustMarshalRED(f.cdc, red)
+	if err := store.Set(stakingtypes.GetREDKey(delegator, src, dst), bz); err != nil {
+		panic(err)
+	}
+	if err := store.Set(stakingtypes.GetREDByValSrcIndexKey(delegator, src, dst), []byte{}); err != nil {
+		panic(err)
+	}
+	if err := store.Set(stakingtypes.GetREDByValDstIndexKey(delegator, src, dst), []byte{}); err != nil {
+		panic(err)
+	}
+}
+
+func (f *mockFixture) writeRedelegationIndexes(delegator sdk.AccAddress, src, dst sdk.ValAddress) {
+	store := f.stakingStore.OpenKVStore(f.ctx)
+	if err := store.Set(stakingtypes.GetREDByValSrcIndexKey(delegator, src, dst), []byte{}); err != nil {
+		panic(err)
+	}
+	if err := store.Set(stakingtypes.GetREDByValDstIndexKey(delegator, src, dst), []byte{}); err != nil {
+		panic(err)
+	}
+}
+
+func (f *mockFixture) writeValidatorHistoricalRewards(
+	val sdk.ValAddress,
+	period uint64,
+	rewards distrtypes.ValidatorHistoricalRewards,
+) {
+	store := f.distributionStore.OpenKVStore(f.ctx)
+	if err := store.Set(distrtypes.GetValidatorHistoricalRewardsKey(val, period), f.cdc.MustMarshal(&rewards)); err != nil {
+		panic(err)
+	}
+}
+
+func (f *mockFixture) writeValidatorSlashEvent(
+	val sdk.ValAddress,
+	height uint64,
+	event distrtypes.ValidatorSlashEvent,
+) {
+	store := f.distributionStore.OpenKVStore(f.ctx)
+	if err := store.Set(distrtypes.GetValidatorSlashEventKey(val, height, event.ValidatorPeriod), f.cdc.MustMarshal(&event)); err != nil {
+		panic(err)
 	}
 }
 
@@ -1523,6 +1608,175 @@ func TestMigrateValidatorDelegations_WithUnbondingAndRedelegation(t *testing.T) 
 	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), uint64(89)).Return(nil)
 
 	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr)
+	require.NoError(t, err)
+}
+
+func TestMigrateValidatorDelegations_UsesScopedRedelegationIndexes(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+	delegator := testAccAddr()
+	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
+
+	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
+	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
+
+	dstVal := sdk.ValAddress(testAccAddr())
+	srcRed := stakingtypes.Redelegation{
+		DelegatorAddress:    delegator.String(),
+		ValidatorSrcAddress: oldValAddr.String(),
+		ValidatorDstAddress: dstVal.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 8,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(50),
+			SharesDst:      math.LegacyNewDec(50),
+			UnbondingId:    88,
+		}},
+	}
+	srcVal := sdk.ValAddress(testAccAddr())
+	dstRed := stakingtypes.Redelegation{
+		DelegatorAddress:    delegator.String(),
+		ValidatorSrcAddress: srcVal.String(),
+		ValidatorDstAddress: oldValAddr.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 9,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(75),
+			SharesDst:      math.LegacyNewDec(75),
+			UnbondingId:    89,
+		}},
+	}
+	unrelatedRed := stakingtypes.Redelegation{
+		DelegatorAddress:    testAccAddr().String(),
+		ValidatorSrcAddress: sdk.ValAddress(testAccAddr()).String(),
+		ValidatorDstAddress: sdk.ValAddress(testAccAddr()).String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 10,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(100),
+			SharesDst:      math.LegacyNewDec(100),
+			UnbondingId:    90,
+		}},
+	}
+	f.writeRedelegation(srcRed)
+	f.writeRedelegation(dstRed)
+	f.writeRedelegation(unrelatedRed)
+
+	rewritten := map[uint64]stakingtypes.Redelegation{}
+	f.stakingKeeper.EXPECT().RemoveRedelegation(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	f.stakingKeeper.EXPECT().SetRedelegation(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ any, red stakingtypes.Redelegation) error {
+			require.True(t, red.ValidatorSrcAddress == newValAddr.String() || red.ValidatorDstAddress == newValAddr.String())
+			require.False(t, red.ValidatorSrcAddress == oldValAddr.String())
+			require.False(t, red.ValidatorDstAddress == oldValAddr.String())
+			rewritten[red.Entries[0].UnbondingId] = red
+			return nil
+		},
+	).Times(2)
+	f.stakingKeeper.EXPECT().InsertRedelegationQueue(gomock.Any(), gomock.Any(), completionTime).Return(nil).Times(2)
+	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr)
+	require.NoError(t, err)
+	require.Len(t, rewritten, 2)
+	require.Equal(t, newValAddr.String(), rewritten[88].ValidatorSrcAddress)
+	require.Equal(t, dstVal.String(), rewritten[88].ValidatorDstAddress)
+	require.Equal(t, srcVal.String(), rewritten[89].ValidatorSrcAddress)
+	require.Equal(t, newValAddr.String(), rewritten[89].ValidatorDstAddress)
+}
+
+func TestMigrateValidatorDelegations_DeduplicatesSourceAndDestinationIndexes(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+	delegator := testAccAddr()
+	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
+
+	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
+	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
+
+	red := stakingtypes.Redelegation{
+		DelegatorAddress:    delegator.String(),
+		ValidatorSrcAddress: oldValAddr.String(),
+		ValidatorDstAddress: oldValAddr.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 10,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(100),
+			SharesDst:      math.LegacyNewDec(100),
+			UnbondingId:    101,
+		}},
+	}
+	f.writeRedelegation(red)
+
+	f.stakingKeeper.EXPECT().RemoveRedelegation(gomock.Any(), red).Return(nil).Times(1)
+	f.stakingKeeper.EXPECT().SetRedelegation(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ any, migrated stakingtypes.Redelegation) error {
+			require.Equal(t, newValAddr.String(), migrated.ValidatorSrcAddress)
+			require.Equal(t, newValAddr.String(), migrated.ValidatorDstAddress)
+			return nil
+		},
+	).Times(1)
+	f.stakingKeeper.EXPECT().InsertRedelegationQueue(gomock.Any(), gomock.Any(), completionTime).Return(nil).Times(1)
+	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), uint64(101)).Return(nil).Times(1)
+
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr)
+	require.NoError(t, err)
+}
+
+func TestMigrateValidatorDelegations_ReturnsErrorForStaleRedelegationIndex(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+	delegator := testAccAddr()
+	dstValAddr := sdk.ValAddress(testAccAddr())
+
+	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
+	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
+
+	f.writeRedelegationIndexes(delegator, oldValAddr, dstValAddr)
+
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "points to missing record")
+}
+
+func TestMigrateValidatorDistribution_UsesScopedDistributionPrefixes(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+	otherValAddr := sdk.ValAddress(testAccAddr())
+
+	oldRewards := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 7}
+	otherRewards := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 99}
+	oldSlash := distrtypes.ValidatorSlashEvent{ValidatorPeriod: 11, Fraction: math.LegacyMustNewDecFromStr("0.010000000000000000")}
+	otherSlash := distrtypes.ValidatorSlashEvent{ValidatorPeriod: 22, Fraction: math.LegacyMustNewDecFromStr("0.020000000000000000")}
+
+	f.writeValidatorHistoricalRewards(oldValAddr, 11, oldRewards)
+	f.writeValidatorHistoricalRewards(otherValAddr, 22, otherRewards)
+	f.writeValidatorSlashEvent(oldValAddr, 100, oldSlash)
+	f.writeValidatorSlashEvent(otherValAddr, 200, otherSlash)
+
+	notFound := errors.New("not found")
+	f.distributionKeeper.EXPECT().GetValidatorCurrentRewards(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorCurrentRewards{}, notFound)
+	f.distributionKeeper.EXPECT().GetValidatorAccumulatedCommission(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorAccumulatedCommission{}, notFound)
+	f.distributionKeeper.EXPECT().GetValidatorOutstandingRewards(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorOutstandingRewards{}, notFound)
+
+	f.distributionKeeper.EXPECT().DeleteValidatorHistoricalRewards(gomock.Any(), oldValAddr)
+	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, uint64(11), oldRewards).Return(nil)
+	f.distributionKeeper.EXPECT().DeleteValidatorSlashEvents(gomock.Any(), oldValAddr)
+	f.distributionKeeper.EXPECT().SetValidatorSlashEvent(gomock.Any(), newValAddr, uint64(100), oldSlash.ValidatorPeriod, oldSlash).Return(nil)
+
+	err := f.keeper.MigrateValidatorDistribution(f.ctx, oldValAddr, newValAddr)
 	require.NoError(t, err)
 }
 

--- a/x/evmigration/keeper/migrate_test.go
+++ b/x/evmigration/keeper/migrate_test.go
@@ -193,6 +193,21 @@ func (f *mockFixture) writeValidatorSlashEvent(
 	}
 }
 
+func countKVPrefix(t *testing.T, storeService corestore.KVStoreService, ctx sdk.Context, prefix []byte) int {
+	t.Helper()
+
+	store := storeService.OpenKVStore(ctx)
+	iterator, err := store.Iterator(prefix, storetypes.PrefixEndBytes(prefix))
+	require.NoError(t, err)
+	defer func() { _ = iterator.Close() }()
+
+	var count int
+	for ; iterator.Valid(); iterator.Next() {
+		count++
+	}
+	return count
+}
+
 func testAccAddr() sdk.AccAddress {
 	return sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
 }
@@ -219,9 +234,10 @@ func expectHistoricalRewardsIncrement(
 	mock.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), val, period, gomock.Any()).Return(nil)
 }
 
-// expectHistoricalRewardsReset sets up mock expectations for
-// resetHistoricalRewardsReferenceCount: iterate to find the period, then set refcount to 1.
-func expectHistoricalRewardsReset(
+// expectHistoricalRewardsSet sets up mock expectations for
+// setHistoricalRewardsReferenceCount: look up the (val, period) row, then write
+// its refcount back in a single set.
+func expectHistoricalRewardsSet(
 	mock *evmigrationmocks.MockDistributionKeeper,
 	val sdk.ValAddress,
 	period uint64,
@@ -1517,8 +1533,7 @@ func TestMigrateValidatorDelegations_WithUnbondingAndRedelegation(t *testing.T) 
 
 	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
 
-	// No active delegations.
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
+	// No active delegations (passed in directly, not fetched).
 
 	// One unbonding delegation with an UnbondingId.
 	ubd := stakingtypes.UnbondingDelegation{
@@ -1534,9 +1549,6 @@ func TestMigrateValidatorDelegations_WithUnbondingAndRedelegation(t *testing.T) 
 			},
 		},
 	}
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(
-		[]stakingtypes.UnbondingDelegation{ubd}, nil,
-	)
 	f.stakingKeeper.EXPECT().RemoveUnbondingDelegation(gomock.Any(), ubd).Return(nil)
 	f.stakingKeeper.EXPECT().SetUnbondingDelegation(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ any, newUbd stakingtypes.UnbondingDelegation) error {
@@ -1579,6 +1591,8 @@ func TestMigrateValidatorDelegations_WithUnbondingAndRedelegation(t *testing.T) 
 			},
 		},
 	}
+	// Redelegations are discovered by an internal scan; this fixture leaves the
+	// scoped store unwired, so the scan falls back to IterateRedelegations.
 	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ any, fn func(int64, stakingtypes.Redelegation) bool) error {
 			require.False(t, fn(0, srcRed))
@@ -1607,7 +1621,12 @@ func TestMigrateValidatorDelegations_WithUnbondingAndRedelegation(t *testing.T) 
 	f.stakingKeeper.EXPECT().InsertRedelegationQueue(gomock.Any(), gomock.Any(), completionTime).Return(nil)
 	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), uint64(89)).Return(nil)
 
-	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr)
+	err := f.keeper.MigrateValidatorDelegations(
+		f.ctx, oldValAddr, newValAddr,
+		nil,
+		[]stakingtypes.UnbondingDelegation{ubd},
+		nil,
+	)
 	require.NoError(t, err)
 }
 
@@ -1619,9 +1638,6 @@ func TestMigrateValidatorDelegations_UsesScopedRedelegationIndexes(t *testing.T)
 	newValAddr := sdk.ValAddress(testAccAddr())
 	delegator := testAccAddr()
 	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
-
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
 
 	dstVal := sdk.ValAddress(testAccAddr())
 	srcRed := stakingtypes.Redelegation{
@@ -1679,7 +1695,9 @@ func TestMigrateValidatorDelegations_UsesScopedRedelegationIndexes(t *testing.T)
 	f.stakingKeeper.EXPECT().InsertRedelegationQueue(gomock.Any(), gomock.Any(), completionTime).Return(nil).Times(2)
 	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
-	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr)
+	// V4's internal scoped scan discovers the two related redelegations
+	// (dropping the unrelated one) and re-keys exactly those.
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr, nil, nil, nil)
 	require.NoError(t, err)
 	require.Len(t, rewritten, 2)
 	require.Equal(t, newValAddr.String(), rewritten[88].ValidatorSrcAddress)
@@ -1696,9 +1714,6 @@ func TestMigrateValidatorDelegations_DeduplicatesSourceAndDestinationIndexes(t *
 	newValAddr := sdk.ValAddress(testAccAddr())
 	delegator := testAccAddr()
 	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
-
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
 
 	red := stakingtypes.Redelegation{
 		DelegatorAddress:    delegator.String(),
@@ -1725,7 +1740,48 @@ func TestMigrateValidatorDelegations_DeduplicatesSourceAndDestinationIndexes(t *
 	f.stakingKeeper.EXPECT().InsertRedelegationQueue(gomock.Any(), gomock.Any(), completionTime).Return(nil).Times(1)
 	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), uint64(101)).Return(nil).Times(1)
 
-	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr)
+	// V4's internal scan collects the doubly-indexed redelegation exactly once
+	// (src == dst), so it is re-keyed a single time (the .Times(1) mocks above).
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr, nil, nil, nil)
+	require.NoError(t, err)
+}
+
+func TestMigrateValidatorDelegations_UsesPreloadedRedelegations(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+	dstValAddr := sdk.ValAddress(testAccAddr())
+	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
+
+	red := stakingtypes.Redelegation{
+		DelegatorAddress:    testAccAddr().String(),
+		ValidatorSrcAddress: oldValAddr.String(),
+		ValidatorDstAddress: dstValAddr.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 10,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(100),
+			SharesDst:      math.LegacyNewDec(100),
+			UnbondingId:    111,
+		}},
+	}
+
+	f.stakingKeeper.EXPECT().RemoveRedelegation(gomock.Any(), red).Return(nil).Times(1)
+	f.stakingKeeper.EXPECT().SetRedelegation(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ sdk.Context, migrated stakingtypes.Redelegation) error {
+			require.Equal(t, newValAddr.String(), migrated.ValidatorSrcAddress)
+			require.Equal(t, dstValAddr.String(), migrated.ValidatorDstAddress)
+			return nil
+		},
+	).Times(1)
+	f.stakingKeeper.EXPECT().InsertRedelegationQueue(gomock.Any(), gomock.Any(), completionTime).Return(nil).Times(1)
+	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), uint64(111)).Return(nil).Times(1)
+
+	// The staking store intentionally has no redelegation rows. Passing a
+	// non-nil preloaded slice proves V4 does not rescan the scoped indexes.
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr, nil, nil, []stakingtypes.Redelegation{red})
 	require.NoError(t, err)
 }
 
@@ -1738,12 +1794,12 @@ func TestMigrateValidatorDelegations_ReturnsErrorForStaleRedelegationIndex(t *te
 	delegator := testAccAddr()
 	dstValAddr := sdk.ValAddress(testAccAddr())
 
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
-
 	f.writeRedelegationIndexes(delegator, oldValAddr, dstValAddr)
 
-	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr)
+	// A stale redelegation index (no backing record) surfaces from V4's internal
+	// scoped scan, which aborts before re-keying anything. delegations/ubds are
+	// nil, so the scan runs first and its error propagates unchanged.
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr, nil, nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "points to missing record")
 }
@@ -1778,6 +1834,312 @@ func TestMigrateValidatorDistribution_UsesScopedDistributionPrefixes(t *testing.
 
 	err := f.keeper.MigrateValidatorDistribution(f.ctx, oldValAddr, newValAddr)
 	require.NoError(t, err)
+}
+
+func TestMigrateValidatorDelegations_RekeysMultipleSourceRedelegations(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
+
+	// Two redelegations that both have oldValAddr as SOURCE, from distinct
+	// delegators to distinct destinations. Both live under the same val-src
+	// index prefix, so the scan must advance the iterator past the first key.
+	dstA := sdk.ValAddress(testAccAddr())
+	dstB := sdk.ValAddress(testAccAddr())
+	redA := stakingtypes.Redelegation{
+		DelegatorAddress:    testAccAddr().String(),
+		ValidatorSrcAddress: oldValAddr.String(),
+		ValidatorDstAddress: dstA.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 8,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(50),
+			SharesDst:      math.LegacyNewDec(50),
+			UnbondingId:    201,
+		}},
+	}
+	redB := stakingtypes.Redelegation{
+		DelegatorAddress:    testAccAddr().String(),
+		ValidatorSrcAddress: oldValAddr.String(),
+		ValidatorDstAddress: dstB.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 9,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(75),
+			SharesDst:      math.LegacyNewDec(75),
+			UnbondingId:    202,
+		}},
+	}
+	f.writeRedelegation(redA)
+	f.writeRedelegation(redB)
+
+	rewritten := map[uint64]stakingtypes.Redelegation{}
+	f.stakingKeeper.EXPECT().RemoveRedelegation(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	f.stakingKeeper.EXPECT().SetRedelegation(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ any, red stakingtypes.Redelegation) error {
+			require.Equal(t, newValAddr.String(), red.ValidatorSrcAddress)
+			require.NotEqual(t, oldValAddr.String(), red.ValidatorDstAddress)
+			rewritten[red.Entries[0].UnbondingId] = red
+			return nil
+		},
+	).Times(2)
+	f.stakingKeeper.EXPECT().InsertRedelegationQueue(gomock.Any(), gomock.Any(), completionTime).Return(nil).Times(2)
+	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+
+	// Both redelegations share the val-src index prefix; V4's internal scan must
+	// advance the iterator past the first key to collect (and re-key) both.
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr, nil, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, rewritten, 2)
+	require.Equal(t, dstA.String(), rewritten[201].ValidatorDstAddress)
+	require.Equal(t, dstB.String(), rewritten[202].ValidatorDstAddress)
+}
+
+// TestMigrateValidatorDelegations_SetsHistoricalRewardsRefCountOnce pins the V4
+// optimization: rather than resetting the target period's historical-rewards
+// reference count and then incrementing it once per delegation (N+1 full-chain
+// scans), the count is written exactly once as base(1) + N. The scoped
+// distribution store is wired, so the lookup is the production O(1) store.Get
+// path; the single write is captured to assert the exact final count. A wrong
+// count (off-by-one) or a per-delegation-increment regression (Times(1) → N)
+// both fail here.
+func TestMigrateValidatorDelegations_SetsHistoricalRewardsRefCountOnce(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+
+	// Three active delegations from distinct delegators.
+	dels := make([]stakingtypes.Delegation, 3)
+	for i := range dels {
+		dels[i] = stakingtypes.NewDelegation(testAccAddr().String(), oldValAddr.String(), math.LegacyNewDec(int64(10*(i+1))))
+	}
+
+	// Current rewards period 5 → target (previous) period 4.
+	const targetPeriod = uint64(4)
+	f.distributionKeeper.EXPECT().GetValidatorCurrentRewards(gomock.Any(), newValAddr).Return(
+		distrtypes.ValidatorCurrentRewards{Period: 5}, nil,
+	)
+	// Seed a stale base row so the scoped O(1) lookup succeeds; its count must be
+	// overwritten in a single write, not incremented from.
+	f.writeValidatorHistoricalRewards(newValAddr, targetPeriod, distrtypes.ValidatorHistoricalRewards{ReferenceCount: 1})
+
+	// The refcount write must happen EXACTLY once; a per-delegation increment
+	// regression would call it N times and fail the Times(1) bound.
+	var capturedRefCount uint32
+	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, targetPeriod, gomock.Any()).DoAndReturn(
+		func(_ sdk.Context, _ sdk.ValAddress, _ uint64, h distrtypes.ValidatorHistoricalRewards) error {
+			capturedRefCount = h.ReferenceCount
+			return nil
+		},
+	).Times(1)
+
+	// Per-delegation re-keying: no refcount call inside the loop. Each delegation's
+	// fresh starting info must reference the target period.
+	f.distributionKeeper.EXPECT().DeleteDelegatorStartingInfo(gomock.Any(), oldValAddr, gomock.Any()).Return(nil).Times(3)
+	f.stakingKeeper.EXPECT().RemoveDelegation(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	f.stakingKeeper.EXPECT().SetDelegation(gomock.Any(), gomock.Any()).Return(nil).Times(3)
+	f.distributionKeeper.EXPECT().SetDelegatorStartingInfo(gomock.Any(), newValAddr, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ sdk.Context, _ sdk.ValAddress, _ sdk.AccAddress, info distrtypes.DelegatorStartingInfo) error {
+			require.Equal(t, targetPeriod, info.PreviousPeriod)
+			return nil
+		},
+	).Times(3)
+
+	// Delegations passed in directly; no unbondings/redelegations.
+	err := f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr, dels, nil, nil)
+	require.NoError(t, err)
+	// base(1) + 3 delegations.
+	require.Equal(t, uint32(4), capturedRefCount)
+}
+
+func TestMigrateValidatorDistribution_RekeysAllPeriodsAndSlashEvents(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+	otherValAddr := sdk.ValAddress(testAccAddr())
+
+	// Two historical-reward periods for old, one for an unrelated validator.
+	// Distinct ReferenceCounts make the two re-key calls distinguishable.
+	rewards11 := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 7}
+	rewards42 := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 13}
+	otherRewards := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 99}
+	f.writeValidatorHistoricalRewards(oldValAddr, 11, rewards11)
+	f.writeValidatorHistoricalRewards(oldValAddr, 42, rewards42)
+	f.writeValidatorHistoricalRewards(otherValAddr, 11, otherRewards)
+
+	// Two slash events for old with DISTINCT heights AND periods (height!=period
+	// per event), plus one for an unrelated validator. Height comes from the
+	// store key, period from the unmarshaled value; making them differ pins down
+	// that the re-key does not swap the two.
+	slash100 := distrtypes.ValidatorSlashEvent{ValidatorPeriod: 5, Fraction: math.LegacyMustNewDecFromStr("0.010000000000000000")}
+	slash250 := distrtypes.ValidatorSlashEvent{ValidatorPeriod: 9, Fraction: math.LegacyMustNewDecFromStr("0.030000000000000000")}
+	otherSlash := distrtypes.ValidatorSlashEvent{ValidatorPeriod: 22, Fraction: math.LegacyMustNewDecFromStr("0.020000000000000000")}
+	f.writeValidatorSlashEvent(oldValAddr, 100, slash100)
+	f.writeValidatorSlashEvent(oldValAddr, 250, slash250)
+	f.writeValidatorSlashEvent(otherValAddr, 300, otherSlash)
+
+	notFound := errors.New("not found")
+	f.distributionKeeper.EXPECT().GetValidatorCurrentRewards(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorCurrentRewards{}, notFound)
+	f.distributionKeeper.EXPECT().GetValidatorAccumulatedCommission(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorAccumulatedCommission{}, notFound)
+	f.distributionKeeper.EXPECT().GetValidatorOutstandingRewards(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorOutstandingRewards{}, notFound)
+
+	f.distributionKeeper.EXPECT().DeleteValidatorHistoricalRewards(gomock.Any(), oldValAddr)
+	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, uint64(11), rewards11).Return(nil)
+	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, uint64(42), rewards42).Return(nil)
+
+	f.distributionKeeper.EXPECT().DeleteValidatorSlashEvents(gomock.Any(), oldValAddr)
+	f.distributionKeeper.EXPECT().SetValidatorSlashEvent(gomock.Any(), newValAddr, uint64(100), uint64(5), slash100).Return(nil)
+	f.distributionKeeper.EXPECT().SetValidatorSlashEvent(gomock.Any(), newValAddr, uint64(250), uint64(9), slash250).Return(nil)
+
+	err := f.keeper.MigrateValidatorDistribution(f.ctx, oldValAddr, newValAddr)
+	require.NoError(t, err)
+}
+
+func TestMigrateValidatorScopedIteration_SimulatesGlobalStateImprovement(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+
+	oldValAddr := sdk.ValAddress(testAccAddr())
+	newValAddr := sdk.ValAddress(testAccAddr())
+	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
+
+	const (
+		unrelatedValidators = 25
+		recordsPerValidator = 20
+	)
+	for i := 0; i < unrelatedValidators; i++ {
+		val := sdk.ValAddress(testAccAddr())
+		for j := 0; j < recordsPerValidator; j++ {
+			period := uint64(10_000 + i*recordsPerValidator + j)
+			height := uint64(20_000 + i*recordsPerValidator + j)
+			f.writeValidatorHistoricalRewards(val, period, distrtypes.ValidatorHistoricalRewards{ReferenceCount: uint32(1 + j%3)})
+			f.writeValidatorSlashEvent(
+				val,
+				height,
+				distrtypes.ValidatorSlashEvent{
+					ValidatorPeriod: period,
+					Fraction:        math.LegacyMustNewDecFromStr("0.010000000000000000"),
+				},
+			)
+			f.writeRedelegation(stakingtypes.Redelegation{
+				DelegatorAddress:    testAccAddr().String(),
+				ValidatorSrcAddress: sdk.ValAddress(testAccAddr()).String(),
+				ValidatorDstAddress: sdk.ValAddress(testAccAddr()).String(),
+				Entries: []stakingtypes.RedelegationEntry{{
+					CreationHeight: int64(height),
+					CompletionTime: completionTime,
+					InitialBalance: math.NewInt(100),
+					SharesDst:      math.LegacyNewDec(100),
+					UnbondingId:    uint64(30_000 + i*recordsPerValidator + j),
+				}},
+			})
+		}
+	}
+
+	rewards11 := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 7}
+	rewards12 := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 8}
+	rewards13 := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 9}
+	f.writeValidatorHistoricalRewards(oldValAddr, 11, rewards11)
+	f.writeValidatorHistoricalRewards(oldValAddr, 12, rewards12)
+	f.writeValidatorHistoricalRewards(oldValAddr, 13, rewards13)
+
+	slash100 := distrtypes.ValidatorSlashEvent{ValidatorPeriod: 21, Fraction: math.LegacyMustNewDecFromStr("0.020000000000000000")}
+	slash101 := distrtypes.ValidatorSlashEvent{ValidatorPeriod: 22, Fraction: math.LegacyMustNewDecFromStr("0.030000000000000000")}
+	f.writeValidatorSlashEvent(oldValAddr, 100, slash100)
+	f.writeValidatorSlashEvent(oldValAddr, 101, slash101)
+
+	dstValAddr := sdk.ValAddress(testAccAddr())
+	srcValAddr := sdk.ValAddress(testAccAddr())
+	srcRed := stakingtypes.Redelegation{
+		DelegatorAddress:    testAccAddr().String(),
+		ValidatorSrcAddress: oldValAddr.String(),
+		ValidatorDstAddress: dstValAddr.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 101,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(50),
+			SharesDst:      math.LegacyNewDec(50),
+			UnbondingId:    40_001,
+		}},
+	}
+	dstRed := stakingtypes.Redelegation{
+		DelegatorAddress:    testAccAddr().String(),
+		ValidatorSrcAddress: srcValAddr.String(),
+		ValidatorDstAddress: oldValAddr.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 102,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(75),
+			SharesDst:      math.LegacyNewDec(75),
+			UnbondingId:    40_002,
+		}},
+	}
+	f.writeRedelegation(srcRed)
+	f.writeRedelegation(dstRed)
+
+	broadScanKeys := countKVPrefix(t, f.distributionStore, f.ctx, distrtypes.ValidatorHistoricalRewardsPrefix) +
+		countKVPrefix(t, f.distributionStore, f.ctx, distrtypes.ValidatorSlashEventPrefix) +
+		countKVPrefix(t, f.stakingStore, f.ctx, stakingtypes.RedelegationKey)
+	scopedDistributionKeys := countKVPrefix(t, f.distributionStore, f.ctx, distrtypes.GetValidatorHistoricalRewardsPrefix(oldValAddr)) +
+		countKVPrefix(t, f.distributionStore, f.ctx, distrtypes.GetValidatorSlashEventPrefix(oldValAddr))
+	scopedRedelegationKeys := countKVPrefix(t, f.stakingStore, f.ctx, stakingtypes.GetREDsFromValSrcIndexKey(oldValAddr)) +
+		countKVPrefix(t, f.stakingStore, f.ctx, stakingtypes.GetREDsToValDstIndexKey(oldValAddr))
+	scopedKeysBeforeRedelegationReuse := scopedDistributionKeys + scopedRedelegationKeys + scopedRedelegationKeys
+	scopedKeysAfterRedelegationReuse := scopedDistributionKeys + scopedRedelegationKeys
+
+	require.Equal(t, 1507, broadScanKeys)
+	require.Equal(t, 9, scopedKeysBeforeRedelegationReuse)
+	require.Equal(t, 7, scopedKeysAfterRedelegationReuse)
+	require.GreaterOrEqual(t, broadScanKeys/scopedKeysAfterRedelegationReuse, 200)
+	t.Logf(
+		"simulated testnet shape: old broad scan keys=%d, scoped before red reuse=%d, scoped after red reuse=%d, main reduction=%dx, incremental scoped reduction=%d%%",
+		broadScanKeys,
+		scopedKeysBeforeRedelegationReuse,
+		scopedKeysAfterRedelegationReuse,
+		broadScanKeys/scopedKeysAfterRedelegationReuse,
+		100*(scopedKeysBeforeRedelegationReuse-scopedKeysAfterRedelegationReuse)/scopedKeysBeforeRedelegationReuse,
+	)
+
+	notFound := errors.New("not found")
+	f.distributionKeeper.EXPECT().GetValidatorCurrentRewards(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorCurrentRewards{}, notFound)
+	f.distributionKeeper.EXPECT().GetValidatorAccumulatedCommission(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorAccumulatedCommission{}, notFound)
+	f.distributionKeeper.EXPECT().GetValidatorOutstandingRewards(gomock.Any(), oldValAddr).Return(distrtypes.ValidatorOutstandingRewards{}, notFound)
+	f.distributionKeeper.EXPECT().DeleteValidatorHistoricalRewards(gomock.Any(), oldValAddr)
+	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, uint64(11), rewards11).Return(nil)
+	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, uint64(12), rewards12).Return(nil)
+	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, uint64(13), rewards13).Return(nil)
+	f.distributionKeeper.EXPECT().DeleteValidatorSlashEvents(gomock.Any(), oldValAddr)
+	f.distributionKeeper.EXPECT().SetValidatorSlashEvent(gomock.Any(), newValAddr, uint64(100), slash100.ValidatorPeriod, slash100).Return(nil)
+	f.distributionKeeper.EXPECT().SetValidatorSlashEvent(gomock.Any(), newValAddr, uint64(101), slash101.ValidatorPeriod, slash101).Return(nil)
+
+	err := f.keeper.MigrateValidatorDistribution(f.ctx, oldValAddr, newValAddr)
+	require.NoError(t, err)
+
+	rewritten := map[uint64]stakingtypes.Redelegation{}
+	f.stakingKeeper.EXPECT().RemoveRedelegation(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+	f.stakingKeeper.EXPECT().SetRedelegation(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ sdk.Context, red stakingtypes.Redelegation) error {
+			rewritten[red.Entries[0].UnbondingId] = red
+			return nil
+		},
+	).Times(2)
+	f.stakingKeeper.EXPECT().InsertRedelegationQueue(gomock.Any(), gomock.Any(), completionTime).Return(nil).Times(2)
+	f.stakingKeeper.EXPECT().SetRedelegationByUnbondingID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(2)
+
+	err = f.keeper.MigrateValidatorDelegations(f.ctx, oldValAddr, newValAddr, nil, nil, []stakingtypes.Redelegation{srcRed, dstRed})
+	require.NoError(t, err)
+	require.Len(t, rewritten, 2)
+	require.Equal(t, newValAddr.String(), rewritten[40_001].ValidatorSrcAddress)
+	require.Equal(t, dstValAddr.String(), rewritten[40_001].ValidatorDstAddress)
+	require.Equal(t, srcValAddr.String(), rewritten[40_002].ValidatorSrcAddress)
+	require.Equal(t, newValAddr.String(), rewritten[40_002].ValidatorDstAddress)
 }
 
 // --- Validator-supernode metrics tests ---

--- a/x/evmigration/keeper/migrate_validator.go
+++ b/x/evmigration/keeper/migrate_validator.go
@@ -61,16 +61,25 @@ func (k Keeper) MigrateValidatorRecord(ctx sdk.Context, oldValAddr, newValAddr s
 
 // MigrateValidatorDelegations re-keys all delegations pointing to oldValAddr
 // to point to newValAddr. This affects ALL delegators, not just the operator.
-func (k Keeper) MigrateValidatorDelegations(ctx sdk.Context, oldValAddr, newValAddr sdk.ValAddress) error {
-	// Re-key active delegations.
-	delegations, err := k.stakingKeeper.GetValidatorDelegations(ctx, oldValAddr)
-	if err != nil {
-		return err
-	}
-
-	// All delegations will reference the same period (currentRewards.Period - 1).
-	// Reset its reference count to 1 (base) since old delegator references are stale
-	// after re-keying distribution state.
+//
+// The delegations, unbonding delegations, and redelegations are supplied by the caller
+// (MigrateValidator), which already read them for the pre-migration
+// MaxValidatorDelegations count check. Threading them in avoids a second O(N)
+// scan of the same staking records on the hot path — for a validator with
+// thousands of delegations that redundant read dominated the block time. Passing
+// redelegations also avoids a second validator-scoped index scan. Tests may pass
+// nil redelegations to exercise the internal scoped scan directly.
+func (k Keeper) MigrateValidatorDelegations(
+	ctx sdk.Context,
+	oldValAddr, newValAddr sdk.ValAddress,
+	delegations []stakingtypes.Delegation,
+	ubds []stakingtypes.UnbondingDelegation,
+	reds []stakingtypes.Redelegation,
+) error {
+	// All delegations reference the same period (currentRewards.Period - 1). Its
+	// reference count becomes base(1) + one per re-keyed delegation. Set it in a
+	// single write here instead of resetting to 1 and incrementing once per
+	// delegation, which cost N+1 full-chain scans of ValidatorHistoricalRewards.
 	var targetPeriod uint64
 	if len(delegations) > 0 {
 		currentRewards, err := k.distributionKeeper.GetValidatorCurrentRewards(ctx, newValAddr)
@@ -78,7 +87,7 @@ func (k Keeper) MigrateValidatorDelegations(ctx sdk.Context, oldValAddr, newValA
 			return err
 		}
 		targetPeriod = currentRewards.Period - 1
-		if err := k.resetHistoricalRewardsReferenceCount(ctx, newValAddr, targetPeriod); err != nil {
+		if err := k.setHistoricalRewardsReferenceCount(ctx, newValAddr, targetPeriod, uint32(1+len(delegations))); err != nil {
 			return err
 		}
 	}
@@ -106,25 +115,19 @@ func (k Keeper) MigrateValidatorDelegations(ctx sdk.Context, oldValAddr, newValA
 
 		// Initialize fresh distribution starting info for (newValAddr, delegator).
 		// The old starting info was deleted above, so we always construct new info.
+		// The historical rewards reference count for targetPeriod was already set
+		// to base(1) + len(delegations) in one write above.
 		startingInfo := distrtypes.DelegatorStartingInfo{
 			PreviousPeriod: targetPeriod,
 			Height:         uint64(ctx.BlockHeight()),
 			Stake:          del.Shares,
-		}
-		if err := k.incrementHistoricalRewardsReferenceCount(ctx, newValAddr, targetPeriod); err != nil {
-			return err
 		}
 		if err := k.distributionKeeper.SetDelegatorStartingInfo(ctx, newValAddr, delAddr, startingInfo); err != nil {
 			return err
 		}
 	}
 
-	// Re-key unbonding delegations.
-	ubds, err := k.stakingKeeper.GetUnbondingDelegationsFromValidator(ctx, oldValAddr)
-	if err != nil {
-		return err
-	}
-
+	// Re-key unbonding delegations. (ubds supplied by the caller.)
 	for _, ubd := range ubds {
 		if err := k.stakingKeeper.RemoveUnbondingDelegation(ctx, ubd); err != nil {
 			return err
@@ -154,9 +157,12 @@ func (k Keeper) MigrateValidatorDelegations(ctx sdk.Context, oldValAddr, newValA
 	// Re-key redelegations where oldValAddr appears as either source or
 	// destination validator. Existing in-flight redelegations must continue to
 	// point at the migrated validator record after operator migration.
-	reds, err := k.redelegationsForValidator(ctx, oldValAddr)
-	if err != nil {
-		return err
+	if reds == nil {
+		var err error
+		reds, err = k.redelegationsForValidator(ctx, oldValAddr)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, red := range reds {

--- a/x/evmigration/keeper/migrate_validator.go
+++ b/x/evmigration/keeper/migrate_validator.go
@@ -154,13 +154,8 @@ func (k Keeper) MigrateValidatorDelegations(ctx sdk.Context, oldValAddr, newValA
 	// Re-key redelegations where oldValAddr appears as either source or
 	// destination validator. Existing in-flight redelegations must continue to
 	// point at the migrated validator record after operator migration.
-	var reds []stakingtypes.Redelegation
-	if err := k.stakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) bool {
-		if red.ValidatorSrcAddress == oldValAddr.String() || red.ValidatorDstAddress == oldValAddr.String() {
-			reds = append(reds, red)
-		}
-		return false
-	}); err != nil {
+	reds, err := k.redelegationsForValidator(ctx, oldValAddr)
+	if err != nil {
 		return err
 	}
 
@@ -236,17 +231,10 @@ func (k Keeper) MigrateValidatorDistribution(ctx sdk.Context, oldValAddr, newVal
 	}
 
 	// ValidatorHistoricalRewards — collect all periods for oldValAddr, then re-key.
-	type historicalEntry struct {
-		period  uint64
-		rewards distrtypes.ValidatorHistoricalRewards
+	historicalRewards, err := k.validatorHistoricalRewards(ctx, oldValAddr)
+	if err != nil {
+		return err
 	}
-	var historicalRewards []historicalEntry
-	k.distributionKeeper.IterateValidatorHistoricalRewards(ctx, func(val sdk.ValAddress, period uint64, rewards distrtypes.ValidatorHistoricalRewards) (stop bool) {
-		if val.Equals(oldValAddr) {
-			historicalRewards = append(historicalRewards, historicalEntry{period, rewards})
-		}
-		return false
-	})
 	k.distributionKeeper.DeleteValidatorHistoricalRewards(ctx, oldValAddr)
 	for _, hr := range historicalRewards {
 		if err := k.distributionKeeper.SetValidatorHistoricalRewards(ctx, newValAddr, hr.period, hr.rewards); err != nil {
@@ -255,17 +243,10 @@ func (k Keeper) MigrateValidatorDistribution(ctx sdk.Context, oldValAddr, newVal
 	}
 
 	// ValidatorSlashEvents — collect all for oldValAddr, then re-key.
-	type slashEntry struct {
-		height uint64
-		event  distrtypes.ValidatorSlashEvent
+	slashEvents, err := k.validatorSlashEvents(ctx, oldValAddr)
+	if err != nil {
+		return err
 	}
-	var slashEvents []slashEntry
-	k.distributionKeeper.IterateValidatorSlashEvents(ctx, func(val sdk.ValAddress, height uint64, event distrtypes.ValidatorSlashEvent) (stop bool) {
-		if val.Equals(oldValAddr) {
-			slashEvents = append(slashEvents, slashEntry{height, event})
-		}
-		return false
-	})
 	k.distributionKeeper.DeleteValidatorSlashEvents(ctx, oldValAddr)
 	for _, se := range slashEvents {
 		if err := k.distributionKeeper.SetValidatorSlashEvent(ctx, newValAddr, se.height, se.event.ValidatorPeriod, se.event); err != nil {

--- a/x/evmigration/keeper/migrate_validator_scoped.go
+++ b/x/evmigration/keeper/migrate_validator_scoped.go
@@ -60,7 +60,7 @@ func (k Keeper) collectRedelegationsByIndex(
 	if err != nil {
 		return err
 	}
-	defer iterator.Close()
+	defer func() { _ = iterator.Close() }()
 
 	for ; iterator.Valid(); iterator.Next() {
 		redKey := indexToRedelegationKey(iterator.Key())
@@ -98,7 +98,7 @@ func (k Keeper) validatorHistoricalRewards(ctx sdk.Context, valAddr sdk.ValAddre
 	if err != nil {
 		return nil, err
 	}
-	defer iterator.Close()
+	defer func() { _ = iterator.Close() }()
 
 	var entries []historicalRewardsEntry
 	for ; iterator.Valid(); iterator.Next() {
@@ -108,6 +108,42 @@ func (k Keeper) validatorHistoricalRewards(ctx sdk.Context, valAddr sdk.ValAddre
 		entries = append(entries, historicalRewardsEntry{period: period, rewards: rewards})
 	}
 	return entries, nil
+}
+
+// validatorHistoricalReward fetches a single (valAddr, period) historical
+// rewards row. With the distribution store wired it is an O(1) key lookup;
+// it only falls back to a full IterateValidatorHistoricalRewards scan when the
+// store service is unwired (tests that do not wire the scoped stores).
+func (k Keeper) validatorHistoricalReward(ctx sdk.Context, valAddr sdk.ValAddress, period uint64) (distrtypes.ValidatorHistoricalRewards, bool, error) {
+	if k.distributionStoreHandle == nil || k.distributionStoreHandle.svc == nil {
+		var (
+			found      bool
+			historical distrtypes.ValidatorHistoricalRewards
+		)
+		k.distributionKeeper.IterateValidatorHistoricalRewards(ctx, func(val sdk.ValAddress, p uint64, rewards distrtypes.ValidatorHistoricalRewards) bool {
+			if val.Equals(valAddr) && p == period {
+				found = true
+				historical = rewards
+				return true
+			}
+			return false
+		})
+		return historical, found, nil
+	}
+
+	store := k.distributionStoreHandle.svc.OpenKVStore(ctx)
+	bz, err := store.Get(distrtypes.GetValidatorHistoricalRewardsKey(valAddr, period))
+	if err != nil {
+		return distrtypes.ValidatorHistoricalRewards{}, false, err
+	}
+	if bz == nil {
+		return distrtypes.ValidatorHistoricalRewards{}, false, nil
+	}
+	var historical distrtypes.ValidatorHistoricalRewards
+	if err := k.cdc.Unmarshal(bz, &historical); err != nil {
+		return distrtypes.ValidatorHistoricalRewards{}, false, err
+	}
+	return historical, true, nil
 }
 
 func (k Keeper) validatorSlashEvents(ctx sdk.Context, valAddr sdk.ValAddress) ([]slashEventEntry, error) {
@@ -128,7 +164,7 @@ func (k Keeper) validatorSlashEvents(ctx sdk.Context, valAddr sdk.ValAddress) ([
 	if err != nil {
 		return nil, err
 	}
-	defer iterator.Close()
+	defer func() { _ = iterator.Close() }()
 
 	var entries []slashEventEntry
 	for ; iterator.Valid(); iterator.Next() {

--- a/x/evmigration/keeper/migrate_validator_scoped.go
+++ b/x/evmigration/keeper/migrate_validator_scoped.go
@@ -1,0 +1,141 @@
+package keeper
+
+import (
+	"fmt"
+
+	corestore "cosmossdk.io/core/store"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+type historicalRewardsEntry struct {
+	period  uint64
+	rewards distrtypes.ValidatorHistoricalRewards
+}
+
+type slashEventEntry struct {
+	height uint64
+	event  distrtypes.ValidatorSlashEvent
+}
+
+func (k Keeper) redelegationsForValidator(ctx sdk.Context, valAddr sdk.ValAddress) ([]stakingtypes.Redelegation, error) {
+	if k.stakingStoreHandle == nil || k.stakingStoreHandle.svc == nil {
+		var reds []stakingtypes.Redelegation
+		if err := k.stakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) bool {
+			if red.ValidatorSrcAddress == valAddr.String() || red.ValidatorDstAddress == valAddr.String() {
+				reds = append(reds, red)
+			}
+			return false
+		}); err != nil {
+			return nil, err
+		}
+		return reds, nil
+	}
+
+	store := k.stakingStoreHandle.svc.OpenKVStore(ctx)
+	seen := make(map[string]stakingtypes.Redelegation)
+	if err := k.collectRedelegationsByIndex(store, stakingtypes.GetREDsFromValSrcIndexKey(valAddr), stakingtypes.GetREDKeyFromValSrcIndexKey, seen); err != nil {
+		return nil, err
+	}
+	if err := k.collectRedelegationsByIndex(store, stakingtypes.GetREDsToValDstIndexKey(valAddr), stakingtypes.GetREDKeyFromValDstIndexKey, seen); err != nil {
+		return nil, err
+	}
+
+	reds := make([]stakingtypes.Redelegation, 0, len(seen))
+	for _, red := range seen {
+		reds = append(reds, red)
+	}
+	return reds, nil
+}
+
+func (k Keeper) collectRedelegationsByIndex(
+	store corestore.KVStore,
+	prefix []byte,
+	indexToRedelegationKey func([]byte) []byte,
+	out map[string]stakingtypes.Redelegation,
+) error {
+	iterator, err := store.Iterator(prefix, storetypes.PrefixEndBytes(prefix))
+	if err != nil {
+		return err
+	}
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		redKey := indexToRedelegationKey(iterator.Key())
+		bz, err := store.Get(redKey)
+		if err != nil {
+			return err
+		}
+		if bz == nil {
+			return fmt.Errorf("redelegation index %X points to missing record %X", iterator.Key(), redKey)
+		}
+		red, err := stakingtypes.UnmarshalRED(k.cdc, bz)
+		if err != nil {
+			return err
+		}
+		out[string(redKey)] = red
+	}
+	return nil
+}
+
+func (k Keeper) validatorHistoricalRewards(ctx sdk.Context, valAddr sdk.ValAddress) ([]historicalRewardsEntry, error) {
+	if k.distributionStoreHandle == nil || k.distributionStoreHandle.svc == nil {
+		var entries []historicalRewardsEntry
+		k.distributionKeeper.IterateValidatorHistoricalRewards(ctx, func(val sdk.ValAddress, period uint64, rewards distrtypes.ValidatorHistoricalRewards) bool {
+			if val.Equals(valAddr) {
+				entries = append(entries, historicalRewardsEntry{period: period, rewards: rewards})
+			}
+			return false
+		})
+		return entries, nil
+	}
+
+	store := k.distributionStoreHandle.svc.OpenKVStore(ctx)
+	prefix := distrtypes.GetValidatorHistoricalRewardsPrefix(valAddr)
+	iterator, err := store.Iterator(prefix, storetypes.PrefixEndBytes(prefix))
+	if err != nil {
+		return nil, err
+	}
+	defer iterator.Close()
+
+	var entries []historicalRewardsEntry
+	for ; iterator.Valid(); iterator.Next() {
+		var rewards distrtypes.ValidatorHistoricalRewards
+		k.cdc.MustUnmarshal(iterator.Value(), &rewards)
+		_, period := distrtypes.GetValidatorHistoricalRewardsAddressPeriod(iterator.Key())
+		entries = append(entries, historicalRewardsEntry{period: period, rewards: rewards})
+	}
+	return entries, nil
+}
+
+func (k Keeper) validatorSlashEvents(ctx sdk.Context, valAddr sdk.ValAddress) ([]slashEventEntry, error) {
+	if k.distributionStoreHandle == nil || k.distributionStoreHandle.svc == nil {
+		var entries []slashEventEntry
+		k.distributionKeeper.IterateValidatorSlashEvents(ctx, func(val sdk.ValAddress, height uint64, event distrtypes.ValidatorSlashEvent) bool {
+			if val.Equals(valAddr) {
+				entries = append(entries, slashEventEntry{height: height, event: event})
+			}
+			return false
+		})
+		return entries, nil
+	}
+
+	store := k.distributionStoreHandle.svc.OpenKVStore(ctx)
+	prefix := distrtypes.GetValidatorSlashEventPrefix(valAddr)
+	iterator, err := store.Iterator(prefix, storetypes.PrefixEndBytes(prefix))
+	if err != nil {
+		return nil, err
+	}
+	defer iterator.Close()
+
+	var entries []slashEventEntry
+	for ; iterator.Valid(); iterator.Next() {
+		var event distrtypes.ValidatorSlashEvent
+		k.cdc.MustUnmarshal(iterator.Value(), &event)
+		_, height := distrtypes.GetValidatorSlashEventAddressHeight(iterator.Key())
+		entries = append(entries, slashEventEntry{height: height, event: event})
+	}
+	return entries, nil
+}

--- a/x/evmigration/keeper/msg_server_claim_legacy_test.go
+++ b/x/evmigration/keeper/msg_server_claim_legacy_test.go
@@ -920,7 +920,7 @@ func TestClaimLegacyAccount_FailAtClaim(t *testing.T) {
 // setupPassingValPreChecks configures mocks so that preChecks, validator-specific
 // checks, and signature verification pass for MigrateValidator, returning the
 // addresses, validator addresses, and the ready message.
-func setupPassingValPreChecks(t *testing.T, f *msgServerFixture) (
+func setupPassingValPreChecks(t *testing.T, f *msgServerFixture, ubds ...stakingtypes.UnbondingDelegation) (
 	sdk.AccAddress, sdk.AccAddress, sdk.ValAddress, sdk.ValAddress, *types.MsgMigrateValidator,
 ) {
 	t.Helper()
@@ -943,9 +943,11 @@ func setupPassingValPreChecks(t *testing.T, f *msgServerFixture) (
 		stakingtypes.Validator{}, stakingtypes.ErrNoValidatorFound,
 	)
 
-	// No delegations/ubds/reds (under limit).
+	// Pre-check count read: no delegations; ubds default to empty unless a caller
+	// supplies records to drive a later V4 re-key step. The reds scan hits the
+	// wired (empty) store.
 	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
+	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(ubds, nil)
 
 	msg := newValidatorMigrationMsg(t, privKey, legacyAddr, newPrivKey, newAddr)
 
@@ -1001,9 +1003,10 @@ func setupV1toV4(f *mockFixture, oldValAddr, newValAddr sdk.ValAddress) {
 	f.distributionKeeper.EXPECT().IterateValidatorSlashEvents(gomock.Any(), gomock.Any())
 	f.distributionKeeper.EXPECT().DeleteValidatorSlashEvents(gomock.Any(), oldValAddr)
 
-	// V4: no delegations.
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
+	// V4: no delegations. The pre-check already read delegations/ubds and V4
+	// reuses those slices instead of re-fetching, so no staking Get mocks here.
+	// With both slices empty and no redelegations in the wired store, V4 makes
+	// no staking calls.
 }
 
 // TestMigrateValidator_FailAtValidatorRecord verifies that a failure in
@@ -1065,7 +1068,16 @@ func TestMigrateValidator_FailAtValidatorDistribution(t *testing.T) {
 // MigrateValidatorDelegations (step V4) propagates and no record is stored.
 func TestMigrateValidator_FailAtValidatorDelegations(t *testing.T) {
 	f := initMsgServerFixture(t)
-	legacyAddr, _, oldValAddr, newValAddr, msg := setupPassingValPreChecks(t, f)
+	// The delegation/ubd read moved into the pre-check, so V4 now fails while
+	// *re-keying* a record, not while fetching one. Feed one unbonding delegation
+	// through the pre-check count read; V4's RemoveUnbondingDelegation then errors.
+	// An unbonding delegation avoids the V1 per-delegator reward withdrawal that a
+	// regular delegation would trigger, keeping this focused on the V4 re-key.
+	ubd := stakingtypes.UnbondingDelegation{
+		DelegatorAddress: testAccAddr().String(),
+		ValidatorAddress: sdk.ValAddress(testAccAddr()).String(),
+	}
+	legacyAddr, _, oldValAddr, newValAddr, msg := setupPassingValPreChecks(t, f, ubd)
 
 	// Steps V1-V3 succeed.
 	f.distributionKeeper.EXPECT().WithdrawValidatorCommission(gomock.Any(), oldValAddr).Return(sdk.Coins{}, nil)
@@ -1094,9 +1106,9 @@ func TestMigrateValidator_FailAtValidatorDelegations(t *testing.T) {
 	f.distributionKeeper.EXPECT().IterateValidatorSlashEvents(gomock.Any(), gomock.Any())
 	f.distributionKeeper.EXPECT().DeleteValidatorSlashEvents(gomock.Any(), oldValAddr)
 
-	// Step V4: delegation re-key fails.
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(
-		nil, fmt.Errorf("delegation index corrupted"),
+	// Step V4: unbonding-delegation re-key fails on its first store op.
+	f.stakingKeeper.EXPECT().RemoveUnbondingDelegation(gomock.Any(), ubd).Return(
+		fmt.Errorf("unbonding index corrupted"),
 	)
 
 	_, err := f.msgServer.MigrateValidator(f.ctx, msg)

--- a/x/evmigration/keeper/msg_server_claim_legacy_test.go
+++ b/x/evmigration/keeper/msg_server_claim_legacy_test.go
@@ -111,9 +111,17 @@ func initMsgServerFixture(t *testing.T) *msgServerFixture {
 	encCfg := moduletestutil.MakeTestEncodingConfig(module.AppModule{})
 	addrCodec := addresscodec.NewBech32Codec(sdk.GetConfig().GetBech32AccountAddrPrefix())
 	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+	stakingStoreKey := storetypes.NewKVStoreKey(stakingtypes.StoreKey)
 	storeService := runtime.NewKVStoreService(storeKey)
-	ctx := testutil.DefaultContextWithDB(t, storeKey, storetypes.NewTransientStoreKey("transient_test")).Ctx.
-		WithChainID(testChainID)
+	stakingStoreService := runtime.NewKVStoreService(stakingStoreKey)
+	ctx := testutil.DefaultContextWithKeys(
+		map[string]*storetypes.KVStoreKey{
+			types.StoreKey:        storeKey,
+			stakingtypes.StoreKey: stakingStoreKey,
+		},
+		map[string]*storetypes.TransientStoreKey{"transient_test": storetypes.NewTransientStoreKey("transient_test")},
+		nil,
+	).WithChainID(testChainID).WithBlockTime(time.Now())
 
 	authority := authtypes.NewModuleAddress(types.GovModuleName)
 
@@ -133,10 +141,10 @@ func initMsgServerFixture(t *testing.T) *msgServerFixture {
 		claimKeeper,
 	)
 
-	// Wire a dummy staking store service so DeleteValidatorRecordNoHooks can run
-	// in unit tests (the store itself is isolated and any delete is a safe no-op
-	// against non-existent keys). Production wiring happens in app.go.
-	k.SetStakingStoreService(storeService)
+	// Wire an isolated staking store service so scoped redelegation iteration
+	// and DeleteValidatorRecordNoHooks can run in unit tests. Production wiring
+	// happens in app.go.
+	k.SetStakingStoreService(stakingStoreService)
 
 	// Initialize params with migration enabled.
 	params := types.NewParams(true, 0, 50, 2000, 20)
@@ -147,6 +155,8 @@ func initMsgServerFixture(t *testing.T) *msgServerFixture {
 	mf := &mockFixture{
 		ctx:                ctx,
 		keeper:             k,
+		cdc:                encCfg.Codec,
+		stakingStore:       stakingStoreService,
 		accountKeeper:      accountKeeper,
 		bankKeeper:         bankKeeper,
 		stakingKeeper:      stakingKeeper,
@@ -936,7 +946,6 @@ func setupPassingValPreChecks(t *testing.T, f *msgServerFixture) (
 	// No delegations/ubds/reds (under limit).
 	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
 	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
 
 	msg := newValidatorMigrationMsg(t, privKey, legacyAddr, newPrivKey, newAddr)
 
@@ -995,7 +1004,6 @@ func setupV1toV4(f *mockFixture, oldValAddr, newValAddr sdk.ValAddress) {
 	// V4: no delegations.
 	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
 	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
 }
 
 // TestMigrateValidator_FailAtValidatorRecord verifies that a failure in

--- a/x/evmigration/keeper/msg_server_migrate_validator.go
+++ b/x/evmigration/keeper/msg_server_migrate_validator.go
@@ -87,16 +87,11 @@ func (ms msgServer) MigrateValidator(goCtx context.Context, msg *types.MsgMigrat
 	// Count redelegations where the validator appears as EITHER source or
 	// destination. The execution path (MigrateValidatorDelegations) re-keys
 	// both directions, so the safety bound must account for both.
-	var redCount int
-	if err := ms.stakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) bool {
-		if red.ValidatorSrcAddress == oldValAddr.String() || red.ValidatorDstAddress == oldValAddr.String() {
-			redCount++
-		}
-		return false
-	}); err != nil {
+	reds, err := ms.redelegationsForValidator(ctx, oldValAddr)
+	if err != nil {
 		return nil, err
 	}
-	totalRecords := uint64(len(delegations) + len(ubds) + redCount)
+	totalRecords := uint64(len(delegations) + len(ubds) + len(reds))
 	if totalRecords > params.MaxValidatorDelegations {
 		return nil, types.ErrTooManyDelegators.Wrapf(
 			"total records %d exceeds max %d", totalRecords, params.MaxValidatorDelegations,

--- a/x/evmigration/keeper/msg_server_migrate_validator.go
+++ b/x/evmigration/keeper/msg_server_migrate_validator.go
@@ -175,7 +175,11 @@ func (ms msgServer) MigrateValidator(goCtx context.Context, msg *types.MsgMigrat
 	}
 
 	// --- Step V4: Re-key all delegations pointing to this validator ---
-	if err := ms.MigrateValidatorDelegations(ctx, oldValAddr, newValAddr); err != nil {
+	// Reuse the delegations/unbondings/redelegations already read for the
+	// MaxValidatorDelegations pre-check above; nothing since (reward withdrawal,
+	// record re-key, distribution re-key) mutates these staking records, so a
+	// second read would be pure overhead on a validator with many delegations.
+	if err := ms.MigrateValidatorDelegations(ctx, oldValAddr, newValAddr, delegations, ubds, reds); err != nil {
 		return nil, fmt.Errorf("migrate validator delegations: %w", err)
 	}
 

--- a/x/evmigration/keeper/msg_server_migrate_validator_test.go
+++ b/x/evmigration/keeper/msg_server_migrate_validator_test.go
@@ -282,22 +282,18 @@ func TestMigrateValidator_Success(t *testing.T) {
 	f.distributionKeeper.EXPECT().DeleteValidatorSlashEvents(gomock.Any(), oldValAddr)
 
 	// Step V4: MigrateValidatorDelegations — re-key the one delegation.
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(
-		[]stakingtypes.Delegation{del}, nil,
-	)
-	// Reset target period refcount before delegation loop.
+	// Delegations/unbondings/redelegations are supplied from the pre-check fetch
+	// above; V4 no longer re-reads them.
+	// Set target period refcount to base(1) + N delegations in a single write.
 	f.distributionKeeper.EXPECT().GetValidatorCurrentRewards(gomock.Any(), newValAddr).Return(
 		distrtypes.ValidatorCurrentRewards{Period: 3}, nil,
 	)
-	expectHistoricalRewardsReset(f.distributionKeeper, newValAddr, 2, 2)
-	// Per-delegation re-keying.
+	expectHistoricalRewardsSet(f.distributionKeeper, newValAddr, 2, 2)
+	// Per-delegation re-keying (no per-delegation refcount bump — set once above).
 	f.distributionKeeper.EXPECT().DeleteDelegatorStartingInfo(gomock.Any(), oldValAddr, legacyAddr).Return(nil)
 	f.stakingKeeper.EXPECT().RemoveDelegation(gomock.Any(), del).Return(nil)
 	f.stakingKeeper.EXPECT().SetDelegation(gomock.Any(), gomock.Any()).Return(nil)
-	expectHistoricalRewardsIncrement(f.distributionKeeper, newValAddr, 2, 1)
 	f.distributionKeeper.EXPECT().SetDelegatorStartingInfo(gomock.Any(), newValAddr, legacyAddr, gomock.Any()).Return(nil)
-	// No unbonding delegations or redelegations.
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
 
 	// Step V5: MigrateValidatorSupernode — not a supernode.
 	f.supernodeKeeper.EXPECT().QuerySuperNode(gomock.Any(), oldValAddr).Return(sntypes.SuperNode{}, false)
@@ -441,10 +437,11 @@ func TestMigrateValidator_OperatorDelegationsToOtherValidators(t *testing.T) {
 	f.distributionKeeper.EXPECT().DeleteValidatorSlashEvents(gomock.Any(), oldValAddr)
 
 	// V4: MigrateValidatorDelegations — re-key self-delegation.
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return([]stakingtypes.Delegation{selfDel}, nil)
+	// Delegations/unbondings are supplied from the pre-check fetch; V4 no longer re-reads.
 	f.distributionKeeper.EXPECT().GetValidatorCurrentRewards(gomock.Any(), newValAddr).Return(currentRewards, nil)
 	targetPeriod := currentRewards.Period - 1
 	histRewards := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 1}
+	// Single write: set target period refcount to base(1) + N delegations.
 	f.distributionKeeper.EXPECT().IterateValidatorHistoricalRewards(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ sdk.Context, fn func(sdk.ValAddress, uint64, distrtypes.ValidatorHistoricalRewards) bool) {
 			fn(newValAddr, targetPeriod, histRewards)
@@ -454,14 +451,7 @@ func TestMigrateValidator_OperatorDelegationsToOtherValidators(t *testing.T) {
 	f.distributionKeeper.EXPECT().DeleteDelegatorStartingInfo(gomock.Any(), oldValAddr, legacyAddr).Return(nil)
 	f.stakingKeeper.EXPECT().RemoveDelegation(gomock.Any(), selfDel).Return(nil)
 	f.stakingKeeper.EXPECT().SetDelegation(gomock.Any(), gomock.Any()).Return(nil)
-	f.distributionKeeper.EXPECT().IterateValidatorHistoricalRewards(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ sdk.Context, fn func(sdk.ValAddress, uint64, distrtypes.ValidatorHistoricalRewards) bool) {
-			fn(newValAddr, targetPeriod, histRewards)
-		},
-	)
-	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, targetPeriod, gomock.Any()).Return(nil)
 	f.distributionKeeper.EXPECT().SetDelegatorStartingInfo(gomock.Any(), newValAddr, legacyAddr, gomock.Any()).Return(nil)
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
 
 	// V5: no supernode.
 	f.supernodeKeeper.EXPECT().QuerySuperNode(gomock.Any(), oldValAddr).Return(sntypes.SuperNode{}, false)
@@ -598,9 +588,9 @@ func TestMigrateValidator_ThirdPartyWithdrawAddrPreserved(t *testing.T) {
 	selfDel := stakingtypes.NewDelegation(legacyAddr.String(), oldValAddr.String(), math.LegacyNewDec(100))
 	thirdDel := stakingtypes.NewDelegation(thirdPartyDelegator.String(), oldValAddr.String(), math.LegacyNewDec(50))
 	allDels := []stakingtypes.Delegation{selfDel, thirdDel}
-	// Called twice: once for pre-check count, once inside MigrateValidatorDelegations.
-	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(allDels, nil).Times(2)
-	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil).Times(2)
+	// Fetched once for the pre-check count; V4 reuses the same slices instead of re-reading.
+	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(allDels, nil)
+	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
 
 	// Step V1: Withdraw commission.
 	f.distributionKeeper.EXPECT().WithdrawValidatorCommission(gomock.Any(), oldValAddr).Return(sdk.Coins{}, nil)
@@ -643,8 +633,9 @@ func TestMigrateValidator_ThirdPartyWithdrawAddrPreserved(t *testing.T) {
 	f.distributionKeeper.EXPECT().IterateValidatorSlashEvents(gomock.Any(), gomock.Any())
 	f.distributionKeeper.EXPECT().DeleteValidatorSlashEvents(gomock.Any(), oldValAddr)
 
-	// Delegation re-keying (2 delegations).
-	// resetHistoricalRewardsReferenceCount needs the iterate to find the entry.
+	// Delegation re-keying (2 delegations). The target period refcount is set to
+	// base(1) + N in a single write before the loop, so the loop does no per-
+	// delegation refcount bump. The iterate below is the lookup for that one write.
 	targetPeriod := currentRewards.Period - 1
 	histRewards := distrtypes.ValidatorHistoricalRewards{ReferenceCount: 2}
 	f.distributionKeeper.EXPECT().GetValidatorCurrentRewards(gomock.Any(), newValAddr).Return(currentRewards, nil)
@@ -658,12 +649,6 @@ func TestMigrateValidator_ThirdPartyWithdrawAddrPreserved(t *testing.T) {
 		f.distributionKeeper.EXPECT().DeleteDelegatorStartingInfo(gomock.Any(), oldValAddr, gomock.Any()).Return(nil)
 		f.stakingKeeper.EXPECT().RemoveDelegation(gomock.Any(), gomock.Any()).Return(nil)
 		f.stakingKeeper.EXPECT().SetDelegation(gomock.Any(), gomock.Any()).Return(nil)
-		f.distributionKeeper.EXPECT().IterateValidatorHistoricalRewards(gomock.Any(), gomock.Any()).DoAndReturn(
-			func(_ sdk.Context, fn func(sdk.ValAddress, uint64, distrtypes.ValidatorHistoricalRewards) bool) {
-				fn(newValAddr, targetPeriod, histRewards)
-			},
-		)
-		f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, targetPeriod, gomock.Any()).Return(nil)
 		f.distributionKeeper.EXPECT().SetDelegatorStartingInfo(gomock.Any(), newValAddr, gomock.Any(), gomock.Any()).Return(nil)
 	}
 

--- a/x/evmigration/keeper/msg_server_migrate_validator_test.go
+++ b/x/evmigration/keeper/msg_server_migrate_validator_test.go
@@ -134,7 +134,62 @@ func TestMigrateValidator_TooManyDelegators(t *testing.T) {
 		}, nil,
 	)
 	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
+
+	msg := newValidatorMigrationMsg(t, privKey, legacyAddr, newPrivKey, newAddr)
+
+	_, err := f.msgServer.MigrateValidator(f.ctx, msg)
+	require.ErrorIs(t, err, types.ErrTooManyDelegators)
+}
+
+func TestMigrateValidator_TooManyDelegatorsIncludesScopedRedelegations(t *testing.T) {
+	f := initMsgServerFixture(t)
+
+	params := types.NewParams(true, 0, 50, 1, 20)
+	require.NoError(t, f.keeper.Params.Set(f.ctx, params))
+
+	privKey := secp256k1.GenPrivKey()
+	legacyAddr := sdk.AccAddress(privKey.PubKey().Address())
+	newPrivKey, newAddr := testNewMigrationAccount(t)
+	oldValAddr := sdk.ValAddress(legacyAddr)
+	newValAddr := sdk.ValAddress(newAddr)
+
+	baseAcc := authtypes.NewBaseAccountWithAddress(legacyAddr)
+	f.accountKeeper.EXPECT().GetAccount(gomock.Any(), legacyAddr).Return(baseAcc)
+	f.stakingKeeper.EXPECT().GetValidator(gomock.Any(), oldValAddr).Return(
+		stakingtypes.Validator{OperatorAddress: oldValAddr.String(), Status: stakingtypes.Bonded}, nil,
+	)
+	f.stakingKeeper.EXPECT().GetValidator(gomock.Any(), newValAddr).Return(
+		stakingtypes.Validator{}, stakingtypes.ErrNoValidatorFound,
+	)
+	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(nil, nil)
+	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
+
+	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
+	delegator := testAccAddr()
+	f.writeRedelegation(stakingtypes.Redelegation{
+		DelegatorAddress:    delegator.String(),
+		ValidatorSrcAddress: oldValAddr.String(),
+		ValidatorDstAddress: sdk.ValAddress(testAccAddr()).String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 10,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(100),
+			SharesDst:      math.LegacyNewDec(100),
+			UnbondingId:    201,
+		}},
+	})
+	f.writeRedelegation(stakingtypes.Redelegation{
+		DelegatorAddress:    delegator.String(),
+		ValidatorSrcAddress: sdk.ValAddress(testAccAddr()).String(),
+		ValidatorDstAddress: oldValAddr.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 11,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(200),
+			SharesDst:      math.LegacyNewDec(200),
+			UnbondingId:    202,
+		}},
+	})
 
 	msg := newValidatorMigrationMsg(t, privKey, legacyAddr, newPrivKey, newAddr)
 
@@ -177,7 +232,6 @@ func TestMigrateValidator_Success(t *testing.T) {
 		[]stakingtypes.Delegation{del}, nil,
 	)
 	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Step V1: Withdraw commission and delegation rewards.
 	f.distributionKeeper.EXPECT().WithdrawValidatorCommission(gomock.Any(), oldValAddr).Return(sdk.Coins{}, nil)
@@ -244,7 +298,6 @@ func TestMigrateValidator_Success(t *testing.T) {
 	f.distributionKeeper.EXPECT().SetDelegatorStartingInfo(gomock.Any(), newValAddr, legacyAddr, gomock.Any()).Return(nil)
 	// No unbonding delegations or redelegations.
 	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Step V5: MigrateValidatorSupernode — not a supernode.
 	f.supernodeKeeper.EXPECT().QuerySuperNode(gomock.Any(), oldValAddr).Return(sntypes.SuperNode{}, false)
@@ -354,7 +407,6 @@ func TestMigrateValidator_OperatorDelegationsToOtherValidators(t *testing.T) {
 		[]stakingtypes.Delegation{selfDel}, nil,
 	)
 	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Step V1: Withdraw commission + self-delegation rewards.
 	f.distributionKeeper.EXPECT().WithdrawValidatorCommission(gomock.Any(), oldValAddr).Return(sdk.Coins{}, nil)
@@ -410,7 +462,6 @@ func TestMigrateValidator_OperatorDelegationsToOtherValidators(t *testing.T) {
 	f.distributionKeeper.EXPECT().SetValidatorHistoricalRewards(gomock.Any(), newValAddr, targetPeriod, gomock.Any()).Return(nil)
 	f.distributionKeeper.EXPECT().SetDelegatorStartingInfo(gomock.Any(), newValAddr, legacyAddr, gomock.Any()).Return(nil)
 	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil)
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
 
 	// V5: no supernode.
 	f.supernodeKeeper.EXPECT().QuerySuperNode(gomock.Any(), oldValAddr).Return(sntypes.SuperNode{}, false)
@@ -550,7 +601,6 @@ func TestMigrateValidator_ThirdPartyWithdrawAddrPreserved(t *testing.T) {
 	// Called twice: once for pre-check count, once inside MigrateValidatorDelegations.
 	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), oldValAddr).Return(allDels, nil).Times(2)
 	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), oldValAddr).Return(nil, nil).Times(2)
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Step V1: Withdraw commission.
 	f.distributionKeeper.EXPECT().WithdrawValidatorCommission(gomock.Any(), oldValAddr).Return(sdk.Coins{}, nil)
@@ -618,7 +668,6 @@ func TestMigrateValidator_ThirdPartyWithdrawAddrPreserved(t *testing.T) {
 	}
 
 	// Redelegation re-keying — none.
-	f.stakingKeeper.EXPECT().IterateRedelegations(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Supernode — not found.
 	f.supernodeKeeper.EXPECT().QuerySuperNode(gomock.Any(), oldValAddr).Return(sntypes.SuperNode{}, false)

--- a/x/evmigration/keeper/query.go
+++ b/x/evmigration/keeper/query.go
@@ -181,14 +181,9 @@ func (qs queryServer) MigrationEstimate(goCtx context.Context, req *types.QueryM
 		}
 		// Count redelegations where the validator is source OR destination
 		// (both are re-keyed during migration).
-		var redCount uint64
-		_ = qs.k.stakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) bool {
-			if red.ValidatorSrcAddress == valAddr.String() || red.ValidatorDstAddress == valAddr.String() {
-				redCount++
-			}
-			return false
-		})
-		resp.ValRedelegationCount = redCount
+		if reds, err := qs.k.redelegationsForValidator(ctx, valAddr); err == nil {
+			resp.ValRedelegationCount = uint64(len(reds))
+		}
 
 		// Surface the validator's BondStatus + Jailed flag so callers can
 		// display the actionable cause when WouldSucceed is false. Jailed

--- a/x/evmigration/keeper/query_test.go
+++ b/x/evmigration/keeper/query_test.go
@@ -312,6 +312,87 @@ func TestQueryMigrationEstimate_AlreadyMigrated(t *testing.T) {
 	require.False(t, resp.HasSupernode)
 }
 
+func TestQueryMigrationEstimate_ValidatorUsesScopedRedelegationIndexesForLimit(t *testing.T) {
+	f := initMockFixture(t)
+	f.wireScopedMigrationStores()
+	qs := keeper.NewQueryServerImpl(f.keeper)
+
+	params := types.NewParams(true, 0, 50, 2, 20)
+	require.NoError(t, f.keeper.Params.Set(f.ctx, params))
+
+	addr := testAccAddr()
+	valAddr := sdk.ValAddress(addr)
+	completionTime := f.ctx.BlockTime().Add(21 * 24 * 3600 * 1e9)
+	delegator := testAccAddr()
+
+	f.writeRedelegation(stakingtypes.Redelegation{
+		DelegatorAddress:    delegator.String(),
+		ValidatorSrcAddress: valAddr.String(),
+		ValidatorDstAddress: sdk.ValAddress(testAccAddr()).String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 10,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(100),
+			SharesDst:      math.LegacyNewDec(100),
+			UnbondingId:    301,
+		}},
+	})
+	f.writeRedelegation(stakingtypes.Redelegation{
+		DelegatorAddress:    delegator.String(),
+		ValidatorSrcAddress: sdk.ValAddress(testAccAddr()).String(),
+		ValidatorDstAddress: valAddr.String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 11,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(200),
+			SharesDst:      math.LegacyNewDec(200),
+			UnbondingId:    302,
+		}},
+	})
+	f.writeRedelegation(stakingtypes.Redelegation{
+		DelegatorAddress:    testAccAddr().String(),
+		ValidatorSrcAddress: sdk.ValAddress(testAccAddr()).String(),
+		ValidatorDstAddress: sdk.ValAddress(testAccAddr()).String(),
+		Entries: []stakingtypes.RedelegationEntry{{
+			CreationHeight: 12,
+			CompletionTime: completionTime,
+			InitialBalance: math.NewInt(300),
+			SharesDst:      math.LegacyNewDec(300),
+			UnbondingId:    303,
+		}},
+	})
+
+	f.stakingKeeper.EXPECT().GetValidator(gomock.Any(), valAddr).Return(
+		stakingtypes.Validator{OperatorAddress: valAddr.String(), Status: stakingtypes.Bonded}, nil,
+	)
+	f.stakingKeeper.EXPECT().GetValidatorDelegations(gomock.Any(), valAddr).Return(
+		[]stakingtypes.Delegation{
+			stakingtypes.NewDelegation(delegator.String(), valAddr.String(), math.LegacyNewDec(50)),
+		}, nil,
+	)
+	f.stakingKeeper.EXPECT().GetUnbondingDelegationsFromValidator(gomock.Any(), valAddr).Return(nil, nil)
+	f.stakingKeeper.EXPECT().GetDelegatorDelegations(gomock.Any(), addr, ^uint16(0)).Return(nil, nil)
+	f.stakingKeeper.EXPECT().GetUnbondingDelegations(gomock.Any(), addr, ^uint16(0)).Return(nil, nil)
+	f.stakingKeeper.EXPECT().GetRedelegations(gomock.Any(), addr, ^uint16(0)).Return(nil, nil)
+	f.authzKeeper.EXPECT().IterateGrants(gomock.Any(), gomock.Any())
+	f.feegrantKeeper.EXPECT().IterateAllFeeAllowances(gomock.Any(), gomock.Any()).Return(nil)
+	f.actionKeeper.EXPECT().IterateActions(gomock.Any(), gomock.Any()).Return(nil)
+	f.bankKeeper.EXPECT().GetAllBalances(gomock.Any(), addr).Return(sdk.Coins{})
+	f.supernodeKeeper.EXPECT().QuerySuperNode(gomock.Any(), valAddr).Return(sntypes.SuperNode{}, false)
+	f.accountKeeper.EXPECT().GetAccount(gomock.Any(), addr).Return(nil)
+
+	resp, err := qs.MigrationEstimate(f.ctx, &types.QueryMigrationEstimateRequest{
+		LegacyAddress: addr.String(),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.IsValidator)
+	require.Equal(t, uint64(1), resp.ValDelegationCount)
+	require.Equal(t, uint64(2), resp.ValRedelegationCount)
+	require.Equal(t, uint64(3), resp.TotalTouched)
+	require.False(t, resp.WouldSucceed)
+	require.Equal(t, "too many delegators", resp.RejectionReason)
+}
+
 // --- LegacyAccounts query tests ---
 
 // TestQueryLegacyAccounts_WithSecp256k1 verifies that accounts with secp256k1


### PR DESCRIPTION
## Summary

Three layered optimizations to the validator migration hot path
(`MigrateValidator` → `MigrateValidatorDelegations` / `MigrateValidatorDistribution`)
so its cost scales with the **migrating validator's own footprint** rather than
with **total chain state** or a redundant multiple of the delegator count.

Validator migration re-keys a validator from its legacy address to its new
address, moving delegations, unbonding delegations, redelegations, and
distribution state (historical rewards, slash events). The original code walked
full-chain indexes and re-read the same staking records multiple times — costs
that blow up for a validator with thousands of delegations on a busy chain.

## Improvements

### 1. Scoped store iteration (replaces full-chain `Iterate*`)

The distribution/staking re-key steps used `IterateValidatorHistoricalRewards`,
`IterateValidatorSlashEvents`, and `IterateRedelegations`, each of which walks
**every** validator's rows across the whole chain and filters client-side —
O(H) in total chain state.

`migrate_validator_scoped.go` now reads only the target validator's key prefix
through wired distribution/staking store handles:
- `GetValidatorHistoricalRewardsPrefix(val)` / `GetValidatorSlashEventPrefix(val)`
- `GetREDsFromValSrcIndexKey(val)` + `GetREDsToValDstIndexKey(val)` (both roles)

When the store service is unwired (mock-based unit tests) it falls back to the
original `Iterate*` path, so behavior is identical in tests. The same scoped
redelegation helper also replaces the full scan in `query.go`'s
`MigrationEstimate`.

**Impact:** `TestMigrateValidatorScopedIteration_SimulatesGlobalStateImprovement`
models 25 unrelated validators × 20 records each plus a small target validator
and asserts a **~215× reduction** in KV keys touched (1507 → 7).

### 2. Eliminate the double-fetch of staking records

The orchestrator's `MaxValidatorDelegations` pre-check already reads the
validator's delegations, unbonding delegations, and redelegations. The old V4
step (`MigrateValidatorDelegations`) then re-read all three. Nothing between the
pre-check and V4 (reward withdrawal, record re-key, distribution re-key) mutates
those records, so the second read was pure overhead — a second O(N) staking scan
plus a second validator-scoped redelegation index scan on the hot path.

They are now threaded into `MigrateValidatorDelegations`. Passing `nil`
redelegations still triggers the internal scoped scan, so tests can exercise
that path directly.

### 3. O(1) historical-rewards reference count (single write vs. N+1 scans)

Re-keying N delegations used to cost **N+1 full-chain scans** of
`ValidatorHistoricalRewards`: `resetHistoricalRewardsReferenceCount` scanned the
whole chain to set the count to 1, then `incrementHistoricalRewardsReferenceCount`
scanned it again once per delegation.

All re-keyed delegations reference the **same** period
(`currentRewards.Period - 1`), so the final reference count is deterministically
`base(1) + len(delegations)`. That value is now written **once** via
`setHistoricalRewardsReferenceCount`. A new `validatorHistoricalReward` helper
does an O(1) keyed `store.Get` of a single `(validator, period)` row (with the
same Iterate* fallback when unwired); `adjustHistoricalRewardsReferenceCount`
uses it too, so the repair/increment paths are O(1) as well.

## Correctness & safety

- **Output-equivalent refcount:** old path = reset-to-1 then +1×N = `1+N`; new
  path writes `1+N` directly. The per-delegation loop only ever summed to a
  constant because every delegation shares one period.
- **Scoped == filtered:** the prefix reads return exactly the rows the old
  client-side-filtered `Iterate*` returned.
- **Wired vs. unwired:** production uses the O(1)/prefix store path; unit tests
  drive the `Iterate*` fallback via mocks, so both branches are covered.
- **Redelegations:** both source and destination roles are re-keyed.
- Atomicity of the migration steps is unchanged; failures still abort before
  state is committed.

## Test plan

- [x] `go test ./x/evmigration/keeper/...` — green (incl. the scoped-iteration
      simulation test and refcount assertions)
- [x] `make lint` — 0 issues
- [x] `go build ./x/evmigration/...` — green
- [ ] `go test -tags='integration test' ./tests/integration/evmigration/... -v`
      — exercises the wired O(1)/prefix store path end-to-end (recommended before merge)

_Note:_ `x/evmigration` registers no simulation `WeightedOperations`, so
`make simulation-tests` does not generate migration txs and would not exercise
this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)