### PR TITLE
fix(devnet): make NM processedPath a sibling of srcPath, not a child

### DIFF
--- a/devnet/scripts/lumera-uploader-setup.sh
+++ b/devnet/scripts/lumera-uploader-setup.sh
@@ -308,7 +308,13 @@ add_dir_to_scanner() {
 		return 0
 	fi
 
-	local processed="${dir%/}/processed"
+	# processedPath MUST be a SIBLING of srcPath, not nested inside it.
+	# scanner/scanner.go walks srcPath with filepath.Walk (RECURSIVE) and dedups
+	# on (dir, name). A nested "<srcPath>/processed" therefore gets re-scanned,
+	# and because the move changes `dir` the file looks brand new -> every file
+	# is registered a SECOND time, doubling cascade fees and load.
+	# Observed on devnet: 13 create-metadata calls sourced from .../processed/.
+	local processed="${dir%/}-processed"
 	local tmp="${cfg}.tmp.$$"
 
 	# Collect existing srcPath entries so repeated calls accumulate rather than
@@ -323,7 +329,7 @@ add_dir_to_scanner() {
 		for e in ${existing}; do
 			[ -n "$e" ] || continue
 			printf ',\n  { srcPath = "%s", processedPath = "%s", isPublic = "random" }' \
-				"$e" "${e%/}/processed"
+				"$e" "${e%/}-processed"
 		done
 		printf '\n]\n'
 	} >"${tmp}.block"


### PR DESCRIPTION
## Problem

`e357c6e7` fixed the `[scanner].directories` block to emit correctly-typed inline tables (the crudini bug), but derived the destination as:

```bash
local processed="${dir%/}/processed"     # INSIDE the scanned directory
```

`scanner/scanner.go` walks `srcPath` with **`filepath.Walk` — recursive** — and dedups on `(dir, name)`:

```go
err := filepath.Walk(directory.SrcPath, func(path string, info os.FileInfo, err error) error {
    ...
    dir  := filepath.Dir(path)
    name := filepath.Base(path)
    exists, err := s.db.HasFile(dir, name)
```

So a nested `<srcPath>/processed` is re-scanned on the next tick. The move changed `dir`, so `HasFile(dir, name)` misses and the file looks brand new — **it is registered a second time**.

Cost: two cascade registrations per file (~15120ulume each, enforced at `x/action/v1/keeper/action.go:69`) plus double supernode upload load, silently.

## Evidence

Observed on the shared devnet — `create-metadata start` whose source path is *already* under the processed dir:

```
INFO rq: create-metadata start {"path": "/shared/nm-files/processed/post-v1120-1786409328-304734.bin"}
INFO rq: create-metadata start {"path": "/shared/nm-files/processed/post-v1120-1786409353-304735.bin"}
INFO rq: create-metadata start {"path": "/shared/nm-files/processed/post-v1120-1786409378-304736.bin"}
```

13 such re-registrations before the fix.

## Fix

Derive a **sibling**:

```bash
local processed="${dir%/}-processed"     # /shared/nm-files -> /shared/nm-files-processed
```

This restores the uploader's own convention — its shipped `config.toml` pairs `~/.lumera-uploader/drop` with the sibling `~/.lumera-uploader/processed`, never a child:

```toml
directories = [
  { srcPath = "~/.lumera-uploader/drop", processedPath = "~/.lumera-uploader/processed", isPublic = "random" }
]
```

## Verification

Deployed to the shared devnet (5 validators, chain `v1.20.2-rc1`, SN `v2.6.4-testnet`), NM restarted through the normal `start.sh` path with no overrides:

| metric | before fix | after fix |
|---|---:|---:|
| re-registrations sourced from processed dir | 13 | **0** |
| uploads started | — | 210 |
| `processed_files` | 1242 | **1276** |

Generated config after the change:

```toml
directories = [
  { srcPath = "/shared/nm-files", processedPath = "/shared/nm-files-processed", isPublic = "random" },
  { srcPath = "/root/nm-files", processedPath = "/root/nm-files-processed", isPublic = "random" },
  { srcPath = "~/.lumera-uploader/drop", processedPath = "~/.lumera-uploader/drop-processed", isPublic = "random" }
]
```

Sustained over ~10 minutes of live load with zero re-registrations.

## Risks

Low. Devnet tooling only — no chain code, no state machine, no consensus surface. `bash -n` clean. No other file in the repo references the nested path.

## Rollback

Revert the commit; the previous behavior returns immediately on the next `lumera-uploader-setup.sh` run.

## Operator note

On a devnet that already ran the nested version, move stranded files out of the scan path **before** restarting, or they get re-registered once on the next pass:

```bash
mv -f /shared/nm-files/processed/* /shared/nm-files-processed/
rmdir /shared/nm-files/processed
```
