### PR TITLE
app: register v1.20.2 migration-only upgrade handler

### DIFF
--- a/app/upgrades/upgrades.go
+++ b/app/upgrades/upgrades.go
@@ -18,6 +18,7 @@ import (
 	upgrade_v1_12_0 "github.com/LumeraProtocol/lumera/app/upgrades/v1_12_0"
 	upgrade_v1_20_0 "github.com/LumeraProtocol/lumera/app/upgrades/v1_20_0"
 	upgrade_v1_20_1 "github.com/LumeraProtocol/lumera/app/upgrades/v1_20_1"
+	upgrade_v1_20_2 "github.com/LumeraProtocol/lumera/app/upgrades/v1_20_2"
 	upgrade_v1_6_1 "github.com/LumeraProtocol/lumera/app/upgrades/v1_6_1"
 	upgrade_v1_8_0 "github.com/LumeraProtocol/lumera/app/upgrades/v1_8_0"
 	upgrade_v1_8_4 "github.com/LumeraProtocol/lumera/app/upgrades/v1_8_4"
@@ -43,6 +44,7 @@ import (
 // | v1.12.0 | custom   | none (Everlight in supernode)     | Runs migrations; Everlight logic embedded in x/supernode
 // | v1.20.0 | custom   | non-mainnet: add feemarket, precisebank, vm, erc20 | EVM bring-up; gated to non-mainnet (mainnet runs it via v1.20.1)
 // | v1.20.1 | custom   | state-driven add-only: feemarket, precisebank, vm, erc20 | EVM bring-up when EVM absent (any network, incl. direct 1.12.0->1.20.1); migrations-only hotfix when EVM already present. Add-only store loader mounts only missing keys.
+// | v1.20.2 | standard | none                              | Migrations only; no historical state repair
 // =================================================================================================================================
 
 type UpgradeConfig struct {
@@ -75,6 +77,7 @@ var upgradeNames = []string{
 	upgrade_v1_12_0.UpgradeName,
 	upgrade_v1_20_0.UpgradeName,
 	upgrade_v1_20_1.UpgradeName,
+	upgrade_v1_20_2.UpgradeName,
 }
 
 var NoUpgradeConfig = UpgradeConfig{
@@ -176,6 +179,10 @@ func SetupUpgrades(upgradeName string, params appParams.AppUpgradeParams) (Upgra
 		return UpgradeConfig{
 			StoreUpgrade: &upgrade_v1_20_0.StoreUpgrades,
 			Handler:      upgrade_v1_20_1.CreateUpgradeHandler(params),
+		}, true
+	case upgrade_v1_20_2.UpgradeName:
+		return UpgradeConfig{
+			Handler: standardUpgradeHandler(upgrade_v1_20_2.UpgradeName, params),
 		}, true
 
 	// add future upgrades here

--- a/app/upgrades/upgrades_test.go
+++ b/app/upgrades/upgrades_test.go
@@ -18,6 +18,7 @@ import (
 	upgrade_v1_12_0 "github.com/LumeraProtocol/lumera/app/upgrades/v1_12_0"
 	upgrade_v1_20_0 "github.com/LumeraProtocol/lumera/app/upgrades/v1_20_0"
 	upgrade_v1_20_1 "github.com/LumeraProtocol/lumera/app/upgrades/v1_20_1"
+	upgrade_v1_20_2 "github.com/LumeraProtocol/lumera/app/upgrades/v1_20_2"
 	upgrade_v1_6_1 "github.com/LumeraProtocol/lumera/app/upgrades/v1_6_1"
 	upgrade_v1_8_0 "github.com/LumeraProtocol/lumera/app/upgrades/v1_8_0"
 	upgrade_v1_8_4 "github.com/LumeraProtocol/lumera/app/upgrades/v1_8_4"
@@ -47,6 +48,7 @@ func TestUpgradeNamesOrder(t *testing.T) {
 		upgrade_v1_12_0.UpgradeName,
 		upgrade_v1_20_0.UpgradeName,
 		upgrade_v1_20_1.UpgradeName,
+		upgrade_v1_20_2.UpgradeName,
 	}
 	require.Equal(t, expected, upgradeNames, "upgradeNames should stay in ascending order")
 }
@@ -222,6 +224,16 @@ func TestV1201CarriesEVMBringupOnAllNetworks(t *testing.T) {
 		require.Contains(t, config.StoreUpgrade.Added, precisebanktypes.StoreKey, "v1.20.1 should add precisebank store key on %s", chainID)
 		require.Contains(t, config.StoreUpgrade.Added, evmtypes.StoreKey, "v1.20.1 should add evm store key on %s", chainID)
 		require.Contains(t, config.StoreUpgrade.Added, erc20types.StoreKey, "v1.20.1 should add erc20 store key on %s", chainID)
+	}
+}
+
+func TestV1202IsMigrationOnlyOnAllNetworks(t *testing.T) {
+	for _, chainID := range []string{"lumera-mainnet-1", "lumera-testnet-2", "lumera-devnet-1"} {
+		params := newTestUpgradeParams(chainID)
+		config, found := SetupUpgrades(upgrade_v1_20_2.UpgradeName, params)
+		require.True(t, found)
+		require.NotNil(t, config.Handler, "v1.20.2 must register a handler on %s", chainID)
+		require.Nil(t, config.StoreUpgrade, "v1.20.2 must not alter stores on %s", chainID)
 	}
 }
 

--- a/app/upgrades/v1_20_2/upgrade.go
+++ b/app/upgrades/v1_20_2/upgrade.go
@@ -1,0 +1,4 @@
+package v1_20_2
+
+// UpgradeName is the on-chain name used for this upgrade.
+const UpgradeName = "v1.20.2"

--- a/app/upgrades/v1_20_2/upgrade_test.go
+++ b/app/upgrades/v1_20_2/upgrade_test.go
@@ -1,0 +1,11 @@
+package v1_20_2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeName(t *testing.T) {
+	require.Equal(t, "v1.20.2", UpgradeName)
+}


### PR DESCRIPTION
## Behavior change

Registers the `v1.20.2` software-upgrade handler and routes it through the standard Cosmos SDK module migration manager.

## Rationale

Testnet is currently running `v1.20.1`. The history-preservation fixes in the parent PR require a named `v1.20.2` handler so Cosmovisor can resume block production at the governance-planned upgrade height.

## State-machine impact

- **State keys:** only keys changed by `moduleManager.RunMigrations` when an installed module consensus version requires migration.
- **CheckTx / DeliverTx:** no new transaction path.
- **BeginBlock / EndBlock:** no new behavior outside the one-time upgrade callback at the planned height.
- **Determinism / replay:** standard deterministic SDK upgrade-handler execution; no wall-clock, network, or filesystem dependency.
- **Partial failure:** an error aborts the upgrade block; no custom repair loop or best-effort mutation.
- **Migration:** standard module migrations only.
- **Historical repair:** none. This PR intentionally does not scan or repair already-corrupted records.

## Risks

- An unregistered or misnamed handler would halt Cosmovisor nodes at the upgrade height.
- A module migration error would prevent the upgrade block from committing.

## Rollback

Before the upgrade height, withdraw/cancel the proposal or deploy a corrected binary. After execution, use the established chain rollback/governance recovery procedure; this PR adds no custom reversible state transform.

## Verification

- Upgrade registration tests
- Handler execution tests
- Exact local rehearsal: `v1.20.1 -> v1.20.2`, five validators, continued block production
- Parent protocol PR: #196

## Stack order

1. #196 — protocol/history preservation
2. **this PR** — `v1.20.2` handler
3. operator tooling/runbooks follow-up
